### PR TITLE
fix: deploy SSH user and error masking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,15 +18,15 @@ jobs:
 
       - name: Deploy to VM
         run: |
-          gcloud compute ssh obsidian-vm \
+          gcloud compute ssh sorensen@obsidian-vm \
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
-            --command="cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci --omit=dev && npm run build && sudo systemctl restart obsidian-watcher && pkill -f 'tsx src/mcp/index.ts' || true"
+            --command="cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci --omit=dev && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true)"
 
       - name: Health check
         run: |
-          gcloud compute ssh obsidian-vm \
+          gcloud compute ssh sorensen@obsidian-vm \
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-03-10
+
+### Added
+- GitHub Actions CI workflow (`ci.yml`): validates PRs with build, type check, test coverage (80%+), and security audit
+- GitHub Actions deploy workflow (`deploy.yml`): auto-deploys to VM via GCP IAP tunnel SSH on merge to main
+- GCP service account `github-actions-deploy` with least-privilege IAM roles
+- Health check step in deploy workflow verifies watcher service is active
+- CI/CD design document and implementation plan
+
+### Changed
+- Updated TODO.md: marked text chunking as DONE, added SA key rotation tracking
+
 ## [0.2.0] — 2026-03-08
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,23 @@
 - `chunk_index` column added to `vault_embeddings` (unique key: `file_path, chunk_index`)
 - 243/243 notes indexed successfully (was 232/243 before chunking)
 
+### ~~CI/CD auto-deploy~~ — DONE (2026-03-10)
+- GitHub Actions: `ci.yml` (PR validation: build, test, coverage, audit) + `deploy.yml` (deploy on merge to main via IAP tunnel SSH)
+- GCP SA `github-actions-deploy` with least-privilege roles
+- Deploy: git pull, npm ci, build, restart watcher, kill MCP, health check
+
 ### SA key rotation schedule
 - **Priority:** High
 - `obsidian-vm-sa` key expires ~90 days from creation (2026-03-07) → **rotate by 2026-06-05**
 - `github-actions-deploy` key `c3044b0c` (created 2026-03-10, no auto-expiry) → **rotate by 2026-06-08**
 - Consider: automate rotation via Cloud Scheduler + Cloud Function, or at minimum set calendar reminders
 - Long-term: migrate to Workload Identity Federation (keyless) for GitHub Actions
+
+### Update google-github-actions to Node.js 24 compatible versions
+- **Priority:** Medium
+- **Deadline:** Before June 2, 2026
+- `google-github-actions/auth@v2` and `google-github-actions/setup-gcloud@v2` use deprecated Node.js 20
+- Check for v3 releases and update workflows
 
 ### Add ESLint to project
 - **Priority:** Medium

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -138,3 +138,14 @@ Regra: cada fase deve estar em producao e funcional antes de avancar. Eu confirm
 - Todos os search tools retornam `PaginatedResult { results, total, limit, offset }`
 - Workflow recomendado: search para descobrir notas → read_note para conteudo completo
 - Operacional: MCP server roda via stdio over SSH. Apos mudancas de codigo na VM, matar processo antigo (`pkill -f "tsx src/mcp/index.ts"`) e reconectar via `/mcp` no Claude Code
+
+### 2026-03-10 — CI/CD GitHub Actions completa
+- CI workflow (`ci.yml`): build + tsc --noEmit + test:coverage (80%) + npm audit em PRs para main
+- Deploy workflow (`deploy.yml`): gcloud compute ssh via IAP tunnel no merge para main
+- Deploy steps: git pull, npm ci --omit=dev, build, systemctl restart obsidian-watcher, pkill MCP
+- Health check: verifica que watcher esta ativo apos deploy
+- SA `github-actions-deploy`: roles iap.tunnelResourceAccessor, compute.instanceAdmin.v1, iam.serviceAccountUser, compute.osLogin
+- SA key rotation: manual a cada 90 dias (proximo: 2026-06-08), tracked em TODO.md
+- Branch protection nao disponivel (requer GitHub Pro) — CI roda mas merge nao e bloqueado
+- Warning: google-github-actions v2 usa Node.js 20 deprecated (deadline: junho 2026)
+- Proxima fase pendente: Fase 10 (Backups & Monitoring)


### PR DESCRIPTION
## Summary
- Use `sorensen@obsidian-vm` in deploy workflow to force correct SSH user (was defaulting to runner, causing Permission denied)
- Isolate `|| true` to `pkill` only so real deploy errors are not masked
- Update CHANGELOG, TODO, and HANDOFF docs for CI/CD completion

## Test plan
- [ ] CI passes (build, test, coverage, audit)
- [ ] After merge, deploy workflow SSHs as `sorensen` and deploys successfully
- [ ] Verify deploy actually ran: `ssh obsidian-vm "cd ~/obsidian_open_brain && git log --oneline -1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)