### PR TITLE
feat: phased VM setup with progress feedback (#29)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: issue
-description: Handle GitHub issues end-to-end for the lox-brain project. Use this skill whenever the user mentions an issue number, asks to fix a bug, wants to work on a GitHub issue, says "issue", "#17", "#21", or refers to any open issue. Also trigger when the user asks to check open issues, triage bugs, or work on reported problems. This skill ensures nothing is missed — version bumps, changelog, tests, code review, PR, release, and cleanup.
+description: Handle GitHub issues end-to-end for the lox-brain project. Use this skill whenever the user mentions an issue number, asks to fix a bug, wants to work on a GitHub issue, says "issue", "#17", "#21", or refers to any open issue. Also trigger when the user asks to check open issues, triage bugs, or work on reported problems. Supports "issue new <description>" to create a new issue and start working on it. This skill ensures nothing is missed — version bumps, changelog, tests, code review, PR, release, and cleanup.
 ---
 
 # /issue — GitHub Issue Handler
 
 End-to-end workflow for resolving GitHub issues in the lox-brain monorepo. Covers everything from reading the issue to creating the GitHub Release.
+
+## Usage modes
+
+- `/issue <number>` — Work on an existing issue (full workflow below)
+- `/issue new <description>` — Create a new issue and optionally start working on it
+- `/issue` (no args) — List open issues and ask which to work on
 
 ## Why this skill exists
 
@@ -16,7 +22,21 @@ Handling issues in this project requires a specific checklist that is easy to fo
 
 This skill encodes the full checklist so nothing slips through.
 
-## Workflow
+## Creating a new issue (`/issue new`)
+
+When the user provides a description for a new issue:
+
+1. **Determine issue type**: bug, feature, or enhancement based on the description.
+2. **Draft the issue** using the repo's issue templates. Create via:
+   ```
+   gh issue create --title "<title>" --body "<body>" --label <bug|enhancement>
+   ```
+3. **Show the created issue URL** to the user.
+4. **Ask**: "Want to start working on this issue now?" If yes, proceed with the full workflow below using the new issue number.
+
+Keep the title concise (<70 chars). Use the description body to include context, expected behavior, and any relevant details the user provided.
+
+## Working on an issue (`/issue <number>`)
 
 ### Phase 1 — Understand
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.0] — 2026-04-04
+
+### Added
+- VM setup progress feedback (#29): monolithic SSH script split into 7 individual phases (system update, Node.js, PostgreSQL, pgvector compile, DB setup, SSH hardening, WireGuard), each with its own spinner and timeout
+- VM log fetching on timeout: when a phase times out, installer attempts to fetch last 20 lines from the VM for diagnosis
+- Per-phase timeout retry: each phase can be retried individually with doubled timeout
+- `/issue new <desc>` mode in the `/issue` skill for creating new issues
+- Disclaimer section in README: data responsibility, GCP costs, no liability for breaches
+- i18n: 8 new VM phase strings in en and pt-BR
+
+### Changed
+- Version bump from 0.1.x to 0.2.0 (feature release)
+
 ## [0.1.7] — 2026-04-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ npm run index-vault                      # One-time full vault indexing
 
 Estimated monthly cost: **~US$18/month** (GCE e2-small + 30GB pd-ssd + Cloud NAT + minimal traffic).
 
+## Status
+
+Lox is under active development. The installer and infrastructure setup are being tested and refined. Breaking changes may occur between minor versions. Check the [CHANGELOG](CHANGELOG.md) and [releases](https://github.com/isorensen/lox-brain/releases) for details.
+
+## Disclaimer
+
+This software is provided "as-is" without warranty of any kind. By using Lox, you acknowledge that:
+
+- **You are responsible for your own data.** Lox stores personal notes, credentials, and API keys on infrastructure you provision. The authors are not responsible for any data loss, unauthorized access, or security incidents arising from misconfiguration, vulnerabilities, or misuse.
+- **GCP costs are your responsibility.** The installer provisions cloud resources (VMs, storage, networking) on your GCP account. Monitor your billing to avoid unexpected charges.
+- **No liability for data breaches.** While Lox follows Zero Trust security principles (VPN-only access, encrypted connections, least-privilege IAM), no system is immune to vulnerabilities. The authors disclaim all liability for personal or corporate data exposure.
+- **Review before deploying in production.** This project is designed for personal use. If you use it in a corporate or team environment, conduct your own security review.
+
+See the [MIT License](LICENSE) for the full legal terms.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -91,6 +91,14 @@ export interface I18nStrings {
 
   // VM setup
   vm_setup_timeout: string;
+  vm_phase_system_update: string;
+  vm_phase_nodejs: string;
+  vm_phase_postgresql: string;
+  vm_phase_pgvector: string;
+  vm_phase_db_setup: string;
+  vm_phase_ssh_hardening: string;
+  vm_phase_wireguard: string;
+  vm_phase_fetching_logs: string;
 }
 
 export const en: I18nStrings = {
@@ -186,4 +194,12 @@ export const en: I18nStrings = {
 
   // VM setup
   vm_setup_timeout: 'VM setup is taking longer than expected. Continue waiting?',
+  vm_phase_system_update: 'Updating system packages',
+  vm_phase_nodejs: 'Installing Node.js 22',
+  vm_phase_postgresql: 'Installing PostgreSQL 16',
+  vm_phase_pgvector: 'Compiling pgvector extension',
+  vm_phase_db_setup: 'Creating database and schema',
+  vm_phase_ssh_hardening: 'Hardening SSH configuration',
+  vm_phase_wireguard: 'Installing WireGuard',
+  vm_phase_fetching_logs: 'Fetching VM logs for diagnosis',
 };

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -93,4 +93,12 @@ export const ptBr: I18nStrings = {
 
   // VM setup
   vm_setup_timeout: 'A configuracao da VM esta demorando mais que o esperado. Continuar aguardando?',
+  vm_phase_system_update: 'Atualizando pacotes do sistema',
+  vm_phase_nodejs: 'Instalando Node.js 22',
+  vm_phase_postgresql: 'Instalando PostgreSQL 16',
+  vm_phase_pgvector: 'Compilando extensao pgvector',
+  vm_phase_db_setup: 'Criando banco de dados e schema',
+  vm_phase_ssh_hardening: 'Fortalecendo configuracao SSH',
+  vm_phase_wireguard: 'Instalando WireGuard',
+  vm_phase_fetching_logs: 'Buscando logs da VM para diagnostico',
 };

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -26,12 +26,86 @@ function isTimeoutError(err: unknown): boolean {
   return false;
 }
 
+// --------------------------------------------------------------------------
+// Constants
+// --------------------------------------------------------------------------
+
 const TOTAL_STEPS = 12;
 const VM_NAME = 'lox-vm';
 const DB_NAME = 'lox_brain';
 const DB_USER = 'lox';
-const SSH_TIMEOUT = 300_000; // 5 minutes — VM commands may install packages
-const VM_SETUP_TIMEOUT = 600_000; // 10 minutes — full setup compiles pgvector
+const SSH_TIMEOUT = 300_000; // 5 minutes — default for individual SSH calls
+
+// --------------------------------------------------------------------------
+// Setup phases — each gets its own SSH call and spinner
+// --------------------------------------------------------------------------
+
+interface SetupPhase {
+  /** i18n key for spinner text */
+  name: string;
+  /** Shell commands joined with && */
+  commands: string[];
+  /** Timeout in ms */
+  timeout: number;
+}
+
+const SETUP_PHASES: SetupPhase[] = [
+  {
+    name: 'vm_phase_system_update',
+    commands: [
+      'sudo apt-get update -qq',
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq',
+    ],
+    timeout: 300_000, // 5 min
+  },
+  {
+    name: 'vm_phase_nodejs',
+    commands: [
+      'curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -',
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs',
+    ],
+    timeout: 180_000, // 3 min
+  },
+  {
+    name: 'vm_phase_postgresql',
+    commands: [
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql-16 postgresql-server-dev-16',
+    ],
+    timeout: 180_000, // 3 min
+  },
+  {
+    name: 'vm_phase_pgvector',
+    commands: [
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential git',
+      'cd /tmp && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git',
+      'cd /tmp/pgvector && make && sudo make install',
+      'rm -rf /tmp/pgvector',
+    ],
+    timeout: 300_000, // 5 min — compiling from source
+  },
+  {
+    name: 'vm_phase_ssh_hardening',
+    commands: [
+      'sudo sed -i "s/#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config',
+      'sudo sed -i "s/PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config',
+      'sudo sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin no/" /etc/ssh/sshd_config',
+      'sudo sed -i "s/PermitRootLogin yes/PermitRootLogin no/" /etc/ssh/sshd_config',
+      'sudo systemctl restart sshd',
+    ],
+    timeout: 60_000, // 1 min
+  },
+  {
+    name: 'vm_phase_wireguard',
+    commands: [
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq wireguard',
+    ],
+    timeout: 120_000, // 2 min
+  },
+];
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
 
 /**
  * Execute a command on the VM via IAP tunnel SSH.
@@ -61,29 +135,30 @@ function generatePassword(length = 32): string {
 }
 
 /**
- * Build the VM setup script that installs Node.js 22, PostgreSQL 16 + pgvector,
- * creates the database, and hardens SSH.
+ * Attempt to fetch recent logs from the VM for timeout diagnosis.
+ * Returns null if logs cannot be retrieved (fails gracefully).
  */
-function buildSetupScript(dbPassword: string): string {
+async function fetchVmLogs(project: string, zone: string): Promise<string | null> {
+  try {
+    const output = await sshExec(
+      project,
+      zone,
+      'tail -20 /var/log/apt/term.log 2>/dev/null || journalctl -n 20 --no-pager 2>/dev/null || echo "No logs available"',
+      15_000,
+    );
+    return output.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the DB setup script: PostgreSQL config, database creation, and schema.
+ * Separated from other phases because it requires the generated password.
+ */
+function buildDbSetupScript(dbPassword: string): string {
   return [
     'set -euo pipefail',
-
-    // Update system
-    'sudo apt-get update -qq',
-    'sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq',
-
-    // Install Node.js 22 LTS
-    'curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -',
-    'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs',
-
-    // Install PostgreSQL 16
-    'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql-16 postgresql-server-dev-16',
-
-    // Install pgvector from source
-    'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential git',
-    'cd /tmp && git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git',
-    'cd /tmp/pgvector && make && sudo make install',
-    'rm -rf /tmp/pgvector',
 
     // Configure PostgreSQL: listen on localhost only (Zero Trust)
     "sudo sed -i \"s/#listen_addresses = 'localhost'/listen_addresses = 'localhost'/\" /etc/postgresql/16/main/postgresql.conf",
@@ -111,24 +186,19 @@ function buildSetupScript(dbPassword: string): string {
       CREATE INDEX IF NOT EXISTS idx_tags ON vault_embeddings USING gin (tags);
       CREATE INDEX IF NOT EXISTS idx_updated_at ON vault_embeddings (updated_at DESC);
     "`,
-
-    // Harden SSH: disable password auth, disable root login
-    'sudo sed -i "s/#PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config',
-    'sudo sed -i "s/PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config',
-    'sudo sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin no/" /etc/ssh/sshd_config',
-    'sudo sed -i "s/PermitRootLogin yes/PermitRootLogin no/" /etc/ssh/sshd_config',
-    'sudo systemctl restart sshd',
-
-    // Install WireGuard (needed for step 8)
-    'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq wireguard',
-
-    'echo "VM_SETUP_COMPLETE"',
   ].join(' && ');
 }
+
+// --------------------------------------------------------------------------
+// Main step
+// --------------------------------------------------------------------------
 
 /**
  * Step 7: SSH into VM via IAP and set up Node.js, PostgreSQL + pgvector,
  * create database, apply schema, store password in Secret Manager, harden SSH.
+ *
+ * Each phase runs as a separate SSH call with its own spinner, giving the user
+ * granular progress feedback instead of a single 5-10 minute wait.
  */
 export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
   const strings = t();
@@ -144,43 +214,100 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
   // Generate a secure DB password
   const dbPassword = generatePassword();
 
-  // Run the setup script on the VM, with timeout-retry loop
-  const script = buildSetupScript(dbPassword);
-  let timeout = VM_SETUP_TIMEOUT;
-  const MAX_TIMEOUT = 1_200_000; // 20 minutes
+  // --- Run each setup phase with its own spinner ---
+  for (const phase of SETUP_PHASES) {
+    const phaseLabel = strings[phase.name as keyof typeof strings] || phase.name;
+    let timeout = phase.timeout;
+    const maxTimeout = timeout * 2;
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    try {
-      await withSpinner(
-        `${strings.installing} Node.js 22, PostgreSQL 16, pgvector on VM...`,
-        async () => {
-          const output = await sshExec(project, zone, script, timeout);
-          if (!output.includes('VM_SETUP_COMPLETE')) {
-            throw new Error('VM setup script did not complete successfully');
+    // Per-phase retry loop (timeout only, one retry with doubled timeout)
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        await withSpinner(
+          `${phaseLabel}...`,
+          async () => {
+            const cmd = ['set -euo pipefail', ...phase.commands].join(' && ');
+            await sshExec(project, zone, cmd, timeout);
+          },
+        );
+        console.log(chalk.green(`  ✓ ${phaseLabel}`));
+        break; // phase succeeded
+      } catch (err) {
+        if (isTimeoutError(err) && timeout < maxTimeout) {
+          // Try to fetch logs for diagnosis
+          const logs = await fetchVmLogs(project, zone);
+          if (logs) {
+            console.log(chalk.dim(`\n  Last VM output:\n${logs}\n`));
           }
-        },
-      );
-      break; // success — exit loop
-    } catch (err) {
-      if (isTimeoutError(err) && timeout < MAX_TIMEOUT) {
-        const { confirm } = await import('@inquirer/prompts');
-        const shouldRetry = await confirm({
-          message: strings.vm_setup_timeout,
-          default: true,
-        });
-        if (shouldRetry) {
-          timeout = Math.min(timeout * 2, MAX_TIMEOUT);
-          continue;
+
+          const { confirm } = await import('@inquirer/prompts');
+          const shouldRetry = await confirm({
+            message: `${phaseLabel}: ${strings.vm_setup_timeout}`,
+            default: true,
+          });
+          if (shouldRetry) {
+            timeout = maxTimeout;
+            continue;
+          }
         }
+        // Non-timeout, user declined, or already at max — fail with phase context
+        if (isTimeoutError(err)) {
+          const msg = `${phaseLabel} timed out after ${timeout / 1000}s`;
+          return { success: false, message: msg };
+        }
+        const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+        return { success: false, message: `${phaseLabel} failed: ${msg}` };
       }
-      // Non-timeout error, user declined retry, or already at max timeout
-      const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
-      return { success: false, message: `VM setup failed: ${msg}` };
     }
   }
 
-  // Store DB password in Secret Manager
+  // --- DB setup phase (needs password) ---
+  {
+    const dbLabel = strings.vm_phase_db_setup || 'vm_phase_db_setup';
+    let timeout = 120_000;
+    const maxTimeout = 240_000;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        await withSpinner(
+          `${dbLabel}...`,
+          async () => {
+            const dbScript = buildDbSetupScript(dbPassword);
+            await sshExec(project, zone, dbScript, timeout);
+          },
+        );
+        console.log(chalk.green(`  ✓ ${dbLabel}`));
+        break;
+      } catch (err) {
+        if (isTimeoutError(err) && timeout < maxTimeout) {
+          const logs = await fetchVmLogs(project, zone);
+          if (logs) {
+            console.log(chalk.dim(`\n  Last VM output:\n${logs}\n`));
+          }
+
+          const { confirm } = await import('@inquirer/prompts');
+          const shouldRetry = await confirm({
+            message: `${dbLabel}: ${strings.vm_setup_timeout}`,
+            default: true,
+          });
+          if (shouldRetry) {
+            timeout = maxTimeout;
+            continue;
+          }
+        }
+        if (isTimeoutError(err)) {
+          const msg = `${dbLabel} timed out after ${timeout / 1000}s`;
+          return { success: false, message: msg };
+        }
+        const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+        return { success: false, message: `${dbLabel} failed: ${msg}` };
+      }
+    }
+  }
+
+  // --- Store DB password in Secret Manager ---
   try {
     await withSpinner(
       'Storing database password in Secret Manager...',

--- a/packages/installer/tests/steps/step-vm-setup.test.ts
+++ b/packages/installer/tests/steps/step-vm-setup.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { existsSync } from 'node:fs';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 // Track writeFileSync/unlinkSync calls
 const writeFileSyncMock = vi.fn();
@@ -35,15 +34,24 @@ vi.mock('chalk', () => ({
     yellow: (s: string) => s,
     green: (s: string) => s,
     cyan: (s: string) => s,
+    dim: (s: string) => s,
   },
 }));
 
-// Mock i18n
+// Mock i18n — include all phase keys
 vi.mock('../../src/i18n/index.js', () => ({
   t: () => ({
     step_postgresql: 'PostgreSQL Setup',
     installing: 'Installing',
     vm_setup_timeout: 'VM setup is taking longer than expected. Continue waiting?',
+    vm_phase_system_update: 'Updating system packages',
+    vm_phase_nodejs: 'Installing Node.js 22',
+    vm_phase_postgresql: 'Installing PostgreSQL 16',
+    vm_phase_pgvector: 'Compiling pgvector extension',
+    vm_phase_db_setup: 'Creating database and schema',
+    vm_phase_ssh_hardening: 'Hardening SSH configuration',
+    vm_phase_wireguard: 'Installing WireGuard',
+    vm_phase_fetching_logs: 'Fetching VM logs for diagnosis',
   }),
 }));
 
@@ -59,6 +67,9 @@ import type { InstallerContext } from '../../src/steps/types.js';
 
 const shellMock = shell as Mock;
 
+// Number of SSH phases: 6 (SETUP_PHASES) + 1 (DB setup) = 7
+const TOTAL_SSH_PHASES = 7;
+
 function makeCtx(overrides: Partial<InstallerContext> = {}): InstallerContext {
   return {
     config: { gcp: { zone: 'us-central1-a' } },
@@ -69,11 +80,34 @@ function makeCtx(overrides: Partial<InstallerContext> = {}): InstallerContext {
   } as InstallerContext;
 }
 
+/** Mock all SSH phase calls to succeed, plus Secret Manager calls. */
+function mockAllPhasesSuccess(): void {
+  // 7 SSH phase calls (6 SETUP_PHASES + 1 DB setup)
+  for (let i = 0; i < TOTAL_SSH_PHASES; i++) {
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  }
+  // Secret create
+  shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+  // Secret version add
+  shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+}
+
+/** Extract SSH calls (gcloud compute ssh) from shellMock history. */
+function getSshCalls(): unknown[][] {
+  return shellMock.mock.calls.filter(
+    (call: unknown[]) => {
+      if (call[0] !== 'gcloud') return false;
+      const args = call[1] as string[];
+      return args.includes('compute') && args.includes('ssh');
+    },
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('stepVmSetup — early exit', () => {
+describe('stepVmSetup -- early exit', () => {
   it('returns failure when project is not set', async () => {
     const ctx = makeCtx({ gcpProjectId: undefined });
     const result = await stepVmSetup(ctx);
@@ -89,35 +123,201 @@ describe('stepVmSetup — early exit', () => {
   });
 });
 
-describe('stepVmSetup — sshExec timeout', () => {
-  it('passes 600_000 timeout to shell for the VM setup script', async () => {
-    // SSH setup script — succeeds with marker
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
-    // Secret create
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-    // Secret version add
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+describe('stepVmSetup -- phased execution', () => {
+  it('executes each phase as a separate SSH call', async () => {
+    mockAllPhasesSuccess();
 
     const result = await stepVmSetup(makeCtx());
     expect(result.success).toBe(true);
 
-    // First shell call is the SSH setup — verify timeout
-    const sshCall = shellMock.mock.calls[0];
-    expect(sshCall[0]).toBe('gcloud');
-    const args = sshCall[1] as string[];
-    expect(args).toContain('--command');
-    expect(sshCall[2]).toMatchObject({ timeout: 600_000 });
+    const sshCalls = getSshCalls();
+    expect(sshCalls.length).toBe(TOTAL_SSH_PHASES);
+  });
+
+  it('uses phase-specific timeouts for each SSH call', async () => {
+    mockAllPhasesSuccess();
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(true);
+
+    const sshCalls = getSshCalls();
+
+    // Expected timeouts: system_update=300k, nodejs=180k, postgresql=180k,
+    // pgvector=300k, ssh_hardening=60k, wireguard=120k, db_setup=120k
+    const expectedTimeouts = [300_000, 180_000, 180_000, 300_000, 60_000, 120_000, 120_000];
+    for (let i = 0; i < TOTAL_SSH_PHASES; i++) {
+      const callOpts = sshCalls[i][2] as { timeout: number };
+      expect(callOpts.timeout).toBe(expectedTimeouts[i]);
+    }
+  });
+
+  it('stops at the first failing phase and reports which phase failed', async () => {
+    // Phase 1 (system update) succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Phase 2 (nodejs) succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Phase 3 (postgresql) fails
+    shellMock.mockRejectedValueOnce(new Error('apt-get failed: unable to locate package'));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Installing PostgreSQL 16');
+    expect(result.message).toContain('failed');
+    expect(result.message).toContain('apt-get failed');
+
+    // Only 3 SSH calls should have been made
+    const sshCalls = getSshCalls();
+    expect(sshCalls.length).toBe(3);
+  });
+
+  it('includes set -euo pipefail in each phase command', async () => {
+    mockAllPhasesSuccess();
+
+    await stepVmSetup(makeCtx());
+
+    const sshCalls = getSshCalls();
+    for (const call of sshCalls) {
+      const args = call[1] as string[];
+      const cmdIdx = args.indexOf('--command');
+      const cmd = args[cmdIdx + 1];
+      expect(cmd).toContain('set -euo pipefail');
+    }
   });
 });
 
-describe('stepVmSetup — Secret Manager uses temp file (no bash)', () => {
+describe('stepVmSetup -- DB setup phase', () => {
+  it('passes dbPassword in the DB setup SSH command', async () => {
+    mockAllPhasesSuccess();
+
+    await stepVmSetup(makeCtx());
+
+    const sshCalls = getSshCalls();
+    // DB setup is the last SSH call (index 6)
+    const dbCall = sshCalls[TOTAL_SSH_PHASES - 1];
+    const args = dbCall[1] as string[];
+    const cmdIdx = args.indexOf('--command');
+    const cmd = args[cmdIdx + 1];
+
+    // Must contain DB setup keywords
+    expect(cmd).toContain('CREATE USER lox');
+    expect(cmd).toContain('CREATE DATABASE lox_brain');
+    expect(cmd).toContain('CREATE EXTENSION IF NOT EXISTS vector');
+    expect(cmd).toContain('vault_embeddings');
+  });
+});
+
+describe('stepVmSetup -- per-phase timeout retry', () => {
+  it('prompts user on timeout, retries with doubled timeout, and succeeds', async () => {
+    // Phase 1 (system update) times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    // fetchVmLogs call — return some logs
+    shellMock.mockResolvedValueOnce({ stdout: 'some log output', stderr: '' });
+    // Retry phase 1 — succeeds
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    // Remaining 6 phases succeed
+    for (let i = 0; i < TOTAL_SSH_PHASES - 1; i++) {
+      shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    }
+    // Secret Manager
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    confirmMock.mockResolvedValueOnce(true);
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(true);
+    expect(confirmMock).toHaveBeenCalledOnce();
+
+    // The retry call should use doubled timeout (300_000 * 2 = 600_000)
+    const sshCalls = getSshCalls();
+    // Call index 2 is the retry of phase 1 (index 0 = fail, index 1 = fetchVmLogs, index 2 = retry)
+    const retryCall = sshCalls[2];
+    const retryOpts = retryCall[2] as { timeout: number };
+    expect(retryOpts.timeout).toBe(600_000);
+  });
+
+  it('returns timeout error with phase name when user declines retry', async () => {
+    // Phase 1 times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    // fetchVmLogs — fails
+    shellMock.mockRejectedValueOnce(new Error('cannot connect'));
+
+    confirmMock.mockResolvedValueOnce(false);
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Updating system packages');
+    expect(result.message).toContain('timed out');
+  });
+
+  it('fails immediately without prompt when already at max timeout', async () => {
+    // Phase 1 times out — user says yes
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // fetchVmLogs
+    confirmMock.mockResolvedValueOnce(true);
+
+    // Retry at doubled timeout — also times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('timed out');
+    // Only prompted once
+    expect(confirmMock).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT prompt on non-timeout errors', async () => {
+    shellMock.mockRejectedValueOnce(new Error('Connection refused'));
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Connection refused');
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('stepVmSetup -- fetchVmLogs on timeout', () => {
+  it('attempts to fetch VM logs when a phase times out', async () => {
+    // Phase 1 times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    // fetchVmLogs succeeds
+    shellMock.mockResolvedValueOnce({ stdout: 'apt log line 1\napt log line 2', stderr: '' });
+
+    confirmMock.mockResolvedValueOnce(false); // user declines retry
+
+    await stepVmSetup(makeCtx());
+
+    // Verify fetchVmLogs SSH call was made
+    const sshCalls = getSshCalls();
+    expect(sshCalls.length).toBe(2); // phase attempt + fetchVmLogs
+    const logCall = sshCalls[1];
+    const logArgs = logCall[1] as string[];
+    const cmdIdx = logArgs.indexOf('--command');
+    const logCmd = logArgs[cmdIdx + 1];
+    expect(logCmd).toContain('tail -20');
+    // fetchVmLogs uses 15_000 timeout
+    const logOpts = logCall[2] as { timeout: number };
+    expect(logOpts.timeout).toBe(15_000);
+  });
+
+  it('continues gracefully when fetchVmLogs fails', async () => {
+    // Phase 1 times out
+    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+    // fetchVmLogs also fails
+    shellMock.mockRejectedValueOnce(new Error('SSH connection lost'));
+
+    confirmMock.mockResolvedValueOnce(false);
+
+    const result = await stepVmSetup(makeCtx());
+    // Should still return a clean error, not crash
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('timed out');
+  });
+});
+
+describe('stepVmSetup -- Secret Manager uses temp file (no bash)', () => {
   it('writes password to temp file and uses --data-file flag', async () => {
-    // SSH setup script — succeeds
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
-    // Secret create
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-    // Secret version add
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    mockAllPhasesSuccess();
 
     const result = await stepVmSetup(makeCtx());
     expect(result.success).toBe(true);
@@ -136,7 +336,9 @@ describe('stepVmSetup — Secret Manager uses temp file (no bash)', () => {
     expect(unlinkSyncMock).toHaveBeenCalledWith(tmpPath);
 
     // The secret version add call should use --data-file, NOT bash
-    const secretAddCall = shellMock.mock.calls[2];
+    // Secret calls are the last 2 shell calls
+    const allCalls = shellMock.mock.calls;
+    const secretAddCall = allCalls[allCalls.length - 1];
     expect(secretAddCall[0]).toBe('gcloud');
     const secretArgs = secretAddCall[1] as string[];
     expect(secretArgs).toContain('secrets');
@@ -154,8 +356,10 @@ describe('stepVmSetup — Secret Manager uses temp file (no bash)', () => {
   });
 
   it('deletes temp file even when gcloud fails', async () => {
-    // SSH setup script — succeeds
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
+    // All SSH phases succeed
+    for (let i = 0; i < TOTAL_SSH_PHASES; i++) {
+      shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    }
     // Secret create — succeeds
     shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // Secret version add — fails
@@ -170,31 +374,24 @@ describe('stepVmSetup — Secret Manager uses temp file (no bash)', () => {
   });
 });
 
-describe('stepVmSetup — error handling', () => {
-  it('returns clean error on SSH setup failure', async () => {
+describe('stepVmSetup -- error handling', () => {
+  it('returns clean error on SSH phase failure (no stack trace)', async () => {
     shellMock.mockRejectedValueOnce(new Error('Connection refused\nstack trace line'));
 
     const result = await stepVmSetup(makeCtx());
     expect(result.success).toBe(false);
-    expect(result.message).toContain('VM setup failed');
+    expect(result.message).toContain('failed');
     expect(result.message).toContain('Connection refused');
     // No stack trace leakage
     expect(result.message).not.toContain('stack trace line');
   });
 
-  it('returns clean error when setup script does not emit marker', async () => {
-    shellMock.mockResolvedValueOnce({ stdout: 'some partial output', stderr: '' });
-
-    const result = await stepVmSetup(makeCtx());
-    expect(result.success).toBe(false);
-    expect(result.message).toContain('VM setup failed');
-    expect(result.message).toContain('did not complete successfully');
-  });
-
   it('returns clean error on secret storage failure', async () => {
-    // SSH setup — succeeds
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
-    // Secret create — fails with non-ignorable error path
+    // All SSH phases succeed
+    for (let i = 0; i < TOTAL_SSH_PHASES; i++) {
+      shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    }
+    // Secret create — succeeds
     shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // Secret version add — fails
     shellMock.mockRejectedValueOnce(new Error('PERMISSION_DENIED: caller lacks permission\ndetails'));
@@ -207,14 +404,9 @@ describe('stepVmSetup — error handling', () => {
   });
 });
 
-describe('stepVmSetup — full success path', () => {
+describe('stepVmSetup -- full success path', () => {
   it('sets database config on context after success', async () => {
-    // SSH setup — succeeds
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
-    // Secret create
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-    // Secret version add
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    mockAllPhasesSuccess();
 
     const ctx = makeCtx();
     const result = await stepVmSetup(ctx);
@@ -226,73 +418,5 @@ describe('stepVmSetup — full success path', () => {
       name: 'lox_brain',
       user: 'lox',
     });
-  });
-});
-
-describe('stepVmSetup — timeout retry', () => {
-  it('prompts user on timeout, retries with doubled timeout, and succeeds', async () => {
-    // First SSH call — times out
-    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
-    // Second SSH call — succeeds
-    shellMock.mockResolvedValueOnce({ stdout: 'VM_SETUP_COMPLETE', stderr: '' });
-    // Secret create
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-    // Secret version add
-    shellMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-
-    confirmMock.mockResolvedValueOnce(true);
-
-    const result = await stepVmSetup(makeCtx());
-
-    expect(result.success).toBe(true);
-    expect(confirmMock).toHaveBeenCalledOnce();
-    expect(confirmMock).toHaveBeenCalledWith(
-      expect.objectContaining({ default: true }),
-    );
-
-    // Second SSH shell call should use doubled timeout (1_200_000)
-    const secondSshCall = shellMock.mock.calls[1];
-    expect(secondSshCall[2]).toMatchObject({ timeout: 1_200_000 });
-  });
-
-  it('returns clean error when user declines to retry after timeout', async () => {
-    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
-    confirmMock.mockResolvedValueOnce(false);
-
-    const result = await stepVmSetup(makeCtx());
-
-    expect(result.success).toBe(false);
-    expect(result.message).toContain('VM setup failed');
-    expect(result.message).toContain('timed out');
-    expect(confirmMock).toHaveBeenCalledOnce();
-    // Shell should only have been called once (no retry)
-    expect(shellMock).toHaveBeenCalledOnce();
-  });
-
-  it('fails immediately without prompting when already at max timeout', async () => {
-    // First call at 600_000 — times out; user says yes → retries at 1_200_000
-    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
-    confirmMock.mockResolvedValueOnce(true); // first prompt: yes
-
-    // Second call at 1_200_000 (max) — also times out
-    shellMock.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
-
-    const result = await stepVmSetup(makeCtx());
-
-    expect(result.success).toBe(false);
-    expect(result.message).toContain('VM setup failed');
-    // Prompt appeared only once (at 600_000); at max timeout no further prompt
-    expect(confirmMock).toHaveBeenCalledOnce();
-    expect(shellMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('does NOT prompt on non-timeout errors', async () => {
-    shellMock.mockRejectedValueOnce(new Error('Connection refused'));
-
-    const result = await stepVmSetup(makeCtx());
-
-    expect(result.success).toBe(false);
-    expect(result.message).toContain('Connection refused');
-    expect(confirmMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Split monolithic VM setup SSH script into 7 individual phases with per-phase spinners:
  1. System update (5min timeout)
  2. Node.js 22 (3min)
  3. PostgreSQL 16 (3min)
  4. pgvector compile (5min)
  5. DB + schema setup (2min)
  6. SSH hardening (1min)
  7. WireGuard (2min)
- `fetchVmLogs()`: on timeout, fetches last 20 lines from VM for diagnosis
- Per-phase timeout retry with confirm prompt and doubled timeout
- `/issue` skill: added `/issue new <desc>` mode
- README: added Status and Disclaimer sections (data responsibility, no liability)
- Bumps version to 0.2.0

## Test plan
- [x] 206/206 tests passing (19 shared + 96 core + 91 installer)
- [x] 18 tests for phased VM setup (phases, timeouts, retry, logs, errors)
- [x] Type check clean
- [ ] Manual validation on Windows (Lara)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)