### PR TITLE
feat: add text chunking for large notes

### DIFF
--- a/docs/plans/2026-03-08-text-chunking-design.md
+++ b/docs/plans/2026-03-08-text-chunking-design.md
@@ -1,0 +1,82 @@
+# Design: Text Chunking for Large Notes
+
+**Date:** 2026-03-08
+**Status:** Approved
+**Problem:** 5 notes exceed OpenAI text-embedding-3-small token limit (8192 tokens) and were never indexed.
+
+## Affected Notes
+
+| Note | Tokens |
+|------|--------|
+| Lei 10820 compilado.md | 13,257 |
+| PORTARIA MTE Nº 435.md | 13,062 |
+| Resolução BCB n 352.md | 45,576 |
+| Resolução CMN n 4966.md | 34,907 |
+| Exponential Organizations.md | 9,297 |
+
+## Approach: Chunks as Separate Rows
+
+Store each chunk as its own row in `vault_embeddings` with a `chunk_index` column. This preserves semantic signal — searching "provisão para perdas esperadas" matches the specific article, not a diluted average of the entire law.
+
+## Schema Changes
+
+```sql
+ALTER TABLE vault_embeddings ADD COLUMN chunk_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE vault_embeddings DROP CONSTRAINT vault_embeddings_file_path_key;
+ALTER TABLE vault_embeddings ADD CONSTRAINT vault_embeddings_file_path_chunk_idx_key UNIQUE(file_path, chunk_index);
+```
+
+- Non-chunked notes: 1 row with `chunk_index = 0` (no behavior change)
+- Chunked notes: N rows with `chunk_index = 0, 1, 2...`
+- `deleteNote` still works (deletes by `file_path`, catches all chunks)
+
+## Chunking Strategy
+
+**New method:** `EmbeddingService.chunkText(text: string): string[]`
+
+- `maxTokens: 6000` — safe margin below 8192 limit
+- `overlapTokens: 200` — context continuity between chunks
+- Token estimation: `Math.ceil(text.length / 4)` (no tiktoken dependency)
+- Split by paragraphs (`\n\n`) to preserve semantic units (articles, sections)
+- If ≤ maxTokens: return `[text]` (no chunking)
+- If > maxTokens: group paragraphs into chunks respecting maxTokens, with overlap
+
+## Pipeline Changes
+
+### VaultWatcher.handleFileChange
+1. Parse note (unchanged)
+2. Call `chunkText()` on content
+3. If 1 chunk: current flow (upsert with chunk_index=0)
+4. If N chunks: generate embedding per chunk, upsert each with chunk_index 0..N-1, delete orphan chunks above N-1
+
+### DbClient
+- `upsertNote`: `ON CONFLICT (file_path, chunk_index)` — add `chunk_index` to `NoteRow`
+- New: `deleteChunksAbove(filePath, maxChunkIndex)` — cleanup orphans
+- `deleteNote`: no change
+- Search methods: no change (chunks appear as regular rows)
+
+### NoteRow type
+- Add `chunk_index: number` (default 0)
+
+## Search Result Behavior
+
+When a chunk matches, the result shows `file_path` (original note) + chunk content. Client uses `read_note` for full document context.
+
+## Tests (~12 new)
+
+- `EmbeddingService.chunkText`: short text → 1 chunk, long text → N chunks, paragraph-based split, overlap between consecutive chunks, fallback for text without `\n\n`
+- `DbClient.upsertNote`: with chunk_index, ON CONFLICT (file_path, chunk_index)
+- `DbClient.deleteChunksAbove`: deletes chunks above index
+- `VaultWatcher.handleFileChange`: large note → multiple upserts, edited note (fewer chunks) → orphan cleanup
+
+## Re-indexing
+
+After deploy: `npm run index-vault` on VM. The 5 failed notes have no hash in DB, so they will be processed automatically.
+
+## Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Indexed notes | All except 5 large ones | All notes |
+| Search coverage | Missing legal/regulatory docs | Complete |
+| Semantic precision | N/A for large docs | Chunk-level matches |

