### PR TITLE
fix: use local deploy script to avoid IAP tunnel drops

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,7 @@ jobs:
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
-            --ssh-flag="-o ServerAliveInterval=10 -o ServerAliveCountMax=6" \
-            --command="set -e && cd /home/sorensen/obsidian_open_brain && git pull origin main && npm ci && npm run build && sudo systemctl restart obsidian-watcher && (pkill -f 'tsx src/mcp/index.ts' || true) && echo DEPLOY_SUCCESS"
+            --command="nohup bash /home/sorensen/obsidian_open_brain/scripts/deploy.sh > /tmp/deploy.log 2>&1; cat /tmp/deploy.log"
 
       - name: Health check
         run: |
@@ -31,5 +30,4 @@ jobs:
             --zone=us-east1-b \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
-            --ssh-flag="-o ServerAliveInterval=10 -o ServerAliveCountMax=6" \
-            --command="systemctl is-active obsidian-watcher"
+            --command="systemctl is-active obsidian-watcher && tail -1 /tmp/deploy.log | grep -q DEPLOY_SUCCESS"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="/home/sorensen/obsidian_open_brain"
+cd "$PROJECT_DIR"
+
+echo "=== Deploy started at $(date -u) ==="
+
+echo "--- git pull ---"
+git pull origin main
+
+echo "--- npm ci ---"
+npm ci
+
+echo "--- npm run build ---"
+npm run build
+
+echo "--- restart watcher ---"
+sudo systemctl restart obsidian-watcher
+
+echo "--- kill stale MCP processes ---"
+pkill -f 'tsx src/mcp/index.ts' || true
+
+echo "--- verify watcher ---"
+systemctl is-active obsidian-watcher
+
+echo "=== Deploy completed at $(date -u) ==="
+echo "DEPLOY_SUCCESS"


### PR DESCRIPTION
## Summary
- Move deploy logic to `scripts/deploy.sh` on the VM
- SSH command runs script via `nohup` so it completes regardless of tunnel stability
- Health check verifies watcher status AND `DEPLOY_SUCCESS` marker in log
- Script already deployed to VM via SCP

## Context
IAP tunnel consistently drops during `tsc` build (~5s), causing exit 255 even though deploy succeeds. ServerAliveInterval keepalive did not help.

## Test plan
- [ ] CI passes
- [ ] Deploy completes with DEPLOY_SUCCESS in logs
- [ ] Health check passes (watcher active + marker present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)