### PR TITLE
fix: use cmd.exe to resolve gcloud.cmd on Windows (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.2] — 2026-04-04
+
+### Fixed
+- gcloud CLI Windows detection fix was incomplete (#17). Node.js `execFile()` cannot execute `.cmd`/`.bat` files at all — not even with explicit extension. Changed fallback to use `cmd.exe /c gcloud --version` which properly resolves `gcloud.cmd` via the Windows command interpreter. Args remain hardcoded with no injection risk.
+
 ## [0.1.1] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/checks/prerequisites.ts
+++ b/packages/installer/src/checks/prerequisites.ts
@@ -51,14 +51,15 @@ export async function checkGcloud(): Promise<PrerequisiteResult> {
     return { name: 'gcloud CLI', installed: true, version: firstLine };
   } catch {
     // On Windows, gcloud SDK installs gcloud.cmd (batch wrapper).
-    // Node.js execFile() doesn't resolve .cmd extensions, so try explicitly.
+    // Node.js execFile() cannot execute .cmd/.bat files directly — they
+    // require cmd.exe as an intermediary to resolve and run the script.
     if (getPlatform() === 'windows') {
       try {
-        const { stdout } = await shell('gcloud.cmd', ['--version']);
+        const { stdout } = await shell('cmd.exe', ['/c', 'gcloud', '--version']);
         const firstLine = stdout.split('\n')[0] ?? '';
         return { name: 'gcloud CLI', installed: true, version: firstLine };
       } catch {
-        // Both gcloud and gcloud.cmd failed — fall through to not-installed
+        // Both approaches failed — fall through to not-installed
       }
     }
 

--- a/packages/installer/tests/checks/prerequisites.test.ts
+++ b/packages/installer/tests/checks/prerequisites.test.ts
@@ -78,10 +78,10 @@ describe('checkGcloud Windows .cmd fallback', () => {
     expect(shellMod.shell).toHaveBeenCalledWith('gcloud', ['--version']);
   });
 
-  it('falls back to gcloud.cmd on Windows when gcloud fails', async () => {
+  it('falls back to cmd.exe /c gcloud on Windows when gcloud fails', async () => {
     const shellMod = await import('../../src/utils/shell.js');
 
-    // First call (gcloud) fails
+    // First call (gcloud) fails; fallback uses cmd.exe to resolve gcloud.cmd
     const shellSpy = vi.spyOn(shellMod, 'shell')
       .mockRejectedValueOnce(new Error('Command not found: gcloud'))
       .mockResolvedValueOnce({
@@ -97,7 +97,7 @@ describe('checkGcloud Windows .cmd fallback', () => {
     expect(result.installed).toBe(true);
     expect(result.version).toBe('Google Cloud SDK 450.0.0');
     expect(shellSpy).toHaveBeenCalledWith('gcloud', ['--version']);
-    expect(shellSpy).toHaveBeenCalledWith('gcloud.cmd', ['--version']);
+    expect(shellSpy).toHaveBeenCalledWith('cmd.exe', ['/c', 'gcloud', '--version']);
   });
 
   it('returns installed: false when both gcloud and gcloud.cmd fail on Windows', async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- v0.1.1 fix was incomplete: Node.js `execFile()` **cannot execute `.cmd`/`.bat` files at all**, not even with explicit extension
- Changed Windows fallback to `execFile('cmd.exe', ['/c', 'gcloud', '--version'])` which delegates resolution to the Windows command interpreter
- Args remain hardcoded in an array — zero injection risk
- Bumps version to 0.1.2

## What changed
- `packages/installer/src/checks/prerequisites.ts` — `gcloud.cmd` → `cmd.exe /c gcloud`
- `packages/installer/tests/checks/prerequisites.test.ts` — updated test assertions
- All `package.json` files bumped to 0.1.2
- CHANGELOG.md updated with 0.1.2 entry

## Test plan
- [x] 39/39 unit tests passing
- [x] Type check clean (`tsc --noEmit`)
- [ ] Manual validation on Windows with Google Cloud SDK installed

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)