--- a/docs/plans/2026-03-08-text-chunking-plan.md
+++ b/docs/plans/2026-03-08-text-chunking-plan.md
@@ -1,0 +1,627 @@
+# Implementation Plan: Text Chunking for Large Notes
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Date:** 2026-03-08
+**Design:** `docs/plans/2026-03-08-text-chunking-design.md`
+**Branch:** `feat/v0_2`
+
+## Overview
+
+Add text chunking to handle notes exceeding the 8192-token OpenAI embedding limit. 5 notes are currently unindexed. Changes span 4 source files, 1 migration script, and 3 test files.
+
+## Prerequisites
+
+- Ensure tests pass before starting: `npm test`
+
+---
+
+## Phase 1: Types (NoteRow)
+
+### Task 1.1 — Test: NoteRow should accept chunk_index
+
+**File:** `tests/lib/db-client.test.ts`
+
+Add a test inside the existing `upsertNote` describe block that verifies `NoteRow` accepts `chunk_index`:
+
+```typescript
+it('should accept chunk_index in NoteRow', async () => {
+  mockPool.query.mockResolvedValue({ rowCount: 1 });
+
+  const note: NoteRow = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    file_path: 'notes/test.md',
+    title: 'Test Note',
+    content: 'Test content',
+    tags: ['tag1'],
+    embedding: [0.1, 0.2],
+    file_hash: 'abc123hash',
+    chunk_index: 0,
+  };
+
+  await client.upsertNote(note);
+  expect(mockPool.query).toHaveBeenCalledTimes(1);
+});
+```
+
+**Verify it fails:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+Expected: TypeScript compilation error — `chunk_index` does not exist on `NoteRow`.
+
+### Task 1.2 — Implement: Add chunk_index to NoteRow
+
+**File:** `src/lib/types.ts`
+
+Add `chunk_index: number;` to the `NoteRow` interface, after `file_hash`:
+
+```typescript
+export interface NoteRow {
+  id: string;
+  file_path: string;
+  title: string | null;
+  content: string;
+  tags: string[];
+  embedding: number[];
+  file_hash: string;
+  chunk_index: number;
+}
+```
+
+**Verify it passes:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+### Task 1.3 — Fix: Add chunk_index to all existing NoteRow usages
+
+The following files construct `NoteRow` objects and need `chunk_index: 0` added:
+
+- `tests/lib/db-client.test.ts` — both `NoteRow` literals in the `upsertNote` describe
+- `tests/watcher/vault-watcher.test.ts` — the `upsertArg` assertion in `handleFileChange`
+- `src/watcher/vault-watcher.ts` — the `upsertNote` call in `handleFileChange`
+
+**Verify all tests pass:**
+```bash
+npm test
+```
+
+---
+
+## Phase 2: EmbeddingService.chunkText()
+
+### Task 2.1 — Test: chunkText returns single chunk for short text
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+Add a new `describe('chunkText', ...)` block after the existing `computeHash` describe:
+
+```typescript
+describe('chunkText', () => {
+  it('should return single chunk for text within token limit', () => {
+    const shortText = 'This is a short note.';
+    const chunks = service.chunkText(shortText);
+
+    expect(chunks).toEqual([shortText]);
+    expect(chunks).toHaveLength(1);
+  });
+});
+```
+
+**Verify it fails:**
+```bash
+npx vitest run tests/lib/embedding-service.test.ts
+```
+
+Expected: `service.chunkText is not a function`.
+
+### Task 2.2 — Test: chunkText returns multiple chunks for long text
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+Inside the `chunkText` describe block, add:
+
+```typescript
+it('should split long text into multiple chunks', () => {
+  // 6000 tokens ~ 24000 chars. Create text > 24000 chars.
+  const paragraph = 'A'.repeat(5000) + '\n\n';
+  const longText = paragraph.repeat(6); // 6 paragraphs x ~5002 chars = ~30012 chars (~7503 tokens)
+
+  const chunks = service.chunkText(longText);
+
+  expect(chunks.length).toBeGreaterThan(1);
+  // All chunks should be non-empty
+  for (const chunk of chunks) {
+    expect(chunk.trim().length).toBeGreaterThan(0);
+  }
+});
+```
+
+### Task 2.3 — Test: chunkText respects paragraph boundaries
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+```typescript
+it('should split on paragraph boundaries (\\n\\n)', () => {
+  // Each paragraph ~2500 tokens (10000 chars). Three paragraphs = 7500 tokens (exceeds 6000).
+  const para = 'B'.repeat(10000);
+  const text = `${para}\n\n${para}\n\n${para}`;
+
+  const chunks = service.chunkText(text);
+
+  expect(chunks.length).toBe(2);
+});
+```
+
+### Task 2.4 — Test: chunkText adds overlap between consecutive chunks
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+```typescript
+it('should include overlap from previous chunk', () => {
+  // Create 4 distinct paragraphs, each ~2000 tokens (8000 chars)
+  const paraA = 'AAAA '.repeat(1600); // 8000 chars = ~2000 tokens
+  const paraB = 'BBBB '.repeat(1600);
+  const paraC = 'CCCC '.repeat(1600);
+  const paraD = 'DDDD '.repeat(1600);
+  const text = [paraA, paraB, paraC, paraD].join('\n\n');
+
+  const chunks = service.chunkText(text);
+
+  expect(chunks.length).toBeGreaterThanOrEqual(2);
+  // The second chunk should contain content from the end of the first chunk (overlap)
+  if (chunks.length >= 2) {
+    expect(chunks[1]).toContain('CCCC');
+  }
+});
+```
+
+### Task 2.5 — Test: chunkText handles text without paragraph separators
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+```typescript
+it('should handle text without \\n\\n separators (single long paragraph)', () => {
+  // Single paragraph > 6000 tokens. Must still return it.
+  const longParagraph = 'X'.repeat(30000); // ~7500 tokens, no \n\n
+
+  const chunks = service.chunkText(longParagraph);
+
+  expect(chunks.length).toBeGreaterThanOrEqual(1);
+  expect(chunks.join('')).toContain('X');
+});
+```
+
+### Task 2.6 — Test: chunkText returns empty array for empty text
+
+**File:** `tests/lib/embedding-service.test.ts`
+
+```typescript
+it('should return single empty chunk for empty text', () => {
+  const chunks = service.chunkText('');
+  expect(chunks).toEqual(['']);
+});
+```
+
+### Task 2.7 — Implement: chunkText method
+
+**File:** `src/lib/embedding-service.ts`
+
+Add method to the `EmbeddingService` class:
+
+```typescript
+chunkText(text: string, maxTokens = 6000, overlapTokens = 200): string[] {
+  const estimateTokens = (t: string): number => Math.ceil(t.length / 4);
+
+  if (estimateTokens(text) <= maxTokens) {
+    return [text];
+  }
+
+  const paragraphs = text.split('\n\n');
+  const chunks: string[] = [];
+  let currentParagraphs: string[] = [];
+  let currentTokens = 0;
+  let overlapParagraphs: string[] = [];
+
+  for (const para of paragraphs) {
+    const paraTokens = estimateTokens(para);
+
+    if (currentTokens + paraTokens > maxTokens && currentParagraphs.length > 0) {
+      // Save current chunk
+      chunks.push(currentParagraphs.join('\n\n'));
+
+      // Build overlap: take paragraphs from end of current chunk
+      overlapParagraphs = [];
+      let overlapCount = 0;
+      for (let i = currentParagraphs.length - 1; i >= 0; i--) {
+        const pTokens = estimateTokens(currentParagraphs[i]);
+        if (overlapCount + pTokens > overlapTokens) break;
+        overlapParagraphs.unshift(currentParagraphs[i]);
+        overlapCount += pTokens;
+      }
+
+      // Start new chunk with overlap
+      currentParagraphs = [...overlapParagraphs, para];
+      currentTokens = overlapCount + paraTokens;
+    } else {
+      currentParagraphs.push(para);
+      currentTokens += paraTokens;
+    }
+  }
+
+  // Flush remaining
+  if (currentParagraphs.length > 0) {
+    chunks.push(currentParagraphs.join('\n\n'));
+  }
+
+  return chunks.length > 0 ? chunks : [text];
+}
+```
+
+**Verify all chunkText tests pass:**
+```bash
+npx vitest run tests/lib/embedding-service.test.ts
+```
+
+---
+
+## Phase 3: DbClient Changes
+
+### Task 3.1 — Test: upsertNote uses ON CONFLICT (file_path, chunk_index)
+
+**File:** `tests/lib/db-client.test.ts`
+
+Update the existing `'should INSERT with ON CONFLICT DO UPDATE'` test assertion from:
+
+```typescript
+expect(sql).toContain('ON CONFLICT (file_path) DO UPDATE');
+```
+
+to:
+
+```typescript
+expect(sql).toContain('ON CONFLICT (file_path, chunk_index) DO UPDATE');
+```
+
+Also verify `chunk_index` appears in SQL params.
+
+**Verify it fails:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+Expected: `ON CONFLICT (file_path, chunk_index)` not found in SQL.
+
+### Task 3.2 — Implement: Update upsertNote SQL
+
+**File:** `src/lib/db-client.ts`
+
+Update `upsertNote` method:
+
+```typescript
+async upsertNote(note: NoteRow): Promise<void> {
+  const sql = `
+    INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, chunk_index, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+    ON CONFLICT (file_path, chunk_index) DO UPDATE SET
+      title = EXCLUDED.title,
+      content = EXCLUDED.content,
+      tags = EXCLUDED.tags,
+      embedding = EXCLUDED.embedding,
+      file_hash = EXCLUDED.file_hash,
+      updated_at = NOW()
+  `;
+
+  await this.pool.query(sql, [
+    note.id,
+    note.file_path,
+    note.title,
+    note.content,
+    note.tags,
+    JSON.stringify(note.embedding),
+    note.file_hash,
+    note.chunk_index,
+  ]);
+}
+```
+
+**Verify it passes:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+### Task 3.3 — Test: deleteChunksAbove deletes chunks above given index
+
+**File:** `tests/lib/db-client.test.ts`
+
+Add a new `describe('deleteChunksAbove', ...)` block:
+
+```typescript
+describe('deleteChunksAbove', () => {
+  it('should DELETE chunks with chunk_index > maxChunkIndex for given file_path', async () => {
+    mockPool.query.mockResolvedValue({ rowCount: 3 });
+
+    await client.deleteChunksAbove('notes/large.md', 2);
+
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockPool.query.mock.calls[0];
+    expect(sql).toContain('DELETE FROM vault_embeddings');
+    expect(sql).toContain('file_path = $1');
+    expect(sql).toContain('chunk_index > $2');
+    expect(params).toEqual(['notes/large.md', 2]);
+  });
+
+  it('should propagate pool.query rejection', async () => {
+    mockPool.query.mockRejectedValue(new Error('connection refused'));
+
+    await expect(client.deleteChunksAbove('notes/test.md', 0)).rejects.toThrow(
+      'connection refused',
+    );
+  });
+});
+```
+
+**Verify it fails:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+Expected: `client.deleteChunksAbove is not a function`.
+
+### Task 3.4 — Implement: deleteChunksAbove method
+
+**File:** `src/lib/db-client.ts`
+
+Add method to `DbClient` class:
+
+```typescript
+async deleteChunksAbove(filePath: string, maxChunkIndex: number): Promise<void> {
+  const sql = 'DELETE FROM vault_embeddings WHERE file_path = $1 AND chunk_index > $2';
+  await this.pool.query(sql, [filePath, maxChunkIndex]);
+}
+```
+
+**Verify it passes:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+### Task 3.5 — Update getFileHash to use LIMIT 1
+
+**File:** `tests/lib/db-client.test.ts`
+
+In the existing `getFileHash` describe, update the `'should return hash string for known file'` test to also assert:
+
+```typescript
+expect(sql).toContain('LIMIT 1');
+```
+
+**Verify it fails**, then update `getFileHash` in `src/lib/db-client.ts`:
+
+```typescript
+async getFileHash(filePath: string): Promise<string | null> {
+  const sql = 'SELECT file_hash FROM vault_embeddings WHERE file_path = $1 LIMIT 1';
+  const result = await this.pool.query(sql, [filePath]);
+  if (result.rows.length === 0) return null;
+  return result.rows[0].file_hash;
+}
+```
+
+**Verify it passes:**
+```bash
+npx vitest run tests/lib/db-client.test.ts
+```
+
+---
+
+## Phase 4: VaultWatcher Multi-Chunk Pipeline
+
+### Task 4.1 — Update mock factories
+
+**File:** `tests/watcher/vault-watcher.test.ts`
+
+Update `createMockEmbeddingService` to include `chunkText`:
+
+```typescript
+chunkText: vi.fn().mockReturnValue(['Some content']),
+```
+
+Update `createMockDbClient` to include `deleteChunksAbove`:
+
+```typescript
+deleteChunksAbove: vi.fn().mockResolvedValue(undefined),
+```
+
+**Verify existing tests still pass:**
+```bash
+npx vitest run tests/watcher/vault-watcher.test.ts
+```
+
+### Task 4.2 — Test: handleFileChange calls chunkText and upserts single chunk with chunk_index=0
+
+**File:** `tests/watcher/vault-watcher.test.ts`
+
+Update the existing `'should index a new file with correct data including UUID'` test to also verify:
+
+```typescript
+expect(mockEmbedding.chunkText).toHaveBeenCalledWith('Some content');
+const upsertArg = mockDb.upsertNote.mock.calls[0][0];
+expect(upsertArg.chunk_index).toBe(0);
+expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/my-note.md', 0);
+```
+
+**Verify it fails.**
+
+### Task 4.3 — Test: handleFileChange with multi-chunk note
+
+**File:** `tests/watcher/vault-watcher.test.ts`
+
+```typescript
+it('should generate embedding per chunk and upsert each with chunk_index', async () => {
+  mockEmbedding.chunkText.mockReturnValue(['chunk zero', 'chunk one', 'chunk two']);
+  const embeddings = [
+    new Array(1536).fill(0.1),
+    new Array(1536).fill(0.2),
+    new Array(1536).fill(0.3),
+  ];
+  mockEmbedding.generateEmbedding
+    .mockResolvedValueOnce(embeddings[0])
+    .mockResolvedValueOnce(embeddings[1])
+    .mockResolvedValueOnce(embeddings[2]);
+
+  await watcher.handleFileChange(`${VAULT_PATH}/notes/large.md`, 'raw content');
+
+  expect(mockEmbedding.generateEmbedding).toHaveBeenCalledTimes(3);
+  expect(mockDb.upsertNote).toHaveBeenCalledTimes(3);
+  expect(mockDb.upsertNote.mock.calls[0][0].chunk_index).toBe(0);
+  expect(mockDb.upsertNote.mock.calls[1][0].chunk_index).toBe(1);
+  expect(mockDb.upsertNote.mock.calls[2][0].chunk_index).toBe(2);
+  expect(mockDb.upsertNote.mock.calls[0][0].content).toBe('chunk zero');
+  expect(mockDb.upsertNote.mock.calls[1][0].content).toBe('chunk one');
+  expect(mockDb.upsertNote.mock.calls[2][0].content).toBe('chunk two');
+  expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/large.md', 2);
+});
+```
+
+### Task 4.4 — Test: handleFileChange cleans orphans when note shrinks
+
+**File:** `tests/watcher/vault-watcher.test.ts`
+
+```typescript
+it('should delete orphan chunks when note shrinks', async () => {
+  mockEmbedding.chunkText.mockReturnValue(['chunk A', 'chunk B']);
+
+  await watcher.handleFileChange(`${VAULT_PATH}/notes/shrunk.md`, 'raw content');
+
+  expect(mockDb.upsertNote).toHaveBeenCalledTimes(2);
+  expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/shrunk.md', 1);
+});
+```
+
+### Task 4.5 — Implement: Update VaultWatcher.handleFileChange
+
+**File:** `src/watcher/vault-watcher.ts`
+
+Replace the `handleFileChange` method:
+
+```typescript
+async handleFileChange(filePath: string, content: string): Promise<void> {
+  const relative = this.relativePath(filePath);
+  const newHash = this.embeddingService.computeHash(content);
+  const existingHash = await this.dbClient.getFileHash(relative);
+
+  if (existingHash === newHash) return;
+
+  try {
+    const metadata = this.embeddingService.parseNote(content);
+    const chunks = this.embeddingService.chunkText(metadata.content);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunkContent = chunks[i];
+      const embeddingText = [metadata.title, chunkContent]
+        .filter(Boolean)
+        .join('\n');
+      const embedding = await this.embeddingService.generateEmbedding(embeddingText);
+
+      await this.dbClient.upsertNote({
+        id: randomUUID(),
+        file_path: relative,
+        title: metadata.title,
+        content: chunkContent,
+        tags: metadata.tags,
+        embedding,
+        file_hash: newHash,
+        chunk_index: i,
+      });
+    }
+
+    await this.dbClient.deleteChunksAbove(relative, chunks.length - 1);
+  } catch (err) {
+    console.error(`[VaultWatcher] Failed to index ${relative}:`, err);
+  }
+}
+```
+
+**Verify all tests pass:**
+```bash
+npm test
+```
+
+---
+
+## Phase 5: SQL Migration Script
+
+### Task 5.1 — Create migration script
+
+**File:** `scripts/migrate-chunk-index.sql`
+
+```sql
+-- Migration: Add chunk_index column for text chunking support
+-- Date: 2026-03-08
+-- Run on VM: psql -U obsidian_brain -d open_brain -f scripts/migrate-chunk-index.sql
+
+BEGIN;
+
+ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS chunk_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE vault_embeddings DROP CONSTRAINT IF EXISTS vault_embeddings_file_path_key;
+ALTER TABLE vault_embeddings ADD CONSTRAINT vault_embeddings_file_path_chunk_idx_key UNIQUE(file_path, chunk_index);
+
+COMMIT;
+```
+
+---
+
+## Phase 6: Verification
+
+### Task 6.1 — Type check
+
+```bash
+npx tsc --noEmit
+```
+
+### Task 6.2 — Full test suite
+
+```bash
+npm test
+```
+
+### Task 6.3 — Update mcp-tools.test.ts mock if needed
+
+**File:** `tests/mcp/mcp-tools.test.ts`
+
+Add `deleteChunksAbove` to `createMockDbClient` if it references `DbClient` type.
+
+---
+
+## Deployment Steps (post-implementation)
+
+1. SSH into VM
+2. Run migration: `psql -U obsidian_brain -d open_brain -f scripts/migrate-chunk-index.sql`
+3. Deploy new code: `git pull origin main && npm run build`
+4. Restart watcher: `sudo systemctl restart obsidian-watcher`
+5. Re-index vault: `npm run index-vault`
+6. Verify the 5 previously-failed notes are now indexed
+7. Reconnect MCP in Claude Code: `/mcp`
+
+---
+
+## Test Summary
+
+| # | Test | File |
+|---|------|------|
+| 1 | NoteRow accepts chunk_index | `tests/lib/db-client.test.ts` |
+| 2 | chunkText: short text → 1 chunk | `tests/lib/embedding-service.test.ts` |
+| 3 | chunkText: long text → N chunks | `tests/lib/embedding-service.test.ts` |
+| 4 | chunkText: paragraph boundaries | `tests/lib/embedding-service.test.ts` |
+| 5 | chunkText: overlap between chunks | `tests/lib/embedding-service.test.ts` |
+| 6 | chunkText: no \n\n separators | `tests/lib/embedding-service.test.ts` |
+| 7 | chunkText: empty text | `tests/lib/embedding-service.test.ts` |
+| 8 | upsertNote: ON CONFLICT (file_path, chunk_index) | `tests/lib/db-client.test.ts` |
+| 9 | deleteChunksAbove: correct SQL | `tests/lib/db-client.test.ts` |
+| 10 | deleteChunksAbove: propagates errors | `tests/lib/db-client.test.ts` |
+| 11 | getFileHash: LIMIT 1 | `tests/lib/db-client.test.ts` |
+| 12 | handleFileChange: single chunk with chunk_index=0 | `tests/watcher/vault-watcher.test.ts` |
+| 13 | handleFileChange: multi-chunk upserts | `tests/watcher/vault-watcher.test.ts` |
+| 14 | handleFileChange: orphan cleanup | `tests/watcher/vault-watcher.test.ts` |

