### PR TITLE
fix: gcloud timeout, per-API enable, clean errors (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.5] — 2026-04-04
+
+### Fixed
+- `gcloud services enable` timeout on new GCP projects (#21). Default 30s was too short — APIs now enabled one at a time with 120s timeout and per-API spinner feedback
+- Raw stack traces on API enable failures — all errors now caught and shown as clean messages
+- `install.ps1` temp directory cleanup failing on Windows due to file handle contention — added retry with delay
+- `install.ps1` silently continuing after `npm ci` or `npm run build` failures — added exit guards
+
+### Changed
+- `shell()` now accepts optional `{ timeout }` parameter (default 30s) for long-running commands
+- Timeout errors now produce clean `Command timed out after Xms: <cmd>` messages
+
 ## [0.1.4] — 2026-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-gcp-project.ts
+++ b/packages/installer/src/steps/step-gcp-project.ts
@@ -226,22 +226,23 @@ export async function stepGcpProject(ctx: InstallerContext): Promise<StepResult>
     return billingResult;
   }
 
-  // Enable required APIs
-  try {
-    await withSpinner(
-      `Enabling APIs (${REQUIRED_APIS.length})...`,
-      async () => {
-        await shell('gcloud', ['services', 'enable', ...REQUIRED_APIS, '--project', projectId]);
-      },
-    );
-  } catch (err: unknown) {
-    if (isBillingError(err)) {
-      return {
-        success: false,
-        message: strings.billing_required_for_apis,
-      };
+  // Enable required APIs one at a time (each can take 1-2 min on new projects)
+  for (const api of REQUIRED_APIS) {
+    const apiName = api.replace('.googleapis.com', '');
+    try {
+      await withSpinner(
+        `Enabling API: ${apiName}...`,
+        async () => {
+          await shell('gcloud', ['services', 'enable', api, '--project', projectId], { timeout: 120_000 });
+        },
+      );
+    } catch (err: unknown) {
+      if (isBillingError(err)) {
+        return { success: false, message: strings.billing_required_for_apis };
+      }
+      const msg = err instanceof Error ? err.message.split('\n')[0] : 'Unknown error';
+      return { success: false, message: `Failed to enable API: ${apiName}. ${msg}` };
     }
-    throw err;
   }
 
   // Set default region and zone

--- a/packages/installer/src/utils/shell.ts
+++ b/packages/installer/src/utils/shell.ts
@@ -12,7 +12,7 @@ export interface ShellResult {
  * Execute a command safely using execFile (no shell interpolation).
  * SECURITY: Uses execFile instead of exec to prevent shell injection.
  */
-export async function shell(cmd: string, args: string[] = []): Promise<ShellResult> {
+export async function shell(cmd: string, args: string[] = [], options?: { timeout?: number }): Promise<ShellResult> {
   // On Windows, .cmd/.bat files cannot be executed directly by execFile().
   // Delegate to cmd.exe which resolves them automatically.
   const actualCmd = process.platform === 'win32' ? 'cmd.exe' : cmd;
@@ -20,7 +20,7 @@ export async function shell(cmd: string, args: string[] = []): Promise<ShellResu
 
   try {
     const { stdout, stderr } = await execFileAsync(actualCmd, actualArgs, {
-      timeout: 30_000,
+      timeout: options?.timeout ?? 30_000,
       maxBuffer: 1024 * 1024,
     });
     return { stdout: stdout.trim(), stderr: stderr.trim() };
@@ -32,6 +32,9 @@ export async function shell(cmd: string, args: string[] = []): Promise<ShellResu
       // On Windows, cmd.exe /c reports missing commands via stderr
       if ('stderr' in err && typeof err.stderr === 'string' && err.stderr.includes('is not recognized')) {
         throw new Error(`Command not found: ${cmd}`);
+      }
+      if ('killed' in err && err.killed === true) {
+        throw new Error(`Command timed out after ${options?.timeout ?? 30_000}ms: ${cmd}`);
       }
     }
     throw err;

--- a/packages/installer/tests/steps/step-gcp-project-billing.test.ts
+++ b/packages/installer/tests/steps/step-gcp-project-billing.test.ts
@@ -287,12 +287,8 @@ describe('ensureBilling', () => {
   });
 });
 
-describe('stepGcpProject — API enable billing error handling', () => {
+describe('stepGcpProject — API enable error handling', () => {
   it('returns clean error when gcloud services enable fails with billing error', async () => {
-    // We test the isBillingError logic indirectly by importing stepGcpProject
-    // and checking that a billing-related error from API enable returns a clean message.
-    // This is covered by the ensureBilling guard, but we also verify the try/catch.
-
     const { stepGcpProject } = await import('../../src/steps/step-gcp-project.js');
     const { input } = await import('@inquirer/prompts');
     const inputMock = input as Mock;
@@ -305,7 +301,7 @@ describe('stepGcpProject — API enable billing error handling', () => {
     shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // checkBillingEnabled — billing is linked (pass the billing check)
     shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/XXX', stderr: '' });
-    // gcloud services enable — fails with billing error
+    // gcloud services enable (first API) — fails with billing error
     const billingErr = new Error('FAILED_PRECONDITION: Billing account not found');
     shellMock.mockRejectedValueOnce(billingErr);
 
@@ -319,5 +315,86 @@ describe('stepGcpProject — API enable billing error handling', () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('Billing is required');
+  });
+
+  it('returns clean error (not stack trace) when API enable fails with non-billing error', async () => {
+    const { stepGcpProject } = await import('../../src/steps/step-gcp-project.js');
+    const { input } = await import('@inquirer/prompts');
+    const inputMock = input as Mock;
+
+    inputMock.mockResolvedValueOnce('test-project-id');
+
+    // projectExists — project exists
+    shellMock.mockResolvedValueOnce({ stdout: 'test-project-id', stderr: '' });
+    // config set project
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // checkBillingEnabled — billing is linked
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/XXX', stderr: '' });
+    // gcloud services enable (first API) — fails with timeout/generic error
+    const timeoutErr = new Error('Command timed out after 120000ms');
+    shellMock.mockRejectedValueOnce(timeoutErr);
+
+    const ctx = {
+      config: {},
+      locale: 'en' as const,
+      gcpUsername: 'test',
+    };
+
+    const result = await stepGcpProject(ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to enable API: compute');
+    expect(result.message).toContain('Command timed out');
+  });
+
+  it('enables APIs one at a time with 120s timeout', async () => {
+    const { stepGcpProject } = await import('../../src/steps/step-gcp-project.js');
+    const { input } = await import('@inquirer/prompts');
+    const inputMock = input as Mock;
+
+    inputMock.mockResolvedValueOnce('test-project-id');
+
+    // projectExists — project exists
+    shellMock.mockResolvedValueOnce({ stdout: 'test-project-id', stderr: '' });
+    // config set project
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // checkBillingEnabled — billing is linked
+    shellMock.mockResolvedValueOnce({ stdout: 'billingAccounts/XXX', stderr: '' });
+    // 3 individual API enable calls
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // config set region
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // config set zone
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const ctx = {
+      config: {},
+      locale: 'en' as const,
+      gcpUsername: 'test',
+    };
+
+    const result = await stepGcpProject(ctx);
+
+    expect(result.success).toBe(true);
+
+    // Verify each API was enabled individually with 120s timeout
+    const apiCalls = shellMock.mock.calls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[])[0] === 'services',
+    );
+    expect(apiCalls).toHaveLength(3);
+
+    for (const call of apiCalls) {
+      expect(call[1][0]).toBe('services');
+      expect(call[1][1]).toBe('enable');
+      // Each call should have a single API: ['services', 'enable', 'x.googleapis.com', '--project', 'id']
+      expect(call[1]).toHaveLength(5);
+    }
+
+    // Verify timeout option was passed
+    for (const call of apiCalls) {
+      expect(call[2]).toMatchObject({ timeout: 120_000 });
+    }
   });
 });

--- a/packages/installer/tests/utils/shell.test.ts
+++ b/packages/installer/tests/utils/shell.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Track calls to execFile so we can assert cmd/args without ESM spy issues
-const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+// Track calls to execFile so we can assert cmd/args/opts without ESM spy issues
+const execFileCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
 
 // Allows individual tests to override the default success behaviour
 type ExecFileCallback = (err: unknown, result?: { stdout: string; stderr: string }) => void;
 let execFileImpl: ((cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => void) | null = null;
 
 vi.mock('node:child_process', () => ({
-  execFile: (cmd: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
-    execFileCalls.push({ cmd, args });
+  execFile: (cmd: string, args: string[], opts: Record<string, unknown>, cb: ExecFileCallback) => {
+    execFileCalls.push({ cmd, args, opts });
     if (execFileImpl) {
-      execFileImpl(cmd, args, _opts, cb);
+      execFileImpl(cmd, args, opts, cb);
     } else {
       cb(null, { stdout: 'mocked output', stderr: '' });
     }
@@ -131,5 +131,25 @@ describe('shell() Windows cmd.exe wrapping', () => {
 
     const { shell } = await import('../../src/utils/shell.js');
     await expect(shell('missingcmd')).rejects.toThrow('Command not found: missingcmd');
+  });
+
+  it('uses default 30s timeout when no options provided', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud', ['--version']);
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].opts).toMatchObject({ timeout: 30_000 });
+  });
+
+  it('uses custom timeout when provided via options', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+
+    const { shell } = await import('../../src/utils/shell.js');
+    await shell('gcloud', ['services', 'enable', 'compute.googleapis.com'], { timeout: 120_000 });
+
+    expect(execFileCalls).toHaveLength(1);
+    expect(execFileCalls[0].opts).toMatchObject({ timeout: 120_000 });
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -31,11 +31,18 @@ git clone --depth 1 https://github.com/isorensen/lox-brain.git "$tempDir\lox-bra
 Set-Location "$tempDir\lox-brain"
 Write-Host "Installing dependencies..."
 npm ci --silent
+if ($LASTEXITCODE -ne 0) { Write-Host "npm ci failed"; exit 1 }
 Write-Host "Building..."
 npm run build --workspaces --silent
+if ($LASTEXITCODE -ne 0) { Write-Host "Build failed"; exit 1 }
 Write-Host ""
 node packages\installer\dist\index.js
 
-# Cleanup
+# Cleanup — retry with delay to allow processes to release file handles
 Set-Location $HOME
-Remove-Item -Recurse -Force $tempDir
+Start-Sleep -Seconds 2
+Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+if (Test-Path $tempDir) {
+    Start-Sleep -Seconds 3
+    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- `shell()` now accepts optional `{ timeout }` parameter (default 30s)
- APIs enabled one at a time with 120s timeout and per-API spinner — no more silent timeout on new projects
- Timeout errors produce clean `Command timed out after Xms` messages
- All API enable errors caught cleanly (no more stack traces)
- `install.ps1`: retry/delay for temp dir cleanup on Windows file handle contention
- `install.ps1`: exit guards after `npm ci` and `npm run build` failures
- Bumps version to 0.1.5

## Test plan
- [x] 178/178 tests passing (19 shared + 96 core + 63 installer)
- [x] Type check clean
- [x] Code review passed — all findings addressed
- [ ] Manual validation on Windows (Lara)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)