### PR TITLE
fix: auto-reindex ivfflat on MCP startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.3] — 2026-04-04
+
+### Fixed
+- Semantic search returning empty results after VM/PostgreSQL restart (#34). The ivfflat index becomes inconsistent on restart — now automatically reindexed on MCP server startup.
+
 ## [0.2.2] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -99,6 +99,19 @@ export class DbClient {
     await this.pool.query(sql, [filePath]);
   }
 
+  async reindexEmbeddings(): Promise<void> {
+    const result = await this.pool.query(`
+      SELECT indexname FROM pg_indexes
+      WHERE tablename = 'vault_embeddings'
+        AND indexdef LIKE '%ivfflat%'
+      LIMIT 1
+    `);
+    if (result.rows.length > 0) {
+      const indexName = result.rows[0].indexname;
+      await this.pool.query(`REINDEX INDEX ${indexName}`);
+    }
+  }
+
   async searchSemantic(
     embedding: number[],
     limitOrOptions: number | Partial<SearchOptions> = {},

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -69,6 +69,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main(): Promise<void> {
+  try {
+    await dbClient.reindexEmbeddings();
+    console.error('Reindexed ivfflat embedding index');
+  } catch (err) {
+    console.error('Warning: failed to reindex embedding index:', err instanceof Error ? err.message : err);
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('Lox Brain MCP Server running on stdio');

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -354,6 +354,33 @@ describe('DbClient', () => {
     });
   });
 
+  describe('reindexEmbeddings', () => {
+    it('should look up ivfflat index name and reindex it', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ indexname: 'idx_embedding' }] })
+        .mockResolvedValueOnce({ rowCount: 0 });
+
+      await client.reindexEmbeddings();
+
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+      expect(mockPool.query.mock.calls[0][0]).toContain('pg_indexes');
+      expect(mockPool.query.mock.calls[1][0]).toBe('REINDEX INDEX idx_embedding');
+    });
+
+    it('should skip reindex when no ivfflat index exists', async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await client.reindexEmbeddings();
+
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate pool.query rejection', async () => {
+      mockPool.query.mockRejectedValue(new Error('permission denied'));
+      await expect(client.reindexEmbeddings()).rejects.toThrow('permission denied');
+    });
+  });
+
   describe('searchText with SearchOptions', () => {
     it('should accept SearchOptions as third parameter', async () => {
       mockPool.query.mockResolvedValue({ rows: [] });

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/tests/utils/error-report.test.ts
+++ b/packages/installer/tests/utils/error-report.test.ts
@@ -76,7 +76,7 @@ describe('offerErrorReport', () => {
   const baseCtx: ErrorReportContext = {
     stepName: 'VM Setup',
     errorMessage: 'SSH connection failed --project my-proj',
-    loxVersion: '0.2.2',
+    loxVersion: '0.2.3',
     os: 'darwin arm64',
     nodeVersion: 'v22.0.0',
   };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- After VM/PostgreSQL restart, the ivfflat index becomes inconsistent, causing `search_semantic` to return empty results while other tools work fine
- MCP server now dynamically looks up the ivfflat index name via `pg_indexes` and runs `REINDEX` on startup
- Failure is logged as a warning without crashing the server

Closes #34

## Test plan
- [x] Unit tests for `reindexEmbeddings()` (lookup + reindex, skip when no index, error propagation)
- [x] Full test suite passing (108 tests)
- [x] Type check clean across all packages
- [x] Verified on live VM: `search_semantic` returns results after reindex

🤖 Generated with [Claude Code](https://claude.com/claude-code)