### PR TITLE
fix: add billing account detection and linking (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.4] — 2026-04-04
+
+### Added
+- Billing account detection and linking in GCP project setup step (#21). The installer now:
+  - Checks if the project has a billing account linked before enabling APIs
+  - Lists available billing accounts and lets the user select one
+  - Links the selected billing account automatically via `gcloud billing projects link`
+  - If no billing accounts exist, guides the user to create one at the GCP Console and waits
+- i18n: 8 new billing-related strings in en and pt-BR
+
+### Fixed
+- `gcloud services enable` no longer crashes with raw stack trace when billing is missing (#21). Now shows a clear error message.
+
 ## [0.1.3] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -75,6 +75,16 @@ export interface I18nStrings {
   preset_para: string;
   preset_para_desc: string;
 
+  // Billing
+  billing_checking: string;
+  billing_not_linked: string;
+  billing_select_account: string;
+  billing_no_accounts: string;
+  billing_press_enter: string;
+  billing_linked_success: string;
+  billing_required_for_apis: string;
+  billing_linking: string;
+
   // Modes
   mode_personal: string;
   mode_team: string;
@@ -156,6 +166,16 @@ export const en: I18nStrings = {
   preset_zettelkasten_desc: 'Atomic notes with unique IDs, interlinked for emergent thinking.',
   preset_para: 'PARA',
   preset_para_desc: 'Projects, Areas, Resources, Archives — action-oriented organization.',
+
+  // Billing
+  billing_checking: 'Checking billing account...',
+  billing_not_linked: 'No billing account linked to project',
+  billing_select_account: 'Select a billing account:',
+  billing_no_accounts: 'No billing accounts found. Create one at:',
+  billing_press_enter: 'Press Enter after creating a billing account',
+  billing_linked_success: 'Billing account linked successfully',
+  billing_required_for_apis: 'Billing is required to enable GCP APIs. Please link a billing account and try again.',
+  billing_linking: 'Linking billing account...',
 
   // Modes
   mode_personal: 'Personal',

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -77,6 +77,16 @@ export const ptBr: I18nStrings = {
   preset_para: 'PARA',
   preset_para_desc: 'Projetos, Areas, Recursos, Arquivos — organizacao orientada a acao.',
 
+  // Billing
+  billing_checking: 'Verificando conta de faturamento...',
+  billing_not_linked: 'Nenhuma conta de faturamento vinculada ao projeto',
+  billing_select_account: 'Selecione uma conta de faturamento:',
+  billing_no_accounts: 'Nenhuma conta de faturamento encontrada. Crie uma em:',
+  billing_press_enter: 'Pressione Enter apos criar uma conta de faturamento',
+  billing_linked_success: 'Conta de faturamento vinculada com sucesso',
+  billing_required_for_apis: 'Faturamento e necessario para ativar APIs do GCP. Vincule uma conta e tente novamente.',
+  billing_linking: 'Vinculando conta de faturamento...',
+
   // Modes
   mode_personal: 'Pessoal',
   mode_team: 'Equipe',

--- a/packages/installer/src/steps/step-gcp-project.ts
+++ b/packages/installer/src/steps/step-gcp-project.ts
@@ -14,6 +14,8 @@ const REQUIRED_APIS = [
   'logging.googleapis.com',
 ];
 
+const BILLING_CREATE_URL = 'https://console.cloud.google.com/billing/create';
+
 /**
  * Check if a GCP project already exists and is accessible.
  */
@@ -24,6 +26,155 @@ async function projectExists(projectId: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Check if a billing account is linked to the project.
+ * Returns the billing account name if linked, empty string otherwise.
+ */
+export async function checkBillingEnabled(projectId: string): Promise<string> {
+  try {
+    const result = await shell('gcloud', [
+      'billing', 'projects', 'describe', projectId,
+      '--format=value(billingAccountName)',
+    ]);
+    return result.stdout;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * List the user's available open billing accounts.
+ * Returns array of { id, displayName } objects.
+ */
+export async function listBillingAccounts(): Promise<Array<{ id: string; displayName: string }>> {
+  try {
+    const result = await shell('gcloud', [
+      'billing', 'accounts', 'list',
+      '--format=value(name,displayName)',
+      '--filter=open=true',
+    ]);
+    if (!result.stdout) return [];
+
+    return result.stdout
+      .split('\n')
+      .filter((line) => line.startsWith('billingAccounts/'))
+      .map((line) => {
+        // Format: "billingAccounts/XXXXXX-YYYYYY-ZZZZZZ\tDisplay Name"
+        const [fullId, ...nameParts] = line.split('\t');
+        const id = fullId.replace('billingAccounts/', '');
+        return { id, displayName: nameParts.join('\t') || id };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Link a billing account to a GCP project.
+ */
+export async function linkBillingAccount(projectId: string, billingAccountId: string): Promise<void> {
+  await shell('gcloud', [
+    'billing', 'projects', 'link', projectId,
+    `--billing-account=${billingAccountId}`,
+  ]);
+}
+
+/**
+ * Prompt the user to select a billing account and link it to the project.
+ */
+async function promptAndLink(
+  projectId: string,
+  accounts: Array<{ id: string; displayName: string }>,
+  strings: ReturnType<typeof t>,
+): Promise<void> {
+  const { select } = await import('@inquirer/prompts');
+  const selectedAccountId = await select({
+    message: strings.billing_select_account,
+    choices: accounts.map((a) => ({
+      name: `${a.displayName} (${a.id})`,
+      value: a.id,
+    })),
+  });
+
+  await withSpinner(
+    strings.billing_linking,
+    () => linkBillingAccount(projectId, selectedAccountId),
+  );
+
+  console.log(chalk.green(`  ✓ ${strings.billing_linked_success}`));
+}
+
+/**
+ * Ensure a billing account is linked to the project.
+ * If not linked, guide the user through selecting or creating one.
+ * Returns { success: true } if billing is set up, or { success: false, message } if not.
+ */
+export async function ensureBilling(projectId: string, strings: ReturnType<typeof t>): Promise<StepResult> {
+  // Check if billing is already enabled
+  const billingAccount = await withSpinner(
+    strings.billing_checking,
+    () => checkBillingEnabled(projectId),
+  );
+
+  if (billingAccount) {
+    return { success: true };
+  }
+
+  // Billing not linked
+  console.log(chalk.yellow(`  → ${strings.billing_not_linked}: ${projectId}`));
+
+  // List available billing accounts
+  const accounts = await listBillingAccounts();
+
+  if (accounts.length > 0) {
+    await promptAndLink(projectId, accounts, strings);
+    return { success: true };
+  }
+
+  // No billing accounts found — guide user to create one
+  console.log(chalk.yellow(`  ${strings.billing_no_accounts}`));
+  console.log(chalk.cyan(`  ${BILLING_CREATE_URL}`));
+  console.log();
+
+  const { input } = await import('@inquirer/prompts');
+  await input({ message: strings.billing_press_enter });
+
+  // Re-check after user creates one
+  const billingAfterCreate = await withSpinner(
+    strings.billing_checking,
+    () => checkBillingEnabled(projectId),
+  );
+
+  if (billingAfterCreate) {
+    console.log(chalk.green(`  ✓ ${strings.billing_linked_success}`));
+    return { success: true };
+  }
+
+  // Still no billing — try listing again in case they created but didn't link
+  const accountsAfterCreate = await listBillingAccounts();
+
+  if (accountsAfterCreate.length > 0) {
+    await promptAndLink(projectId, accountsAfterCreate, strings);
+    return { success: true };
+  }
+
+  return { success: false, message: strings.billing_required_for_apis };
+}
+
+/**
+ * Check if an error message indicates a billing issue.
+ */
+function isBillingError(err: unknown): boolean {
+  if (err instanceof Error) {
+    return err.message.toLowerCase().includes('billing');
+  }
+  if (err && typeof err === 'object' && 'stderr' in err) {
+    const stderr = (err as { stderr: string }).stderr;
+    return typeof stderr === 'string' && stderr.toLowerCase().includes('billing');
+  }
+  return false;
 }
 
 export async function stepGcpProject(ctx: InstallerContext): Promise<StepResult> {
@@ -69,13 +220,29 @@ export async function stepGcpProject(ctx: InstallerContext): Promise<StepResult>
     },
   );
 
+  // Ensure billing is linked before enabling APIs
+  const billingResult = await ensureBilling(projectId, strings);
+  if (!billingResult.success) {
+    return billingResult;
+  }
+
   // Enable required APIs
-  await withSpinner(
-    `Enabling APIs (${REQUIRED_APIS.length})...`,
-    async () => {
-      await shell('gcloud', ['services', 'enable', ...REQUIRED_APIS, '--project', projectId]);
-    },
-  );
+  try {
+    await withSpinner(
+      `Enabling APIs (${REQUIRED_APIS.length})...`,
+      async () => {
+        await shell('gcloud', ['services', 'enable', ...REQUIRED_APIS, '--project', projectId]);
+      },
+    );
+  } catch (err: unknown) {
+    if (isBillingError(err)) {
+      return {
+        success: false,
+        message: strings.billing_required_for_apis,
+      };
+    }
+    throw err;
+  }
 
   // Set default region and zone
   await withSpinner(

--- a/packages/installer/tests/steps/step-gcp-project-billing.test.ts
+++ b/packages/installer/tests/steps/step-gcp-project-billing.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// Mock shell utility
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+}));
+
+// Mock @inquirer/prompts
+vi.mock('@inquirer/prompts', () => ({
+  input: vi.fn(),
+  select: vi.fn(),
+}));
+
+// Mock UI modules (they use terminal features not available in tests)
+vi.mock('../../src/ui/box.js', () => ({
+  renderStepHeader: vi.fn(() => ''),
+}));
+
+vi.mock('../../src/ui/spinner.js', () => ({
+  withSpinner: vi.fn((_msg: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+// Mock chalk to pass-through
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    cyan: (s: string) => s,
+  },
+}));
+
+// Mock i18n
+vi.mock('../../src/i18n/index.js', () => ({
+  t: () => ({
+    step_gcp_project: 'GCP Project',
+    creating: 'Creating',
+    configuring: 'Configuring',
+    checking: 'Checking',
+    billing_checking: 'Checking billing account...',
+    billing_not_linked: 'No billing account linked to project',
+    billing_select_account: 'Select a billing account:',
+    billing_no_accounts: 'No billing accounts found. Create one at:',
+    billing_press_enter: 'Press Enter after creating a billing account',
+    billing_linked_success: 'Billing account linked successfully',
+    billing_required_for_apis: 'Billing is required to enable GCP APIs. Please link a billing account and try again.',
+    billing_linking: 'Linking billing account...',
+  }),
+}));
+
+import { shell } from '../../src/utils/shell.js';
+import { select, input } from '@inquirer/prompts';
+import {
+  checkBillingEnabled,
+  listBillingAccounts,
+  linkBillingAccount,
+  ensureBilling,
+} from '../../src/steps/step-gcp-project.js';
+import { t } from '../../src/i18n/index.js';
+
+const shellMock = shell as Mock;
+const selectMock = select as Mock;
+const inputMock = input as Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkBillingEnabled', () => {
+  it('returns billing account name when linked', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/012345-6789AB-CDEF01', stderr: '' });
+
+    const result = await checkBillingEnabled('my-project');
+
+    expect(result).toBe('billingAccounts/012345-6789AB-CDEF01');
+    expect(shellMock).toHaveBeenCalledWith('gcloud', [
+      'billing', 'projects', 'describe', 'my-project',
+      '--format=value(billingAccountName)',
+    ]);
+  });
+
+  it('returns empty string when no billing linked', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await checkBillingEnabled('my-project');
+
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when command fails', async () => {
+    shellMock.mockRejectedValueOnce(new Error('command failed'));
+
+    const result = await checkBillingEnabled('my-project');
+
+    expect(result).toBe('');
+  });
+});
+
+describe('listBillingAccounts', () => {
+  it('parses billing accounts list correctly', async () => {
+    shellMock.mockResolvedValueOnce({
+      stdout: 'billingAccounts/AAAAAA-BBBBBB-CCCCCC\tMy Billing Account',
+      stderr: '',
+    });
+
+    const accounts = await listBillingAccounts();
+
+    expect(accounts).toEqual([
+      { id: 'AAAAAA-BBBBBB-CCCCCC', displayName: 'My Billing Account' },
+    ]);
+  });
+
+  it('handles multiple accounts', async () => {
+    shellMock.mockResolvedValueOnce({
+      stdout: 'billingAccounts/AAA-BBB-CCC\tAccount One\nbillingAccounts/DDD-EEE-FFF\tAccount Two',
+      stderr: '',
+    });
+
+    const accounts = await listBillingAccounts();
+
+    expect(accounts).toHaveLength(2);
+    expect(accounts[0].id).toBe('AAA-BBB-CCC');
+    expect(accounts[1].id).toBe('DDD-EEE-FFF');
+  });
+
+  it('returns empty array when no accounts', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const accounts = await listBillingAccounts();
+
+    expect(accounts).toEqual([]);
+  });
+
+  it('returns empty array on command failure', async () => {
+    shellMock.mockRejectedValueOnce(new Error('failed'));
+
+    const accounts = await listBillingAccounts();
+
+    expect(accounts).toEqual([]);
+  });
+});
+
+describe('linkBillingAccount', () => {
+  it('calls gcloud with correct arguments', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await linkBillingAccount('my-project', 'AAAAAA-BBBBBB-CCCCCC');
+
+    expect(shellMock).toHaveBeenCalledWith('gcloud', [
+      'billing', 'projects', 'link', 'my-project',
+      '--billing-account=AAAAAA-BBBBBB-CCCCCC',
+    ]);
+  });
+
+  it('propagates error when gcloud link fails (e.g. insufficient IAM permissions)', async () => {
+    const iamError = new Error(
+      'ERROR: (gcloud.billing.projects.link) PERMISSION_DENIED: ' +
+      'The caller does not have permission',
+    );
+    shellMock.mockRejectedValueOnce(iamError);
+
+    await expect(linkBillingAccount('my-project', 'AAAAAA-BBBBBB-CCCCCC')).rejects.toThrow(
+      'PERMISSION_DENIED',
+    );
+  });
+});
+
+describe('ensureBilling', () => {
+  const strings = t();
+
+  it('skips linking when billing is already enabled', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/XXX-YYY-ZZZ', stderr: '' });
+
+    const result = await ensureBilling('my-project', strings);
+
+    expect(result.success).toBe(true);
+    // Should not prompt user
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(inputMock).not.toHaveBeenCalled();
+  });
+
+  it('lets user select and link when accounts are available', async () => {
+    // checkBillingEnabled returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // listBillingAccounts
+    shellMock.mockResolvedValueOnce({
+      stdout: 'billingAccounts/AAA-BBB-CCC\tTest Account',
+      stderr: '',
+    });
+    // linkBillingAccount
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    selectMock.mockResolvedValueOnce('AAA-BBB-CCC');
+
+    const result = await ensureBilling('my-project', strings);
+
+    expect(result.success).toBe(true);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    // Verify link was called
+    expect(shellMock).toHaveBeenCalledWith('gcloud', [
+      'billing', 'projects', 'link', 'my-project',
+      '--billing-account=AAA-BBB-CCC',
+    ]);
+  });
+
+  it('guides user to create billing account when none exist, then re-checks', async () => {
+    // checkBillingEnabled returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // listBillingAccounts returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    inputMock.mockResolvedValueOnce('');
+
+    // After user confirms, re-check billing — now it's linked
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/NEW-ACC-123', stderr: '' });
+
+    const result = await ensureBilling('my-project', strings);
+
+    expect(result.success).toBe(true);
+    expect(inputMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns failure when no billing after user creates account', async () => {
+    // checkBillingEnabled returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // listBillingAccounts returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    inputMock.mockResolvedValueOnce('');
+
+    // Re-check billing — still empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Re-list accounts — still empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await ensureBilling('my-project', strings);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Billing is required');
+  });
+
+  it('propagates linkBillingAccount error through ensureBilling', async () => {
+    // checkBillingEnabled returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // listBillingAccounts returns one account
+    shellMock.mockResolvedValueOnce({
+      stdout: 'billingAccounts/AAA-BBB-CCC\tTest Account',
+      stderr: '',
+    });
+
+    selectMock.mockResolvedValueOnce('AAA-BBB-CCC');
+
+    // linkBillingAccount throws permission denied
+    const iamError = new Error(
+      'ERROR: (gcloud.billing.projects.link) PERMISSION_DENIED: ' +
+      'The caller does not have permission',
+    );
+    shellMock.mockRejectedValueOnce(iamError);
+
+    await expect(ensureBilling('my-project', strings)).rejects.toThrow('PERMISSION_DENIED');
+  });
+
+  it('lets user select newly created account after re-check', async () => {
+    // checkBillingEnabled returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // listBillingAccounts returns empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    inputMock.mockResolvedValueOnce('');
+
+    // Re-check billing — still empty
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Re-list accounts — now has one
+    shellMock.mockResolvedValueOnce({
+      stdout: 'billingAccounts/NEW-ACC-456\tNew Account',
+      stderr: '',
+    });
+
+    selectMock.mockResolvedValueOnce('NEW-ACC-456');
+
+    // linkBillingAccount
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await ensureBilling('my-project', strings);
+
+    expect(result.success).toBe(true);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stepGcpProject — API enable billing error handling', () => {
+  it('returns clean error when gcloud services enable fails with billing error', async () => {
+    // We test the isBillingError logic indirectly by importing stepGcpProject
+    // and checking that a billing-related error from API enable returns a clean message.
+    // This is covered by the ensureBilling guard, but we also verify the try/catch.
+
+    const { stepGcpProject } = await import('../../src/steps/step-gcp-project.js');
+    const { input } = await import('@inquirer/prompts');
+    const inputMock = input as Mock;
+
+    inputMock.mockResolvedValueOnce('test-project-id');
+
+    // projectExists — project exists
+    shellMock.mockResolvedValueOnce({ stdout: 'test-project-id', stderr: '' });
+    // config set project
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // checkBillingEnabled — billing is linked (pass the billing check)
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/XXX', stderr: '' });
+    // gcloud services enable — fails with billing error
+    const billingErr = new Error('FAILED_PRECONDITION: Billing account not found');
+    shellMock.mockRejectedValueOnce(billingErr);
+
+    const ctx = {
+      config: {},
+      locale: 'en' as const,
+      gcpUsername: 'test',
+    };
+
+    const result = await stepGcpProject(ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Billing is required');
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Installer now checks for billing before enabling GCP APIs
- Detects missing billing via `gcloud billing projects describe`
- Lists available billing accounts for user selection
- Links selected account via `gcloud billing projects link`
- If no accounts exist, guides user to GCP Console and waits for confirmation
- `gcloud services enable` no longer crashes with raw stack trace — shows clean error
- i18n: 8 new billing strings in en + pt-BR
- Bumps version to 0.1.4

## Test plan
- [x] 174/174 tests passing (19 shared + 96 core + 59 installer)
- [x] 16 new tests covering: billing check, account listing, linking, ensureBilling flow, error handling
- [x] Type check clean
- [x] Code review passed — all findings addressed
- [ ] Manual validation on Windows

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)