### PR TITLE
fix: SA IAM binding and VM creation reliability (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.6] — 2026-04-04
+
+### Fixed
+- IAM binding `--condition=None` flag causing parse error on gcloud (#21). Removed the flag entirely — no condition is the default behavior.
+- Service account "does not exist" error during IAM binding (#21). GCP propagation delay after SA creation now handled with 5s initial delay + retry (3 attempts, 5s between each).
+- Raw stack traces on IAM binding and VM creation failures — now caught with clean error messages.
+- VM creation timeout — increased to 120s (was 30s default, VM creation takes 30-60s).
+
 ## [0.1.5] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm.ts
+++ b/packages/installer/src/steps/step-vm.ts
@@ -17,6 +17,37 @@ const VPC_NAME = 'lox-vpc';
 const SUBNET_NAME = 'lox-subnet';
 
 /**
+ * Retry a function up to `retries` times with a delay between attempts.
+ * Only retries when `retryIf` returns true (or is omitted).
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  delayMs: number,
+  retryIf?: (err: unknown) => boolean,
+): Promise<T> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === retries || (retryIf && !retryIf(err))) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error('Unreachable');
+}
+
+/**
+ * Extract a clean, single-line error message from a thrown error.
+ */
+function cleanErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message.split('\n')[0];
+  }
+  return String(err).split('\n')[0];
+}
+
+/**
  * Check if the service account already exists.
  */
 async function saExists(project: string): Promise<boolean> {
@@ -83,24 +114,38 @@ export async function stepVm(ctx: InstallerContext): Promise<StepResult> {
     );
   }
 
