### PR TITLE
fix: SSH flag, auto-issue-report, dynamic version (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.2] — 2026-04-04
+
+### Fixed
+- `--ssh-flag="-o StrictHostKeyChecking=accept-new"` not recognized by gcloud (#31). Replaced with native `--strict-host-key-checking=accept_new` flag.
+- `LOX_VERSION` was hardcoded in installer `index.ts` — now imported from `@lox-brain/shared`.
+
+### Added
+- Auto-issue-reporting: when the installer fails, offers to create a GitHub issue via `gh` CLI with sanitized error details (redacts GCP project IDs, service accounts, Windows paths, billing IDs).
+- Centralized `handleStepFailure()` in index.ts — all 12 steps now use consistent error handling with auto-report.
+
 ## [0.2.1] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -100,6 +100,13 @@ export interface I18nStrings {
   vm_phase_wireguard: string;
   vm_phase_fetching_logs: string;
   vm_ssh_warmup: string;
+
+  // Error reporting
+  error_report_prompt: string;
+  error_report_creating: string;
+  error_report_created: string;
+  error_report_failed: string;
+  error_report_note: string;
 }
 
 export const en: I18nStrings = {
@@ -204,4 +211,11 @@ export const en: I18nStrings = {
   vm_phase_wireguard: 'Installing WireGuard',
   vm_phase_fetching_logs: 'Fetching VM logs for diagnosis',
   vm_ssh_warmup: 'Establishing SSH connection to VM',
+
+  // Error reporting
+  error_report_prompt: 'Would you like to report this issue on GitHub?',
+  error_report_creating: 'Creating issue report...',
+  error_report_created: 'Issue created:',
+  error_report_failed: 'Could not create issue report',
+  error_report_note: 'Personal data has been redacted from the report',
 };

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -102,4 +102,11 @@ export const ptBr: I18nStrings = {
   vm_phase_wireguard: 'Instalando WireGuard',
   vm_phase_fetching_logs: 'Buscando logs da VM para diagnostico',
   vm_ssh_warmup: 'Estabelecendo conexao SSH com a VM',
+
+  // Error reporting
+  error_report_prompt: 'Would you like to report this issue on GitHub?',
+  error_report_creating: 'Creating issue report...',
+  error_report_created: 'Issue created:',
+  error_report_failed: 'Could not create issue report',
+  error_report_note: 'Personal data has been redacted from the report',
 };

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -15,7 +15,21 @@ import { stepObsidian } from './steps/step-obsidian.js';
 import { stepDeploy } from './steps/step-deploy.js';
 import { stepMcp } from './steps/step-mcp.js';
 import { runPostInstall } from './steps/step-post-install.js';
+import { offerErrorReport } from './utils/error-report.js';
+import { LOX_VERSION } from '@lox-brain/shared';
 import type { InstallerContext } from './steps/types.js';
+
+async function handleStepFailure(stepName: string, message: string | undefined): Promise<never> {
+  console.error(`\n${message ?? 'Unknown error'}`);
+  await offerErrorReport({
+    stepName,
+    errorMessage: message ?? 'Unknown error',
+    loxVersion: LOX_VERSION,
+    os: `${process.platform} ${process.arch}`,
+    nodeVersion: process.version,
+  });
+  process.exit(1);
+}
 
 async function main(): Promise<void> {
   // Check for subcommands
@@ -40,87 +54,51 @@ async function main(): Promise<void> {
 
   // Step 1: Prerequisites
   const prereqResult = await stepPrerequisites(ctx);
-  if (!prereqResult.success) {
-    console.error(`\n${prereqResult.message}`);
-    process.exit(1);
-  }
+  if (!prereqResult.success) await handleStepFailure('Prerequisites', prereqResult.message);
 
   // Step 2: GCP Auth
   const authResult = await stepGcpAuth(ctx);
-  if (!authResult.success) {
-    console.error(`\n${authResult.message}`);
-    process.exit(1);
-  }
+  if (!authResult.success) await handleStepFailure('GCP Auth', authResult.message);
 
   // Step 3: GCP Project
   const projectResult = await stepGcpProject(ctx);
-  if (!projectResult.success) {
-    console.error(`\n${projectResult.message}`);
-    process.exit(1);
-  }
+  if (!projectResult.success) await handleStepFailure('GCP Project', projectResult.message);
 
   // Step 4: Billing
   const billingResult = await stepBilling(ctx);
-  if (!billingResult.success) {
-    console.error(`\n${billingResult.message}`);
-    process.exit(1);
-  }
+  if (!billingResult.success) await handleStepFailure('Billing', billingResult.message);
 
   // Step 5: VPC Network
   const networkResult = await stepNetwork(ctx);
-  if (!networkResult.success) {
-    console.error(`\n${networkResult.message}`);
-    process.exit(1);
-  }
+  if (!networkResult.success) await handleStepFailure('VPC Network', networkResult.message);
 
   // Step 6: VM Instance
   const vmResult = await stepVm(ctx);
-  if (!vmResult.success) {
-    console.error(`\n${vmResult.message}`);
-    process.exit(1);
-  }
+  if (!vmResult.success) await handleStepFailure('VM Instance', vmResult.message);
 
   // Step 7: VM Setup (Node.js, PostgreSQL, pgvector)
   const vmSetupResult = await stepVmSetup(ctx);
-  if (!vmSetupResult.success) {
-    console.error(`\n${vmSetupResult.message}`);
-    process.exit(1);
-  }
+  if (!vmSetupResult.success) await handleStepFailure('VM Setup', vmSetupResult.message);
 
   // Step 8: WireGuard VPN
   const vpnResult = await stepVpn(ctx);
-  if (!vpnResult.success) {
-    console.error(`\n${vpnResult.message}`);
-    process.exit(1);
-  }
+  if (!vpnResult.success) await handleStepFailure('WireGuard VPN', vpnResult.message);
 
   // Step 9: Vault Setup
   const vaultResult = await stepVault(ctx);
-  if (!vaultResult.success) {
-    console.error(`\n${vaultResult.message}`);
-    process.exit(1);
-  }
+  if (!vaultResult.success) await handleStepFailure('Vault Setup', vaultResult.message);
 
   // Step 10: Obsidian
   const obsidianResult = await stepObsidian(ctx);
-  if (!obsidianResult.success) {
-    console.error(`\n${obsidianResult.message}`);
-    process.exit(1);
-  }
+  if (!obsidianResult.success) await handleStepFailure('Obsidian', obsidianResult.message);
 
   // Step 11: Deploy Lox Core
   const deployResult = await stepDeploy(ctx);
-  if (!deployResult.success) {
-    console.error(`\n${deployResult.message}`);
-    process.exit(1);
-  }
+  if (!deployResult.success) await handleStepFailure('Deploy', deployResult.message);
 
   // Step 12: Claude Code MCP
   const mcpResult = await stepMcp(ctx);
-  if (!mcpResult.success) {
-    console.error(`\n${mcpResult.message}`);
-    process.exit(1);
-  }
+  if (!mcpResult.success) await handleStepFailure('MCP Server', mcpResult.message);
 
   // Post-install: Security audit + success screen
   await runPostInstall(ctx);

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -118,7 +118,7 @@ function baseSshArgs(project: string, zone: string): string[] {
     `--project=${project}`,
     '--tunnel-through-iap',
     '--quiet',
-    '--ssh-flag=-o StrictHostKeyChecking=accept-new',
+    '--strict-host-key-checking=accept_new',
   ];
 }
 

--- a/packages/installer/src/utils/error-report.ts
+++ b/packages/installer/src/utils/error-report.ts
@@ -1,0 +1,121 @@
+import { shell } from './shell.js';
+import { t } from '../i18n/index.js';
+
+export interface ErrorReportContext {
+  stepName: string;
+  errorMessage: string;
+  loxVersion: string;
+  os: string;
+  nodeVersion: string;
+}
+
+/**
+ * Sanitize private data from error messages before reporting.
+ *
+ * Redacts: GCP project IDs, service account emails, Windows user paths,
+ * billing account IDs, and GCP project numbers.
+ */
+export function sanitize(text: string): string {
+  let result = text;
+
+  // GCP project IDs: --project <id> or --project=<id>
+  result = result.replace(/--project[= ](\S+)/g, '--project <REDACTED>');
+
+  // Service account emails: *@*.iam.gserviceaccount.com
+  result = result.replace(
+    /[\w.+-]+@[\w.-]+\.iam\.gserviceaccount\.com/g,
+    '<REDACTED>@<REDACTED>.iam.gserviceaccount.com',
+  );
+
+  // Windows user paths: C:\Users\<name>\
+  result = result.replace(
+    /C:\\Users\\[^\\]+\\/gi,
+    'C:\\Users\\<REDACTED>\\',
+  );
+
+  // Billing account IDs: XXXXXX-YYYYYY-ZZZZZZ (6 alphanum groups separated by dashes)
+  result = result.replace(
+    /[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}/gi,
+    '<REDACTED>',
+  );
+
+  // GCP project numbers: 6-12 digit sequences after project/ or project'
+  result = result.replace(
+    /project[/']\d{6,12}/g,
+    (match) => match.replace(/\d{6,12}/, '<REDACTED>'),
+  );
+
+  return result;
+}
+
+function buildIssueBody(ctx: ErrorReportContext): string {
+  const sanitizedError = sanitize(ctx.errorMessage);
+
+  return `## Auto-reported installer failure
+
+**Step:** ${ctx.stepName}
+
+### Error
+\`\`\`
+${sanitizedError}
+\`\`\`
+
+### Environment
+- **OS:** ${ctx.os}
+- **Node.js:** ${ctx.nodeVersion}
+- **Lox version:** ${ctx.loxVersion}
+
+---
+*This issue was automatically created by the Lox installer. Personal data has been redacted.*`;
+}
+
+/**
+ * Offer the user to report a failed installer step as a GitHub issue.
+ *
+ * Best-effort: this function NEVER throws. If anything fails
+ * (missing `gh`, network error, user declines), it silently returns.
+ */
+export async function offerErrorReport(ctx: ErrorReportContext): Promise<void> {
+  try {
+    const strings = t();
+
+    // Dynamic import to avoid issues in test environments
+    const { confirm } = await import('@inquirer/prompts');
+
+    console.log(`\n${strings.error_report_note}`);
+
+    const shouldReport = await confirm({
+      message: strings.error_report_prompt,
+      default: false,
+    });
+
+    if (!shouldReport) return;
+
+    console.log(strings.error_report_creating);
+
+    const title = `[Auto-report] ${ctx.stepName} failed`;
+    const body = buildIssueBody(ctx);
+
+    const result = await shell('gh', [
+      'issue', 'create',
+      '--repo', 'isorensen/lox-brain',
+      '--title', title,
+      '--label', 'bug',
+      '--body', body,
+    ], { timeout: 30_000 });
+
+    // gh issue create prints the URL to stdout
+    const issueUrl = result.stdout.trim();
+    if (issueUrl) {
+      console.log(`${strings.error_report_created} ${issueUrl}`);
+    }
+  } catch {
+    // Best-effort: never throw
+    try {
+      const strings = t();
+      console.log(strings.error_report_failed);
+    } catch {
+      // Even i18n might fail — truly silent
+    }
+  }
+}

--- a/packages/installer/tests/steps/step-vm-setup.test.ts
+++ b/packages/installer/tests/steps/step-vm-setup.test.ts
@@ -194,7 +194,7 @@ describe('stepVmSetup -- SSH warm-up', () => {
     const cmd = firstCall[0] as string;
     expect(isWarmupCall(cmd)).toBe(true);
     expect(cmd).toContain('--quiet');
-    expect(cmd).toContain('StrictHostKeyChecking=accept-new');
+    expect(cmd).toContain('strict-host-key-checking=accept_new');
 
     // Warm-up uses stdio: 'inherit' for interactive prompts
     const opts = firstCall[1] as Record<string, unknown>;
@@ -264,7 +264,7 @@ describe('stepVmSetup -- phased execution via SCP', () => {
     for (const call of sshCalls) {
       const cmd = call[0] as string;
       expect(cmd).toContain('--quiet');
-      expect(cmd).toContain('StrictHostKeyChecking=accept-new');
+      expect(cmd).toContain('strict-host-key-checking=accept_new');
     }
   });
 

--- a/packages/installer/tests/utils/error-report.test.ts
+++ b/packages/installer/tests/utils/error-report.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sanitize, offerErrorReport, type ErrorReportContext } from '../../src/utils/error-report.js';
+
+describe('sanitize', () => {
+  it('redacts GCP project IDs with --project <id>', () => {
+    const input = 'gcloud compute instances list --project my-secret-project';
+    const result = sanitize(input);
+    expect(result).toBe('gcloud compute instances list --project <REDACTED>');
+    expect(result).not.toContain('my-secret-project');
+  });
+
+  it('redacts GCP project IDs with --project=<id>', () => {
+    const input = 'gcloud compute instances list --project=my-secret-project';
+    const result = sanitize(input);
+    expect(result).toBe('gcloud compute instances list --project <REDACTED>');
+    expect(result).not.toContain('my-secret-project');
+  });
+
+  it('redacts service account emails', () => {
+    const input = 'Permission denied for lox-sa@my-project.iam.gserviceaccount.com';
+    const result = sanitize(input);
+    expect(result).toBe('Permission denied for <REDACTED>@<REDACTED>.iam.gserviceaccount.com');
+    expect(result).not.toContain('lox-sa');
+    expect(result).not.toContain('my-project');
+  });
+
+  it('redacts Windows user paths', () => {
+    const input = 'Error reading C:\\Users\\Eduardo\\AppData\\Local\\lox\\config.json';
+    const result = sanitize(input);
+    expect(result).toBe('Error reading C:\\Users\\<REDACTED>\\AppData\\Local\\lox\\config.json');
+    expect(result).not.toContain('Eduardo');
+  });
+
+  it('redacts Windows user paths case-insensitively', () => {
+    const input = 'c:\\users\\Lara\\Documents\\vault';
+    const result = sanitize(input);
+    expect(result).toContain('<REDACTED>');
+    expect(result).not.toContain('Lara');
+  });
+
+  it('redacts billing account IDs', () => {
+    const input = 'Billing account AB12CD-EF34GH-IJ56KL not found';
+    const result = sanitize(input);
+    expect(result).toBe('Billing account <REDACTED> not found');
+    expect(result).not.toContain('AB12CD');
+  });
+
+  it('redacts GCP project numbers after project/', () => {
+    const input = 'projects/project/123456789012/zones/us-central1-a';
+    const result = sanitize(input);
+    expect(result).toContain('project/<REDACTED>');
+    expect(result).not.toContain('123456789012');
+  });
+
+  it('handles text with multiple sensitive values', () => {
+    const input = [
+      'Error in --project my-proj',
+      'sa@my-proj.iam.gserviceaccount.com',
+      'C:\\Users\\John\\path',
+      'billing AAAAAA-BBBBBB-CCCCCC',
+    ].join(' | ');
+
+    const result = sanitize(input);
+    expect(result).not.toContain('my-proj');
+    expect(result).not.toContain('John');
+    expect(result).not.toContain('AAAAAA');
+  });
+
+  it('returns unchanged text when nothing to redact', () => {
+    const input = 'Connection timeout after 30000ms';
+    expect(sanitize(input)).toBe(input);
+  });
+});
+
+describe('offerErrorReport', () => {
+  const baseCtx: ErrorReportContext = {
+    stepName: 'VM Setup',
+    errorMessage: 'SSH connection failed --project my-proj',
+    loxVersion: '0.2.2',
+    os: 'darwin arm64',
+    nodeVersion: 'v22.0.0',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when gh is not available', async () => {
+    // Mock confirm to say yes
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockResolvedValue(true),
+    }));
+
+    // shell will fail because gh is not available in test env — that's fine
+    // The function should catch and not throw
+    await expect(offerErrorReport(baseCtx)).resolves.toBeUndefined();
+  });
+
+  it('does not throw when user declines', async () => {
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockResolvedValue(false),
+    }));
+
+    await expect(offerErrorReport(baseCtx)).resolves.toBeUndefined();
+  });
+
+  it('does not throw on any unexpected error', async () => {
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockRejectedValue(new Error('stdin closed')),
+    }));
+
+    await expect(offerErrorReport(baseCtx)).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Fix `--ssh-flag="-o StrictHostKeyChecking=accept-new"` → gcloud native `--strict-host-key-checking=accept_new`
- Auto-issue-reporting: on installer failure, offer to create GitHub issue via `gh` CLI with sanitized error details
- `LOX_VERSION` imported from `@lox-brain/shared` instead of hardcoded in `index.ts`
- Centralized `handleStepFailure()` for all 12 steps
- Bumps version to 0.2.2

## Test plan
- [x] 223/223 tests passing (19 shared + 96 core + 108 installer)
- [x] 12 new tests for error-report sanitization and offerErrorReport
- [x] Type check clean
- [ ] Manual validation on Windows (Lara)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)