### PR TITLE
fix: add SSH keepalive to prevent IAP tunnel drop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,8 @@ jobs:
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
-            --command="cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true)"
+            --ssh-flag="-o ServerAliveInterval=10 -o ServerAliveCountMax=6" \
+            --command="set -e && cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true) && echo DEPLOY_SUCCESS"
 
       - name: Health check
         run: |
@@ -30,4 +31,5 @@ jobs:
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
+            --ssh-flag="-o ServerAliveInterval=10 -o ServerAliveCountMax=6" \
             --command="systemctl is-active obsidian-watcher"


### PR DESCRIPTION
## Summary
- Add `ServerAliveInterval=10` and `ServerAliveCountMax=6` to SSH flags
- Add `set -e` for proper error propagation inside SSH command
- Add `echo DEPLOY_SUCCESS` marker to confirm full execution

Previous deploy runs had the IAP tunnel drop during `tsc` build, causing exit code 255 even though the deploy completed successfully.

## Test plan
- [ ] CI passes
- [ ] Deploy completes without exit 255
- [ ] Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)