### PR TITLE
fix: VM setup timeout, Windows bash compat, retry prompt (#27)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -20,9 +20,15 @@ This skill encodes the full checklist so nothing slips through.
 
 ### Phase 1 — Understand
 
-1. **Read the issue**: `gh issue view <number>` — understand the bug/feature, environment, steps to reproduce.
-2. **Read related code**: Explore the files involved before proposing changes. Never modify code you haven't read.
-3. **Check for related issues**: `gh issue list --state open` — are there duplicates or related issues?
+1. **Read the issue**: `gh issue view <number> --comments` — understand the bug/feature, environment, steps to reproduce. **Always include `--comments`** to see the full conversation.
+2. **Scan for private data in comments**: Check every comment for sensitive information:
+   - GCP project numbers, project IDs, billing account IDs
+   - Service account emails, API keys, tokens, Help Tokens
+   - Windows user paths (`C:\Users\<name>\...`)
+   - IP addresses, SSH keys, credentials of any kind
+   - If found: **delete the comment** (`gh api repos/OWNER/REPO/issues/comments/ID -X DELETE`) and **create a replacement comment** summarizing the content without the sensitive data. Only repo admins can delete others' comments.
+3. **Read related code**: Explore the files involved before proposing changes. Never modify code you haven't read.
+4. **Check for related issues**: `gh issue list --state open` — are there duplicates or related issues?
 
 ### Phase 2 — Branch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.1.7] — 2026-04-04
+
+### Fixed
+- VM setup SSH command timing out at 30s (#27). `sshExec()` now uses the declared `SSH_TIMEOUT` constant (5 min default, 10 min for full setup script).
+- Secret Manager password storage using `bash -c` which doesn't exist on Windows. Replaced with cross-platform temp file approach.
+- No error handling in `stepVmSetup` — SSH and secret storage failures now return clean messages.
+
+### Added
+- Timeout retry prompt: when VM setup times out, user is asked "Continue waiting?" instead of failing immediately. Timeout doubles on each retry (max 20 min).
+
 ## [0.1.6] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -88,6 +88,9 @@ export interface I18nStrings {
   // Modes
   mode_personal: string;
   mode_team: string;
+
+  // VM setup
+  vm_setup_timeout: string;
 }
 
 export const en: I18nStrings = {
@@ -180,4 +183,7 @@ export const en: I18nStrings = {
   // Modes
   mode_personal: 'Personal',
   mode_team: 'Team',
+
+  // VM setup
+  vm_setup_timeout: 'VM setup is taking longer than expected. Continue waiting?',
 };

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -90,4 +90,7 @@ export const ptBr: I18nStrings = {
   // Modes
   mode_personal: 'Pessoal',
   mode_team: 'Equipe',
+
+  // VM setup
+  vm_setup_timeout: 'A configuracao da VM esta demorando mais que o esperado. Continuar aguardando?',
 };

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -1,4 +1,7 @@
 import crypto from 'node:crypto';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import chalk from 'chalk';
 import { shell } from '../utils/shell.js';
 import { t } from '../i18n/index.js';
@@ -6,11 +9,29 @@ import { renderStepHeader } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
 import type { InstallerContext, StepResult } from './types.js';
 
+/**
+ * Returns true when an error is caused by a process timeout (SIGTERM / killed).
+ */
+function isTimeoutError(err: unknown): boolean {
+  if (err instanceof Error) {
+    return (
+      err.message.includes('timed out') ||
+      err.message.includes('SIGTERM') ||
+      ('killed' in err && (err as unknown as { killed: boolean }).killed === true)
+    );
+  }
+  if (err !== null && typeof err === 'object' && 'killed' in err) {
+    return (err as { killed: boolean }).killed === true;
+  }
+  return false;
+}
+
 const TOTAL_STEPS = 12;
 const VM_NAME = 'lox-vm';
 const DB_NAME = 'lox_brain';
 const DB_USER = 'lox';
-const SSH_TIMEOUT = 120_000; // 2 minutes per SSH command
+const SSH_TIMEOUT = 300_000; // 5 minutes — VM commands may install packages
+const VM_SETUP_TIMEOUT = 600_000; // 10 minutes — full setup compiles pgvector
 
 /**
  * Execute a command on the VM via IAP tunnel SSH.
@@ -20,6 +41,7 @@ async function sshExec(
   project: string,
   zone: string,
   command: string,
+  timeout?: number,
 ): Promise<string> {
   const { stdout } = await shell('gcloud', [
     'compute', 'ssh', VM_NAME,
@@ -27,7 +49,7 @@ async function sshExec(
     '--project', project,
     '--tunnel-through-iap',
     '--command', command,
-  ]);
+  ], { timeout: timeout ?? SSH_TIMEOUT });
   return stdout;
 }
 
@@ -122,41 +144,77 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
   // Generate a secure DB password
   const dbPassword = generatePassword();
 
-  // Run the setup script on the VM
-  await withSpinner(
-    `${strings.installing} Node.js 22, PostgreSQL 16, pgvector on VM...`,
-    async () => {
-      const script = buildSetupScript(dbPassword);
-      const output = await sshExec(project, zone, script);
-      if (!output.includes('VM_SETUP_COMPLETE')) {
-        throw new Error('VM setup script did not complete successfully');
+  // Run the setup script on the VM, with timeout-retry loop
+  const script = buildSetupScript(dbPassword);
+  let timeout = VM_SETUP_TIMEOUT;
+  const MAX_TIMEOUT = 1_200_000; // 20 minutes
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await withSpinner(
+        `${strings.installing} Node.js 22, PostgreSQL 16, pgvector on VM...`,
+        async () => {
+          const output = await sshExec(project, zone, script, timeout);
+          if (!output.includes('VM_SETUP_COMPLETE')) {
+            throw new Error('VM setup script did not complete successfully');
+          }
+        },
+      );
+      break; // success — exit loop
+    } catch (err) {
+      if (isTimeoutError(err) && timeout < MAX_TIMEOUT) {
+        const { confirm } = await import('@inquirer/prompts');
+        const shouldRetry = await confirm({
+          message: strings.vm_setup_timeout,
+          default: true,
+        });
+        if (shouldRetry) {
+          timeout = Math.min(timeout * 2, MAX_TIMEOUT);
+          continue;
+        }
       }
-    },
-  );
+      // Non-timeout error, user declined retry, or already at max timeout
+      const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+      return { success: false, message: `VM setup failed: ${msg}` };
+    }
+  }
 
   // Store DB password in Secret Manager
-  await withSpinner(
-    'Storing database password in Secret Manager...',
-    async () => {
-      // Create the secret
-      try {
-        await shell('gcloud', [
-          'secrets', 'create', 'lox-db-password',
-          '--replication-policy=automatic',
-          '--project', project,
-        ]);
-      } catch {
-        // Secret may already exist — add a new version
-      }
+  try {
+    await withSpinner(
+      'Storing database password in Secret Manager...',
+      async () => {
+        // Create the secret (may already exist)
+        try {
+          await shell('gcloud', [
+            'secrets', 'create', 'lox-db-password',
+            '--replication-policy=automatic',
+            '--project', project,
+          ]);
+        } catch {
+          // Secret may already exist — add a new version
+        }
 
-      // Add the password as a secret version via stdin
-      // SECURITY: Password is piped, never appears in process args
-      await shell('bash', [
-        '-c',
-        `echo -n "${dbPassword}" | gcloud secrets versions add lox-db-password --data-file=- --project=${project}`,
-      ]);
-    },
-  );
+        // Write password to a temp file for cross-platform compatibility.
+        // SECURITY: File has restrictive permissions (0o600) and is always deleted.
+        const tmpFile = join(tmpdir(), `lox-db-pw-${crypto.randomBytes(8).toString('hex')}`);
+        writeFileSync(tmpFile, dbPassword, { mode: 0o600 });
+        try {
+          await shell('gcloud', [
+            'secrets', 'versions', 'add', 'lox-db-password',
+            `--data-file=${tmpFile}`,
+            '--project', project,
+          ]);
+        } finally {
+          unlinkSync(tmpFile);
+        }
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    return { success: false, message: `Failed to store DB password in Secret Manager: ${msg}` };
+  }
 
   // Store database config
   ctx.config.database = {

--- a/packages/installer/tests/steps/step-vm-setup.test.ts
+++ b/packages/installer/tests/steps/step-vm-setup.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { existsSync } from 'node:fs';
+
+// Track writeFileSync/unlinkSync calls
+const writeFileSyncMock = vi.fn();
+const unlinkSyncMock = vi.fn();
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args),
+    unlinkSync: (...args: unknown[]) => unlinkSyncMock(...args),
+    existsSync: actual.existsSync,
+  };
+});
+
+// Mock shell utility
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+}));
+
+// Mock UI modules
+vi.mock('../../src/ui/box.js', () => ({
+  renderStepHeader: vi.fn(() => ''),
+}));
+
+vi.mock('../../src/ui/spinner.js', () => ({
+  withSpinner: vi.fn((_msg: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+// Mock chalk
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    cyan: (s: string) => s,
+  },
+}));
+
+// Mock i18n
+vi.mock('../../src/i18n/index.js', () => ({
+  t: () => ({
+    step_postgresql: 'PostgreSQL Setup',
+    installing: 'Installing',
+    vm_setup_timeout: 'VM setup is taking longer than expected. Continue waiting?',
+  }),
+}));
+
+// Mock @inquirer/prompts so tests control the confirm response
+const confirmMock = vi.fn();
+vi.mock('@inquirer/prompts', () => ({
+  confirm: (...args: unknown[]) => confirmMock(...args),
+}));
+
+import { shell } from '../../src/utils/shell.js';
+import { stepVmSetup } from '../../src/steps/step-vm-setup.js';
+import type { InstallerContext } from '../../src/steps/types.js';
+
+const shellMock = shell as Mock;
+
+function makeCtx(overrides: Partial<InstallerContext> = {}): InstallerContext {
+  return {
+    config: { gcp: { zone: 'us-central1-a' } },
+    locale: 'en' as const,
+    gcpProjectId: 'test-project',
+    gcpUsername: 'test-user',
+    ...overrides,
+  } as InstallerContext;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('stepVmSetup — early exit', () => {
+  it('returns failure when project is not set', async () => {
+    const ctx = makeCtx({ gcpProjectId: undefined });
+    const result = await stepVmSetup(ctx);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('GCP project or zone not set');
+  });
+
+  it('returns failure when zone is not set', async () => {
+    const ctx = makeCtx({ config: { gcp: { zone: undefined } } } as unknown as Partial<InstallerContext>);
+    const result = await stepVmSetup(ctx);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('GCP project or zone not set');
+  });
+});
+
+describe('stepVmSetup — sshExec timeout', () => {
+  it('passes 600_000 timeout to shell for the VM setup script', async () => {
+    // SSH setup script — succeeds with marker
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(true);
+
+    // First shell call is the SSH setup — verify timeout
+    const sshCall = shellMock.mock.calls[0];
+    expect(sshCall[0]).toBe('gcloud');
+    const args = sshCall[1] as string[];
+    expect(args).toContain('--command');
+    expect(sshCall[2]).toMatchObject({ timeout: 600_000 });
+  });
+});
+
+describe('stepVmSetup — Secret Manager uses temp file (no bash)', () => {
+  it('writes password to temp file and uses --data-file flag', async () => {
+    // SSH setup script — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(true);
+
+    // writeFileSync should have been called with a temp file path and mode 0o600
+    expect(writeFileSyncMock).toHaveBeenCalledOnce();
+    const [tmpPath, content, opts] = writeFileSyncMock.mock.calls[0];
+    expect(typeof tmpPath).toBe('string');
+    expect(tmpPath).toMatch(/lox-db-pw-/);
+    expect(typeof content).toBe('string');
+    expect(content.length).toBeGreaterThan(0);
+    expect(opts).toMatchObject({ mode: 0o600 });
+
+    // unlinkSync should have been called to clean up
+    expect(unlinkSyncMock).toHaveBeenCalledOnce();
+    expect(unlinkSyncMock).toHaveBeenCalledWith(tmpPath);
+
+    // The secret version add call should use --data-file, NOT bash
+    const secretAddCall = shellMock.mock.calls[2];
+    expect(secretAddCall[0]).toBe('gcloud');
+    const secretArgs = secretAddCall[1] as string[];
+    expect(secretArgs).toContain('secrets');
+    expect(secretArgs).toContain('versions');
+    expect(secretArgs).toContain('add');
+    const dataFileArg = secretArgs.find((a: string) => a.startsWith('--data-file='));
+    expect(dataFileArg).toBeDefined();
+    expect(dataFileArg).toContain('lox-db-pw-');
+
+    // bash should NEVER be called
+    const bashCalls = shellMock.mock.calls.filter(
+      (call: unknown[]) => call[0] === 'bash',
+    );
+    expect(bashCalls).toHaveLength(0);
+  });
+
+  it('deletes temp file even when gcloud fails', async () => {
+    // SSH setup script — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add — fails
+    shellMock.mockRejectedValueOnce(new Error('gcloud secrets error'));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to store DB password in Secret Manager');
+
+    // Temp file must still be cleaned up
+    expect(unlinkSyncMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('stepVmSetup — error handling', () => {
+  it('returns clean error on SSH setup failure', async () => {
+    shellMock.mockRejectedValueOnce(new Error('Connection refused\nstack trace line'));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('VM setup failed');
+    expect(result.message).toContain('Connection refused');
+    // No stack trace leakage
+    expect(result.message).not.toContain('stack trace line');
+  });
+
+  it('returns clean error when setup script does not emit marker', async () => {
+    shellMock.mockResolvedValueOnce({ stdout: 'some partial output', stderr: '' });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('VM setup failed');
+    expect(result.message).toContain('did not complete successfully');
+  });
+
+  it('returns clean error on secret storage failure', async () => {
+    // SSH setup — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create — fails with non-ignorable error path
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add — fails
+    shellMock.mockRejectedValueOnce(new Error('PERMISSION_DENIED: caller lacks permission\ndetails'));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Failed to store DB password');
+    expect(result.message).toContain('PERMISSION_DENIED');
+    expect(result.message).not.toContain('details');
+  });
+});
+
+describe('stepVmSetup — full success path', () => {
+  it('sets database config on context after success', async () => {
+    // SSH setup — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const ctx = makeCtx();
+    const result = await stepVmSetup(ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.config.database).toEqual({
+      host: '127.0.0.1',
+      port: 5432,
+      name: 'lox_brain',
+      user: 'lox',
+    });
+  });
+});
+
+describe('stepVmSetup — timeout retry', () => {
+  it('prompts user on timeout, retries with doubled timeout, and succeeds', async () => {
+    // First SSH call — times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    // Second SSH call — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // Secret create
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Secret version add
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    confirmMock.mockResolvedValueOnce(true);
+
+    const result = await stepVmSetup(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(confirmMock).toHaveBeenCalledOnce();
+    expect(confirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ default: true }),
+    );
+
+    // Second SSH shell call should use doubled timeout (1_200_000)
+    const secondSshCall = shellMock.mock.calls[1];
+    expect(secondSshCall[2]).toMatchObject({ timeout: 1_200_000 });
+  });
+
+  it('returns clean error when user declines to retry after timeout', async () => {
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    confirmMock.mockResolvedValueOnce(false);
+
+    const result = await stepVmSetup(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('VM setup failed');
+    expect(result.message).toContain('timed out');
+    expect(confirmMock).toHaveBeenCalledOnce();
+    // Shell should only have been called once (no retry)
+    expect(shellMock).toHaveBeenCalledOnce();
+  });
+
+  it('fails immediately without prompting when already at max timeout', async () => {
+    // First call at 600_000 — times out; user says yes → retries at 1_200_000
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    confirmMock.mockResolvedValueOnce(true); // first prompt: yes
+
+    // Second call at 1_200_000 (max) — also times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+
+    const result = await stepVmSetup(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('VM setup failed');
+    // Prompt appeared only once (at 600_000); at max timeout no further prompt
+    expect(confirmMock).toHaveBeenCalledOnce();
+    expect(shellMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT prompt on non-timeout errors', async () => {
+    shellMock.mockRejectedValueOnce(new Error('Connection refused'));
+
+    const result = await stepVmSetup(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Connection refused');
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `sshExec()` now uses `SSH_TIMEOUT` (5min default, 10min for full VM setup)
- Timeout retry: asks user "Continue waiting?" with doubling timeout (max 20min)
- Secret Manager: replaced `bash -c` pipe with cross-platform temp file approach
- Clean error messages on SSH and secret storage failures
- `/issue` skill: added private data scanning step for issue comments

Bumps version to 0.1.7.

## Test plan
- [x] 201/201 tests passing (19 shared + 96 core + 86 installer)
- [x] Type check clean
- [ ] Manual validation on Windows (Lara)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)