### PR TITLE
fix: systemic Windows .cmd resolution and dynamic version (#17, #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.3] — 2026-04-04
+
+### Fixed
+- Systemic fix: `shell()` utility now wraps all commands with `cmd.exe /c` on Windows, resolving `.cmd`/`.bat` execution for all 43+ `gcloud` call sites (#17, #21)
+- GCP authentication verification failing on Windows (#21) — `getActiveAccount()` used `execFile('gcloud', ...)` which couldn't resolve `gcloud.cmd`
+- `LOX_VERSION` and `DEFAULT_CONFIG.version` were hardcoded at `0.1.0` while `package.json` was at `0.1.2` — splash screen showed wrong version
+- Windows "command not found" errors now produce clean `Command not found: <cmd>` messages instead of raw `cmd.exe` error output
+
+### Changed
+- `LOX_VERSION` now reads dynamically from `package.json` — version can never desync again
+- `DEFAULT_CONFIG.version` imports `LOX_VERSION` from constants instead of hardcoding
+- Removed per-caller `.cmd` fallback in `checkGcloud()` — handled systemically by `shell()`
+
 ## [0.1.2] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/checks/prerequisites.ts
+++ b/packages/installer/src/checks/prerequisites.ts
@@ -44,25 +44,12 @@ async function checkGit(): Promise<PrerequisiteResult> {
   }
 }
 
-export async function checkGcloud(): Promise<PrerequisiteResult> {
+async function checkGcloud(): Promise<PrerequisiteResult> {
   try {
     const { stdout } = await shell('gcloud', ['--version']);
     const firstLine = stdout.split('\n')[0] ?? '';
     return { name: 'gcloud CLI', installed: true, version: firstLine };
   } catch {
-    // On Windows, gcloud SDK installs gcloud.cmd (batch wrapper).
-    // Node.js execFile() cannot execute .cmd/.bat files directly — they
-    // require cmd.exe as an intermediary to resolve and run the script.
-    if (getPlatform() === 'windows') {
-      try {
-        const { stdout } = await shell('cmd.exe', ['/c', 'gcloud', '--version']);
-        const firstLine = stdout.split('\n')[0] ?? '';
-        return { name: 'gcloud CLI', installed: true, version: firstLine };
-      } catch {
-        // Both approaches failed — fall through to not-installed
-      }
-    }
-
     return {
       name: 'gcloud CLI',
       installed: false,

--- a/packages/installer/src/utils/shell.ts
+++ b/packages/installer/src/utils/shell.ts
@@ -13,15 +13,26 @@ export interface ShellResult {
  * SECURITY: Uses execFile instead of exec to prevent shell injection.
  */
 export async function shell(cmd: string, args: string[] = []): Promise<ShellResult> {
+  // On Windows, .cmd/.bat files cannot be executed directly by execFile().
+  // Delegate to cmd.exe which resolves them automatically.
+  const actualCmd = process.platform === 'win32' ? 'cmd.exe' : cmd;
+  const actualArgs = process.platform === 'win32' ? ['/c', cmd, ...args] : args;
+
   try {
-    const { stdout, stderr } = await execFileAsync(cmd, args, {
+    const { stdout, stderr } = await execFileAsync(actualCmd, actualArgs, {
       timeout: 30_000,
       maxBuffer: 1024 * 1024,
     });
     return { stdout: stdout.trim(), stderr: stderr.trim() };
   } catch (err: unknown) {
-    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-      throw new Error(`Command not found: ${cmd}`);
+    if (err && typeof err === 'object') {
+      if ('code' in err && err.code === 'ENOENT') {
+        throw new Error(`Command not found: ${cmd}`);
+      }
+      // On Windows, cmd.exe /c reports missing commands via stderr
+      if ('stderr' in err && typeof err.stderr === 'string' && err.stderr.includes('is not recognized')) {
+        throw new Error(`Command not found: ${cmd}`);
+      }
     }
     throw err;
   }

--- a/packages/installer/tests/checks/prerequisites.test.ts
+++ b/packages/installer/tests/checks/prerequisites.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { getPlatform } from '../../src/utils/shell.js';
 
 describe('getPlatform', () => {
@@ -54,82 +54,5 @@ describe('PrerequisiteResult interface', () => {
         expect(r.installCommand.length).toBeGreaterThan(0);
       }
     }
-  });
-});
-
-describe('checkGcloud Windows .cmd fallback', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('detects gcloud normally when shell("gcloud") succeeds', async () => {
-    const shellMod = await import('../../src/utils/shell.js');
-    vi.spyOn(shellMod, 'shell').mockResolvedValueOnce({
-      stdout: 'Google Cloud SDK 450.0.0\nother lines',
-      stderr: '',
-    });
-
-    // Re-import to pick up the mock (checkGcloud uses the same module reference)
-    const { checkGcloud } = await import('../../src/checks/prerequisites.js');
-    const result = await checkGcloud();
-
-    expect(result.installed).toBe(true);
-    expect(result.version).toBe('Google Cloud SDK 450.0.0');
-    expect(shellMod.shell).toHaveBeenCalledWith('gcloud', ['--version']);
-  });
-
-  it('falls back to cmd.exe /c gcloud on Windows when gcloud fails', async () => {
-    const shellMod = await import('../../src/utils/shell.js');
-
-    // First call (gcloud) fails; fallback uses cmd.exe to resolve gcloud.cmd
-    const shellSpy = vi.spyOn(shellMod, 'shell')
-      .mockRejectedValueOnce(new Error('Command not found: gcloud'))
-      .mockResolvedValueOnce({
-        stdout: 'Google Cloud SDK 450.0.0\nother lines',
-        stderr: '',
-      });
-
-    vi.spyOn(shellMod, 'getPlatform').mockReturnValue('windows');
-
-    const { checkGcloud } = await import('../../src/checks/prerequisites.js');
-    const result = await checkGcloud();
-
-    expect(result.installed).toBe(true);
-    expect(result.version).toBe('Google Cloud SDK 450.0.0');
-    expect(shellSpy).toHaveBeenCalledWith('gcloud', ['--version']);
-    expect(shellSpy).toHaveBeenCalledWith('cmd.exe', ['/c', 'gcloud', '--version']);
-  });
-
-  it('returns installed: false when both gcloud and gcloud.cmd fail on Windows', async () => {
-    const shellMod = await import('../../src/utils/shell.js');
-
-    vi.spyOn(shellMod, 'shell')
-      .mockRejectedValueOnce(new Error('Command not found: gcloud'))
-      .mockRejectedValueOnce(new Error('Command not found: gcloud.cmd'));
-
-    vi.spyOn(shellMod, 'getPlatform').mockReturnValue('windows');
-
-    const { checkGcloud } = await import('../../src/checks/prerequisites.js');
-    const result = await checkGcloud();
-
-    expect(result.installed).toBe(false);
-    expect(result.installCommand).toBeDefined();
-  });
-
-  it('does not try gcloud.cmd fallback on non-Windows platforms', async () => {
-    const shellMod = await import('../../src/utils/shell.js');
-
-    const shellSpy = vi.spyOn(shellMod, 'shell')
-      .mockRejectedValueOnce(new Error('Command not found: gcloud'));
-
-    vi.spyOn(shellMod, 'getPlatform').mockReturnValue('linux');
-
-    const { checkGcloud } = await import('../../src/checks/prerequisites.js');
-    const result = await checkGcloud();
-
-    expect(result.installed).toBe(false);
-    // Should only have called shell once (no .cmd fallback)
-    expect(shellSpy).toHaveBeenCalledTimes(1);
-    expect(shellSpy).toHaveBeenCalledWith('gcloud', ['--version']);
   });
 });

--- a/packages/installer/tests/utils/shell.test.ts
+++ b/packages/installer/tests/utils/shell.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Track calls to execFile so we can assert cmd/args without ESM spy issues
+const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+
+// Allows individual tests to override the default success behaviour
+type ExecFileCallback = (err: unknown, result?: { stdout: string; stderr: string }) => void;
+let execFileImpl: ((cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => void) | null = null;
+
+vi.mock('node:child_process', () => ({
+  execFile: (cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
+    execFileCalls.push({ cmd, args });
+    if (execFileImpl) {
+      execFileImpl(cmd, args, _opts, cb);
+    } else {
+      cb(null, { stdout: 'mocked output', stderr: '' });
+    }
+  },
+}));
+
+describe('shell() Windows cmd.exe wrapping', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    execFileCalls.length = 0;
+    execFileImpl = null;
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+    vi.resetModules();
+  });
+
+  it('wraps commands with cmd.exe /c on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud', ['--version']);
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('cmd.exe');
+    expect(execFileCalls[0].args).toEqual(['/c', 'gcloud', '--version']);
+  });
+
+  it('does not wrap on darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud', ['--version']);
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('gcloud');
+    expect(execFileCalls[0].args).toEqual(['--version']);
+  });
+
+  it('does not wrap on linux', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('node', ['--version']);
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('node');
+    expect(execFileCalls[0].args).toEqual(['--version']);
+  });
+
+  it('preserves all arguments when wrapping for Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud', ['compute', 'instances', 'list', '--format=json']);
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('cmd.exe');
+    expect(execFileCalls[0].args).toEqual(['/c', 'gcloud', 'compute', 'instances', 'list', '--format=json']);
+  });
+
+  it('handles empty args on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud');
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('cmd.exe');
+    expect(execFileCalls[0].args).toEqual(['/c', 'gcloud']);
+  });
+
+  it('commandExists works through the same wrapping', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const { commandExists } = await import('../../src/utils/shell.js');
+    const result = await commandExists('gcloud');
+
+    expect(result).toBe(true);
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].cmd).toBe('cmd.exe');
+    expect(execFileCalls[0].args).toEqual(['/c', 'gcloud', '--version']);
+  });
+
+  it('commandExists returns false when cmd.exe stderr contains "is not recognized" on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    execFileImpl = (_cmd, _args, _opts, cb) => {
+      const err = Object.assign(new Error('Command failed'), {
+        stderr: "'nonexistent' is not recognized as an internal or external command",
+        code: 1,
+      });
+      cb(err);
+    };
+
+    const { commandExists } = await import('../../src/utils/shell.js');
+    const result = await commandExists('nonexistent');
+
+    expect(result).toBe(false);
+  });
+
+  it('shell() throws "Command not found" when cmd.exe stderr contains "is not recognized" on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    execFileImpl = (_cmd, _args, _opts, cb) => {
+      const err = Object.assign(new Error('Command failed'), {
+        stderr: "'missingcmd' is not recognized as an internal or external command",
+        code: 1,
+      });
+      cb(err);
+    };
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await expect(shell('missingcmd')).rejects.toThrow('Command not found: missingcmd');
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,3 +1,5 @@
+import { LOX_VERSION } from './constants.js';
+
 export interface VpnPeer {
   name: string;
   ip: string;
@@ -37,7 +39,7 @@ export interface LoxConfig {
 }
 
 export const DEFAULT_CONFIG: Partial<LoxConfig> = {
-  version: '0.1.0',
+  version: LOX_VERSION,
   mode: 'personal',
   database: {
     host: '127.0.0.1',

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,4 +1,11 @@
-export const LOX_VERSION = '0.1.0';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// __dirname at runtime is dist/ (compiled output), so go up one level to package root
+const pkgPath = resolve(__dirname, '..', 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version: string };
+
+export const LOX_VERSION = pkg.version;
 
 export const LOX_ASCII_LOGO = `  _        ___   __  __
  | |      / _ \\  \\ \\/ /

--- a/packages/shared/tests/index.test.ts
+++ b/packages/shared/tests/index.test.ts
@@ -112,8 +112,9 @@ describe('config', () => {
     expect(DEFAULT_CONFIG.vpn!.peers).toEqual([]);
   });
 
-  it('DEFAULT_CONFIG should have version 1.0.0 and mode personal', () => {
-    expect(DEFAULT_CONFIG.version).toBe('0.1.0');
+  it('DEFAULT_CONFIG should have a valid semver version and mode personal', () => {
+    expect(DEFAULT_CONFIG.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(DEFAULT_CONFIG.version).toBe(LOX_VERSION);
     expect(DEFAULT_CONFIG.mode).toBe('personal');
   });
 
@@ -160,8 +161,11 @@ describe('config', () => {
 });
 
 describe('constants', () => {
-  it('LOX_VERSION should be 1.0.0', () => {
-    expect(LOX_VERSION).toBe('0.1.0');
+  it('LOX_VERSION should match package.json version', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('../package.json') as { version: string };
+    expect(LOX_VERSION).toBe(pkg.version);
+    expect(LOX_VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 
   it('LOX_ASCII_LOGO should contain LOX letter patterns', () => {


### PR DESCRIPTION
## Summary
- `shell()` now wraps all commands with `cmd.exe /c` on Windows, fixing `.cmd`/`.bat` execution for all 43+ `gcloud` call sites (#17, #21)
- Windows "is not recognized" errors produce clean `Command not found` messages
- `LOX_VERSION` reads from `package.json` dynamically — splash screen version can never desync again
- Removed per-caller `.cmd` fallback in `checkGcloud()` — handled systemically by `shell()`
- Bumps version to 0.1.3

## Test plan
- [x] 158/158 tests passing (19 shared + 96 core + 43 installer)
- [x] Type check clean (`tsc --noEmit`)
- [x] Code review passed (no remaining comments)
- [ ] Manual validation on Windows with Google Cloud SDK

Closes #17, Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)