--- a/scripts/migrate-chunk-index.sql
+++ b/scripts/migrate-chunk-index.sql
@@ -1,0 +1,18 @@
+-- Migration: Add chunk_index column for text chunking support
+-- Date: 2026-03-08
+-- Design: docs/plans/2026-03-08-text-chunking-design.md
+--
+-- Run on VM: psql -U obsidian_brain -d open_brain -f scripts/migrate-chunk-index.sql
+
+BEGIN;
+
+-- Step 1: Add chunk_index column (default 0 for existing single-chunk rows)
+ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS chunk_index INTEGER NOT NULL DEFAULT 0;
+
+-- Step 2: Drop old unique constraint on file_path alone
+ALTER TABLE vault_embeddings DROP CONSTRAINT IF EXISTS vault_embeddings_file_path_key;
+
+-- Step 3: Add new composite unique constraint
+ALTER TABLE vault_embeddings ADD CONSTRAINT vault_embeddings_file_path_chunk_idx_key UNIQUE(file_path, chunk_index);
+
+COMMIT;

--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -71,9 +71,9 @@ export class DbClient {
 
   async upsertNote(note: NoteRow): Promise<void> {
     const sql = `
-      INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, updated_at)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-      ON CONFLICT (file_path) DO UPDATE SET
+      INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, chunk_index, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+      ON CONFLICT (file_path, chunk_index) DO UPDATE SET
         title = EXCLUDED.title,
         content = EXCLUDED.content,
         tags = EXCLUDED.tags,
@@ -90,6 +90,7 @@ export class DbClient {
       note.tags,
       JSON.stringify(note.embedding),
       note.file_hash,
+      note.chunk_index,
     ]);
   }
 
@@ -136,7 +137,7 @@ export class DbClient {
   }
 
   async getFileHash(filePath: string): Promise<string | null> {
-    const sql = 'SELECT file_hash FROM vault_embeddings WHERE file_path = $1';
+    const sql = 'SELECT file_hash FROM vault_embeddings WHERE file_path = $1 LIMIT 1';
     const result = await this.pool.query(sql, [filePath]);
 
     if (result.rows.length === 0) {
@@ -144,6 +145,11 @@ export class DbClient {
     }
 
     return result.rows[0].file_hash;
+  }
+
+  async deleteChunksAbove(filePath: string, maxChunkIndex: number): Promise<void> {
+    const sql = 'DELETE FROM vault_embeddings WHERE file_path = $1 AND chunk_index > $2';
+    await this.pool.query(sql, [filePath, maxChunkIndex]);
   }
 
   async listRecent(

--- a/src/lib/embedding-service.ts
+++ b/src/lib/embedding-service.ts
@@ -73,6 +73,67 @@ export class EmbeddingService {
     return { title, tags, content };
   }
 
+  chunkText(text: string, maxTokens = 6000, overlapTokens = 200): string[] {
+    const estimateTokens = (t: string): number => Math.ceil(t.length / 4);
+
+    if (estimateTokens(text) <= maxTokens) {
+      return [text];
+    }
+
+    const paragraphs = text.split('\n\n');
+    const maxChars = maxTokens * 4;
+    const chunks: string[] = [];
+    let currentParagraphs: string[] = [];
+    let currentTokens = 0;
+    let overlapParagraphs: string[] = [];
+
+    for (const para of paragraphs) {
+      const paraTokens = estimateTokens(para);
+
+      // Force-split oversized paragraphs by character boundary
+      if (paraTokens > maxTokens) {
+        // Flush any accumulated paragraphs first
+        if (currentParagraphs.length > 0) {
+          chunks.push(currentParagraphs.join('\n\n'));
+          currentParagraphs = [];
+          currentTokens = 0;
+        }
+        // Split into sub-chunks directly (no overlap for char-boundary splits)
+        for (let offset = 0; offset < para.length; offset += maxChars) {
+          chunks.push(para.slice(offset, offset + maxChars));
+        }
+        overlapParagraphs = [];
+        continue;
+      }
+
+      if (currentTokens + paraTokens > maxTokens && currentParagraphs.length > 0) {
+        chunks.push(currentParagraphs.join('\n\n'));
+
+        overlapParagraphs = [];
+        let overlapCount = 0;
+        for (let i = currentParagraphs.length - 1; i >= 0; i--) {
+          const pTokens = estimateTokens(currentParagraphs[i]);
+          if (overlapCount + pTokens > overlapTokens && overlapParagraphs.length > 0) break;
+          overlapParagraphs.unshift(currentParagraphs[i]);
+          overlapCount += pTokens;
+          if (overlapCount >= overlapTokens) break;
+        }
+
+        currentParagraphs = [...overlapParagraphs, para];
+        currentTokens = overlapCount + paraTokens;
+      } else {
+        currentParagraphs.push(para);
+        currentTokens += paraTokens;
+      }
+    }
+
+    if (currentParagraphs.length > 0) {
+      chunks.push(currentParagraphs.join('\n\n'));
+    }
+
+    return chunks.length > 0 ? chunks : [text];
+  }
+
   computeHash(content: string): string {
     return createHash('sha256').update(content, 'utf8').digest('hex');
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface NoteRow {
   tags: string[];
   embedding: number[];
   file_hash: string;
+  chunk_index: number;
 }
 
 export interface SearchOptions {

--- a/src/watcher/vault-watcher.ts
+++ b/src/watcher/vault-watcher.ts
@@ -31,21 +31,33 @@ export class VaultWatcher {
 
     try {
       const metadata = this.embeddingService.parseNote(content);
-      const embeddingText = [metadata.title, metadata.content]
-        .filter(Boolean)
-        .join('\n');
-      const embedding = await this.embeddingService.generateEmbedding(embeddingText);
+      const chunks = this.embeddingService.chunkText(metadata.content);
 
-      await this.dbClient.upsertNote({
-        // id is used only for INSERT; ON CONFLICT (file_path) preserves the existing row's id.
-        id: randomUUID(),
-        file_path: relative,
-        title: metadata.title,
-        content: metadata.content,
-        tags: metadata.tags,
-        embedding,
-        file_hash: newHash,
-      });
+      // Phase 1: Generate all embeddings (may fail — no DB writes yet)
+      const chunkData: Array<{ content: string; embedding: number[] }> = [];
+      for (const chunkContent of chunks) {
+        const embeddingText = [metadata.title, chunkContent]
+          .filter(Boolean)
+          .join('\n');
+        const embedding = await this.embeddingService.generateEmbedding(embeddingText);
+        chunkData.push({ content: chunkContent, embedding });
+      }
+
+      // Phase 2: All embeddings succeeded — now upsert all chunks
+      for (let i = 0; i < chunkData.length; i++) {
+        await this.dbClient.upsertNote({
+          id: randomUUID(),
+          file_path: relative,
+          title: metadata.title,
+          content: chunkData[i].content,
+          tags: metadata.tags,
+          embedding: chunkData[i].embedding,
+          file_hash: newHash,
+          chunk_index: i,
+        });
+      }
+
+      await this.dbClient.deleteChunksAbove(relative, chunkData.length - 1);
     } catch (err) {
       console.error(`[VaultWatcher] Failed to index ${relative}:`, err);
     }

--- a/tests/lib/db-client.test.ts
+++ b/tests/lib/db-client.test.ts
@@ -25,6 +25,7 @@ describe('DbClient', () => {
         tags: ['tag1', 'tag2'],
         embedding: Array.from({ length: 1536 }, () => 0.1),
         file_hash: 'abc123hash',
+        chunk_index: 0,
       };
 
       await client.upsertNote(note);
@@ -32,12 +33,13 @@ describe('DbClient', () => {
       expect(mockPool.query).toHaveBeenCalledTimes(1);
       const [sql, params] = mockPool.query.mock.calls[0];
       expect(sql).toContain('INSERT INTO vault_embeddings');
-      expect(sql).toContain('ON CONFLICT (file_path) DO UPDATE');
+      expect(sql).toContain('ON CONFLICT (file_path, chunk_index) DO UPDATE');
       expect(params).toContain(note.id);
       expect(params).toContain(note.file_path);
       expect(params).toContain(note.title);
       expect(params).toContain(note.content);
       expect(params).toContain(note.file_hash);
+      expect(params).toContain(note.chunk_index);
 
       // Embedding must be passed as JSON string, not raw array
       const embeddingParam = params[5];
@@ -56,6 +58,7 @@ describe('DbClient', () => {
         tags: ['tag1'],
         embedding: [0.1, 0.2],
         file_hash: 'abc123hash',
+        chunk_index: 0,
       };
 
       await expect(client.upsertNote(note)).rejects.toThrow('connection refused');
@@ -214,6 +217,7 @@ describe('DbClient', () => {
       const [sql, params] = mockPool.query.mock.calls[0];
       expect(sql).toContain('file_hash');
       expect(sql).toContain('$1');
+      expect(sql).toContain('LIMIT 1');
       expect(params).toEqual(['notes/test.md']);
     });
 
@@ -223,6 +227,24 @@ describe('DbClient', () => {
       const hash = await client.getFileHash('notes/unknown.md');
 
       expect(hash).toBeNull();
+    });
+  });
+
+  describe('deleteChunksAbove', () => {
+    it('should DELETE chunks with chunk_index > maxChunkIndex for given file_path', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 3 });
+      await client.deleteChunksAbove('notes/large.md', 2);
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('DELETE FROM vault_embeddings');
+      expect(sql).toContain('file_path = $1');
+      expect(sql).toContain('chunk_index > $2');
+      expect(params).toEqual(['notes/large.md', 2]);
+    });
+
+    it('should propagate pool.query rejection', async () => {
+      mockPool.query.mockRejectedValue(new Error('connection refused'));
+      await expect(client.deleteChunksAbove('notes/test.md', 0)).rejects.toThrow('connection refused');
     });
   });
 

--- a/tests/lib/embedding-service.test.ts
+++ b/tests/lib/embedding-service.test.ts
@@ -140,6 +140,75 @@ Content here.`;
     });
   });
 