+  // Allow GCP propagation time after SA creation
+  if (!saAlreadyExists) {
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+
   // Grant least-privilege IAM roles
   const roles = [
     'roles/secretmanager.secretAccessor',
     'roles/logging.logWriter',
   ];
 
-  for (const role of roles) {
-    await withSpinner(
-      `Granting ${role.split('/')[1]}...`,
-      async () => {
-        await shell('gcloud', [
-          'projects', 'add-iam-policy-binding', project,
-          `--member=serviceAccount:${saEmail}`,
-          `--role=${role}`,
-          '--condition=None',
-        ]);
-      },
-    );
+  try {
+    for (const role of roles) {
+      await withSpinner(
+        `Granting ${role.split('/')[1]}...`,
+        async () => {
+          await withRetry(
+            () => shell('gcloud', [
+              'projects', 'add-iam-policy-binding', project,
+              `--member=serviceAccount:${saEmail}`,
+              `--role=${role}`,
+            ]),
+            3,
+            5_000,
+            (err) => err instanceof Error && err.message.includes('does not exist'),
+          );
+        },
+      );
+    }
+  } catch (err) {
+    const msg = cleanErrorMessage(err);
+    return { success: false, message: `Failed to grant IAM role: ${msg}` };
   }
 
   // Create VM if it doesn't exist
@@ -108,27 +153,32 @@ export async function stepVm(ctx: InstallerContext): Promise<StepResult> {
   if (vmAlreadyExists) {
     console.log(chalk.yellow(`  → VM ${VM_NAME} already exists, skipping creation.`));
   } else {
-    await withSpinner(
-      `${strings.creating} VM ${VM_NAME} (${MACHINE_TYPE})...`,
-      async () => {
-        await shell('gcloud', [
-          'compute', 'instances', 'create', VM_NAME,
-          '--zone', zone,
-          '--machine-type', MACHINE_TYPE,
-          '--network', VPC_NAME,
-          '--subnet', SUBNET_NAME,
-          '--no-address',
-          '--tags=vpn-server,allow-iap',
-          `--service-account=${saEmail}`,
-          '--scopes=cloud-platform',
-          `--image-family=${IMAGE_FAMILY}`,
-          `--image-project=${IMAGE_PROJECT}`,
-          `--boot-disk-size=${BOOT_DISK_SIZE}`,
-          `--boot-disk-type=${BOOT_DISK_TYPE}`,
-          '--project', project,
-        ]);
-      },
-    );
+    try {
+      await withSpinner(
+        `${strings.creating} VM ${VM_NAME} (${MACHINE_TYPE})...`,
+        async () => {
+          await shell('gcloud', [
+            'compute', 'instances', 'create', VM_NAME,
+            '--zone', zone,
+            '--machine-type', MACHINE_TYPE,
+            '--network', VPC_NAME,
+            '--subnet', SUBNET_NAME,
+            '--no-address',
+            '--tags=vpn-server,allow-iap',
+            `--service-account=${saEmail}`,
+            '--scopes=cloud-platform',
+            `--image-family=${IMAGE_FAMILY}`,
+            `--image-project=${IMAGE_PROJECT}`,
+            `--boot-disk-size=${BOOT_DISK_SIZE}`,
+            `--boot-disk-type=${BOOT_DISK_TYPE}`,
+            '--project', project,
+          ], { timeout: 120_000 });
+        },
+      );
+    } catch (err) {
+      const msg = cleanErrorMessage(err);
+      return { success: false, message: `Failed to create VM ${VM_NAME}: ${msg}` };
+    }
   }
 
   // Store service account in config

--- a/packages/installer/tests/steps/step-vm.test.ts
+++ b/packages/installer/tests/steps/step-vm.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// Mock shell utility
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+}));
+
+// Mock UI modules (they use terminal features not available in tests)
+vi.mock('../../src/ui/box.js', () => ({
+  renderStepHeader: vi.fn(() => ''),
+}));
+
+vi.mock('../../src/ui/spinner.js', () => ({
+  withSpinner: vi.fn((_msg: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+// Mock chalk to pass-through
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    cyan: (s: string) => s,
+  },
+}));
+
+// Mock i18n
+vi.mock('../../src/i18n/index.js', () => ({
+  t: () => ({
+    step_vm_instance: 'VM Instance',
+    creating: 'Creating',
+  }),
+}));
+
+import { shell } from '../../src/utils/shell.js';
+import { stepVm } from '../../src/steps/step-vm.js';
+import type { InstallerContext } from '../../src/steps/types.js';
+
+const shellMock = shell as Mock;
+
+function makeCtx(overrides: Partial<InstallerContext> = {}): InstallerContext {
+  return {
+    config: { gcp: { zone: 'us-central1-a' } },
+    locale: 'en' as const,
+    gcpProjectId: 'test-project',
+    gcpUsername: 'test-user',
+    ...overrides,
+  } as InstallerContext;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Use fake timers so setTimeout resolves instantly
+  vi.useFakeTimers();
+});
+
+/**
+ * Helper: advances all pending timers and microtasks so withRetry delays
+ * and the propagation delay resolve immediately.
+ */
+async function flushTimers(): Promise<void> {
+  await vi.runAllTimersAsync();
+}
+
+describe('stepVm — early exit', () => {
+  it('returns failure when project is not set', async () => {
+    vi.useRealTimers();
+    const ctx = makeCtx({ gcpProjectId: undefined });
+    const result = await stepVm(ctx);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('GCP project or zone not set');
+  });
+
+  it('returns failure when zone is not set', async () => {
+    vi.useRealTimers();
+    const ctx = makeCtx({ config: { gcp: { zone: undefined } } } as unknown as Partial<InstallerContext>);
+    const result = await stepVm(ctx);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('GCP project or zone not set');
+  });
+});
+
+describe('stepVm — IAM binding args (no --condition=None)', () => {
+  it('does not pass --condition=None in gcloud IAM binding args', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'lox-vm-sa@test-project.iam.gserviceaccount.com', stderr: '' });
+    // IAM binding: secretmanager.secretAccessor
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // IAM binding: logging.logWriter
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'lox-vm', stderr: '' });
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+
+    // Find IAM binding calls
+    const iamCalls = shellMock.mock.calls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[]).includes('add-iam-policy-binding'),
+    );
+    expect(iamCalls).toHaveLength(2);
+
+    for (const call of iamCalls) {
+      const args = call[1] as string[];
+      expect(args).not.toContain('--condition=None');
+      expect(args).toContain('--member=serviceAccount:lox-vm-sa@test-project.iam.gserviceaccount.com');
+    }
+
+    // Verify the two roles
+    expect((iamCalls[0][1] as string[]).find((a: string) => a.startsWith('--role='))).toBe(
+      '--role=roles/secretmanager.secretAccessor',
+    );
+    expect((iamCalls[1][1] as string[]).find((a: string) => a.startsWith('--role='))).toBe(
+      '--role=roles/logging.logWriter',
+    );
+  });
+});
+
+describe('stepVm — IAM binding retry on propagation delay', () => {
+  it('retries IAM binding when SA "does not exist" and succeeds on retry', async () => {
+    // saExists — SA does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // SA create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // IAM binding: first attempt fails with "does not exist"
+    shellMock.mockRejectedValueOnce(new Error('Service account does not exist'));
+    // IAM binding: second attempt succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // IAM binding: logWriter — succeeds first try
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'lox-vm', stderr: '' });
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+
+    // The IAM binding should have been called 3 times total (1 retry + 1 success + 1 for second role)
+    const iamCalls = shellMock.mock.calls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[]).includes('add-iam-policy-binding'),
+    );
+    expect(iamCalls).toHaveLength(3);
+  });
+
+  it('returns clean error after max retries on "does not exist"', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'exists', stderr: '' });
+    // IAM binding: all 3 attempts fail with "does not exist"
+    shellMock.mockRejectedValueOnce(new Error('Service account does not exist'));
+    shellMock.mockRejectedValueOnce(new Error('Service account does not exist'));
+    shellMock.mockRejectedValueOnce(new Error('Service account does not exist'));
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to grant IAM role');
+    expect(result.message).toContain('does not exist');
+    // No raw stack trace — message is single line
+    expect(result.message).not.toContain('\n');
+  });
+
+  it('does not retry on non-matching errors (e.g. permission denied)', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'exists', stderr: '' });
+    // IAM binding: fails with permission denied (should NOT retry)
+    shellMock.mockRejectedValueOnce(new Error('PERMISSION_DENIED: caller lacks permission'));
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to grant IAM role');
+    expect(result.message).toContain('PERMISSION_DENIED');
+
+    // Only 1 IAM binding attempt (no retries)
+    const iamCalls = shellMock.mock.calls.filter(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[]).includes('add-iam-policy-binding'),
+    );
+    expect(iamCalls).toHaveLength(1);
+  });
+});
+
+describe('stepVm — VM creation error handling', () => {
+  it('passes 120s timeout to shell for VM creation', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'exists', stderr: '' });
+    // IAM bindings succeed
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // VM create — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+
+    // Find the VM creation call (contains both 'instances' and 'create')
+    const vmCreateCall = shellMock.mock.calls.find(
+      (call: unknown[]) => {
+        if (!Array.isArray(call[1])) return false;
+        const args = call[1] as string[];
+        return args.includes('instances') && args.includes('create');
+      },
+    );
+    expect(vmCreateCall).toBeDefined();
+    expect(vmCreateCall![2]).toMatchObject({ timeout: 120_000 });
+  });
+
+  it('returns clean error when VM creation fails', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'exists', stderr: '' });
+    // IAM bindings succeed
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // VM create — fails with timeout
+    shellMock.mockRejectedValueOnce(new Error('Command timed out after 120000ms: gcloud'));
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to create VM lox-vm');
+    expect(result.message).toContain('timed out');
+    expect(result.message).not.toContain('\n');
+  });
+
+  it('returns clean error when VM creation fails with quota error', async () => {
+    // saExists — SA already exists
+    shellMock.mockResolvedValueOnce({ stdout: 'exists', stderr: '' });
+    // IAM bindings succeed
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // VM create — fails with quota
+    shellMock.mockRejectedValueOnce(new Error('QUOTA_EXCEEDED: Insufficient quota\nsome stack trace'));
+
+    const promise = stepVm(makeCtx());
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('QUOTA_EXCEEDED');
+    // Only first line, no stack trace
+    expect(result.message).not.toContain('some stack trace');
+  });
+});
+
+describe('stepVm — full success path', () => {
+  it('creates SA, grants roles, creates VM, and stores config', async () => {
+    // saExists — SA does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // SA create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // IAM bindings succeed
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // vmExists — VM does not exist
+    shellMock.mockRejectedValueOnce(new Error('not found'));
+    // VM create — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const ctx = makeCtx();
+    const promise = stepVm(ctx);
+    await flushTimers();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(ctx.config.gcp?.service_account).toBe('lox-vm-sa@test-project.iam.gserviceaccount.com');
+    expect(ctx.config.gcp?.vm_name).toBe('lox-vm');
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Remove `--condition=None` from gcloud IAM binding — caused parse error
- Add 5s delay after SA creation + retry (3 attempts, 5s) for GCP propagation delay
- Wrap IAM binding and VM creation errors with clean messages (no stack traces)
- VM creation timeout increased to 120s (was 30s default)
- Bumps version to 0.1.6

## Test plan
- [x] 188/188 tests passing (19 shared + 96 core + 73 installer)
- [x] 10 new tests covering SA/IAM/VM paths
- [x] Type check clean
- [ ] Manual validation on Windows (Lara)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)