### PR TITLE
fix: remove --omit=dev so tsc is available for build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
-            --command="cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci --omit=dev && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true)"
+            --command="cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true)"
 
       - name: Health check
         run: |


### PR DESCRIPTION
## Summary
- Remove `--omit=dev` from `npm ci` in deploy workflow
- `tsc` is a devDependency — omitting dev deps caused `tsc: not found` during `npm run build`

## Test plan
- [ ] CI passes
- [ ] Deploy succeeds with `npm run build` completing without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)