+  describe('chunkText', () => {
+    it('should return single chunk for text within token limit', () => {
+      const shortText = 'This is a short note.';
+      const chunks = service.chunkText(shortText);
+      expect(chunks).toEqual([shortText]);
+      expect(chunks).toHaveLength(1);
+    });
+
+    it('should split long text into multiple chunks', () => {
+      const paragraph = 'A'.repeat(5000) + '\n\n';
+      const longText = paragraph.repeat(6);
+      const chunks = service.chunkText(longText);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should split on paragraph boundaries (\\n\\n)', () => {
+      const para = 'B'.repeat(10000);
+      const text = `${para}\n\n${para}\n\n${para}`;
+      const chunks = service.chunkText(text);
+      expect(chunks.length).toBe(2);
+    });
+
+    it('should include overlap from previous chunk', () => {
+      const paraA = 'AAAA '.repeat(1600);
+      const paraB = 'BBBB '.repeat(1600);
+      const paraC = 'CCCC '.repeat(1600);
+      const paraD = 'DDDD '.repeat(1600);
+      const text = [paraA, paraB, paraC, paraD].join('\n\n');
+      const chunks = service.chunkText(text);
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      if (chunks.length >= 2) {
+        expect(chunks[1]).toContain('CCCC');
+      }
+    });
+
+    it('should handle text without \\n\\n separators (single long paragraph)', () => {
+      const longParagraph = 'X'.repeat(30000);
+      const chunks = service.chunkText(longParagraph);
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(24000);
+      }
+      expect(chunks.join('')).toBe(longParagraph);
+    });
+
+    it('should force-split a single long paragraph that exceeds maxTokens', () => {
+      // Single paragraph of ~7500 tokens (30000 chars), no \n\n
+      const longParagraph = 'X'.repeat(30000);
+      const chunks = service.chunkText(longParagraph);
+
+      // Should be split into multiple chunks, each within token limit
+      expect(chunks.length).toBeGreaterThan(1);
+      // Each chunk should be within the maxTokens limit (6000 tokens = 24000 chars)
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(24000);
+      }
+      // All content should be preserved
+      expect(chunks.join('')).toBe(longParagraph);
+    });
+
+    it('should return single empty chunk for empty text', () => {
+      const chunks = service.chunkText('');
+      expect(chunks).toEqual(['']);
+    });
+  });
+
   describe('computeHash', () => {
     it('should compute deterministic SHA256 hash', () => {
       const content = 'Hello, World!';

--- a/tests/mcp/mcp-tools.test.ts
+++ b/tests/mcp/mcp-tools.test.ts
@@ -15,6 +15,7 @@ function createMockDbClient(): DbClient {
     searchText: vi.fn().mockResolvedValue(emptyPaginated),
     listRecent: vi.fn().mockResolvedValue(emptyPaginated),
     getFileHash: vi.fn().mockResolvedValue(null),
+    deleteChunksAbove: vi.fn().mockResolvedValue(undefined),
   } as unknown as DbClient;
 }
 

--- a/tests/watcher/vault-watcher.test.ts
+++ b/tests/watcher/vault-watcher.test.ts
@@ -4,7 +4,7 @@ import type { EmbeddingService } from '../../src/lib/embedding-service.js';
 import type { DbClient } from '../../src/lib/db-client.js';
 
 function createMockEmbeddingService(): {
-  [K in keyof Pick<EmbeddingService, 'parseNote' | 'generateEmbedding' | 'computeHash'>]: ReturnType<typeof vi.fn>;
+  [K in keyof Pick<EmbeddingService, 'parseNote' | 'generateEmbedding' | 'computeHash' | 'chunkText'>]: ReturnType<typeof vi.fn>;
 } {
   return {
     parseNote: vi.fn().mockReturnValue({
@@ -14,16 +14,18 @@ function createMockEmbeddingService(): {
     }),
     generateEmbedding: vi.fn().mockResolvedValue(new Array(1536).fill(0.1)),
     computeHash: vi.fn().mockReturnValue('abc123hash'),
+    chunkText: vi.fn().mockReturnValue(['Some content']),
   };
 }
 
 function createMockDbClient(): {
-  [K in keyof Pick<DbClient, 'getFileHash' | 'upsertNote' | 'deleteNote'>]: ReturnType<typeof vi.fn>;
+  [K in keyof Pick<DbClient, 'getFileHash' | 'upsertNote' | 'deleteNote' | 'deleteChunksAbove'>]: ReturnType<typeof vi.fn>;
 } {
   return {
     getFileHash: vi.fn().mockResolvedValue(null),
     upsertNote: vi.fn().mockResolvedValue(undefined),
     deleteNote: vi.fn().mockResolvedValue(undefined),
+    deleteChunksAbove: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -86,6 +88,9 @@ describe('VaultWatcher', () => {
       expect(mockEmbedding.parseNote).toHaveBeenCalledWith(content);
       expect(mockEmbedding.generateEmbedding).toHaveBeenCalledWith('Test Note\nSome content');
 
+      // chunkText should be called with parsed content
+      expect(mockEmbedding.chunkText).toHaveBeenCalledWith('Some content');
+
       // upsertNote should be called with correct data
       expect(mockDb.upsertNote).toHaveBeenCalledTimes(1);
       const upsertArg = mockDb.upsertNote.mock.calls[0][0];
@@ -96,11 +101,15 @@ describe('VaultWatcher', () => {
         tags: ['tag1', 'tag2'],
         embedding: new Array(1536).fill(0.1),
         file_hash: 'abc123hash',
+        chunk_index: 0,
       });
       // id should be a valid UUID
       expect(upsertArg.id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
+
+      // orphan cleanup should be called
+      expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/my-note.md', 0);
     });
 
     it('should skip indexing if hash is unchanged', async () => {
@@ -143,12 +152,61 @@ describe('VaultWatcher', () => {
       expect(mockDb.upsertNote).not.toHaveBeenCalled();
     });
 
+    it('should generate embedding per chunk and upsert each with chunk_index', async () => {
+      mockEmbedding.chunkText.mockReturnValue(['chunk zero', 'chunk one', 'chunk two']);
+      const embeddings = [
+        new Array(1536).fill(0.1),
+        new Array(1536).fill(0.2),
+        new Array(1536).fill(0.3),
+      ];
+      mockEmbedding.generateEmbedding
+        .mockResolvedValueOnce(embeddings[0])
+        .mockResolvedValueOnce(embeddings[1])
+        .mockResolvedValueOnce(embeddings[2]);
+
+      await watcher.handleFileChange(`${VAULT_PATH}/notes/large.md`, 'raw content');
+
+      expect(mockEmbedding.generateEmbedding).toHaveBeenCalledTimes(3);
+      expect(mockDb.upsertNote).toHaveBeenCalledTimes(3);
+      expect(mockDb.upsertNote.mock.calls[0][0].chunk_index).toBe(0);
+      expect(mockDb.upsertNote.mock.calls[1][0].chunk_index).toBe(1);
+      expect(mockDb.upsertNote.mock.calls[2][0].chunk_index).toBe(2);
+      expect(mockDb.upsertNote.mock.calls[0][0].content).toBe('chunk zero');
+      expect(mockDb.upsertNote.mock.calls[1][0].content).toBe('chunk one');
+      expect(mockDb.upsertNote.mock.calls[2][0].content).toBe('chunk two');
+      expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/large.md', 2);
+    });
+
+    it('should delete orphan chunks when note shrinks', async () => {
+      mockEmbedding.chunkText.mockReturnValue(['chunk A', 'chunk B']);
+
+      await watcher.handleFileChange(`${VAULT_PATH}/notes/shrunk.md`, 'raw content');
+
+      expect(mockDb.upsertNote).toHaveBeenCalledTimes(2);
+      expect(mockDb.deleteChunksAbove).toHaveBeenCalledWith('notes/shrunk.md', 1);
+    });
+
+    it('should not upsert any chunks if embedding fails mid-pipeline', async () => {
+      mockEmbedding.chunkText.mockReturnValue(['chunk zero', 'chunk one', 'chunk two']);
+      mockEmbedding.generateEmbedding
+        .mockResolvedValueOnce(new Array(1536).fill(0.1))
+        .mockRejectedValueOnce(new Error('OpenAI API rate limit exceeded'));
+
+      await watcher.handleFileChange(`${VAULT_PATH}/notes/failing.md`, 'raw content');
+
+      // No upserts should have happened since embedding failed on chunk 1
+      expect(mockDb.upsertNote).not.toHaveBeenCalled();
+      // No orphan cleanup either
+      expect(mockDb.deleteChunksAbove).not.toHaveBeenCalled();
+    });
+
     it('should handle title being null in embedding text', async () => {
       mockEmbedding.parseNote.mockReturnValue({
         title: null,
         tags: [],
         content: 'No title content',
       });
+      mockEmbedding.chunkText.mockReturnValue(['No title content']);
 
       await watcher.handleFileChange(filePath, content);
 


### PR DESCRIPTION
## Summary

- 5 notes (legal docs, 9K-45K tokens) were never indexed due to OpenAI 8192 token limit
- Adds `EmbeddingService.chunkText()` with paragraph-based splitting (6000 token max, 200 token overlap)
- Force-splits oversized paragraphs by character boundary
- Two-phase pipeline: generate all embeddings first, then batch upsert (prevents partial state on failure)
- Adds `chunk_index` column + SQL migration script
- 91 tests passing, types clean

## Test plan

- [x] 91 tests passing (16 embedding, 26 db-client, 15 watcher, 33 mcp-tools)
- [x] `tsc --noEmit` clean
- [x] Force-split test: single 30K char paragraph → multiple chunks ≤24K chars each
- [x] Atomicity test: embedding failure mid-pipeline → zero upserts
- [ ] Deploy to VM, run migration, run `npm run index-vault`
- [ ] Verify 5 previously-failed notes are now indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)