### PR TITLE
fix: SSH flag invalid value and auto-report truncation (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.4] — 2026-04-04
+
+### Fixed
+- `--strict-host-key-checking=accept_new` is not a valid gcloud value (#35). Changed to `--strict-host-key-checking=no` (valid choices: ask, no, yes).
+- Auto-report issue body truncated on Windows (#35). Multiline `--body` argument was mangled by `cmd.exe /c`. Now uses `--body-file` with a temp file for reliable cross-platform behavior.
+
 ## [0.2.3] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -118,7 +118,7 @@ function baseSshArgs(project: string, zone: string): string[] {
     `--project=${project}`,
     '--tunnel-through-iap',
     '--quiet',
-    '--strict-host-key-checking=accept_new',
+    '--strict-host-key-checking=no',
   ];
 }
 

--- a/packages/installer/src/utils/error-report.ts
+++ b/packages/installer/src/utils/error-report.ts
@@ -1,3 +1,7 @@
+import { randomBytes } from 'node:crypto';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { shell } from './shell.js';
 import { t } from '../i18n/index.js';
 
@@ -96,18 +100,28 @@ export async function offerErrorReport(ctx: ErrorReportContext): Promise<void> {
     const title = `[Auto-report] ${ctx.stepName} failed`;
     const body = buildIssueBody(ctx);
 
-    const result = await shell('gh', [
-      'issue', 'create',
-      '--repo', 'isorensen/lox-brain',
-      '--title', title,
-      '--label', 'bug',
-      '--body', body,
-    ], { timeout: 30_000 });
+    // Write body to a temp file to avoid multiline string truncation
+    // on Windows (cmd.exe /c + execFile drops content after first newline).
+    const tempFilePath = join(tmpdir(), `lox-error-report-${randomBytes(4).toString('hex')}.md`);
+    try {
+      writeFileSync(tempFilePath, body, 'utf-8');
 
-    // gh issue create prints the URL to stdout
-    const issueUrl = result.stdout.trim();
-    if (issueUrl) {
-      console.log(`${strings.error_report_created} ${issueUrl}`);
+      const result = await shell('gh', [
+        'issue', 'create',
+        '--repo', 'isorensen/lox-brain',
+        '--title', title,
+        '--label', 'bug',
+        '--body-file', tempFilePath,
+      ], { timeout: 30_000 });
+
+      // gh issue create prints the URL to stdout
+      const issueUrl = result.stdout.trim();
+      if (issueUrl) {
+        console.log(`${strings.error_report_created} ${issueUrl}`);
+      }
+    } finally {
+      // Best-effort cleanup of temp file
+      try { unlinkSync(tempFilePath); } catch { /* ignore */ }
     }
   } catch {
     // Best-effort: never throw

--- a/packages/installer/tests/steps/step-vm-setup.test.ts
+++ b/packages/installer/tests/steps/step-vm-setup.test.ts
@@ -194,7 +194,7 @@ describe('stepVmSetup -- SSH warm-up', () => {
     const cmd = firstCall[0] as string;
     expect(isWarmupCall(cmd)).toBe(true);
     expect(cmd).toContain('--quiet');
-    expect(cmd).toContain('strict-host-key-checking=accept_new');
+    expect(cmd).toContain('strict-host-key-checking=no');
 
     // Warm-up uses stdio: 'inherit' for interactive prompts
     const opts = firstCall[1] as Record<string, unknown>;
@@ -264,7 +264,7 @@ describe('stepVmSetup -- phased execution via SCP', () => {
     for (const call of sshCalls) {
       const cmd = call[0] as string;
       expect(cmd).toContain('--quiet');
-      expect(cmd).toContain('strict-host-key-checking=accept_new');
+      expect(cmd).toContain('strict-host-key-checking=no');
     }
   });
 

--- a/packages/installer/tests/utils/error-report.test.ts
+++ b/packages/installer/tests/utils/error-report.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { sanitize, offerErrorReport, type ErrorReportContext } from '../../src/utils/error-report.js';
 
 describe('sanitize', () => {
@@ -72,6 +74,11 @@ describe('sanitize', () => {
   });
 });
 
+// Mock shell at module level so we can inspect calls
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn().mockResolvedValue({ stdout: 'https://github.com/isorensen/lox-brain/issues/99', stderr: '' }),
+}));
+
 describe('offerErrorReport', () => {
   const baseCtx: ErrorReportContext = {
     stepName: 'VM Setup',
@@ -86,13 +93,14 @@ describe('offerErrorReport', () => {
   });
 
   it('does not throw when gh is not available', async () => {
-    // Mock confirm to say yes
     vi.mock('@inquirer/prompts', () => ({
       confirm: vi.fn().mockResolvedValue(true),
     }));
 
-    // shell will fail because gh is not available in test env — that's fine
-    // The function should catch and not throw
+    // Re-mock shell to simulate gh not found
+    const { shell } = await import('../../src/utils/shell.js');
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gh'));
+
     await expect(offerErrorReport(baseCtx)).resolves.toBeUndefined();
   });
 
@@ -110,5 +118,58 @@ describe('offerErrorReport', () => {
     }));
 
     await expect(offerErrorReport(baseCtx)).resolves.toBeUndefined();
+  });
+
+  it('uses --body-file instead of --body to avoid Windows truncation', async () => {
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockResolvedValue(true),
+    }));
+
+    const { shell } = await import('../../src/utils/shell.js');
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'https://github.com/isorensen/lox-brain/issues/42', stderr: '' });
+
+    await offerErrorReport(baseCtx);
+
+    expect(shell).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['--body-file', expect.stringMatching(/lox-error-report-[0-9a-f]{8}\.md/)]),
+      expect.anything(),
+    );
+    // Must NOT contain --body (without -file)
+    const callArgs = vi.mocked(shell).mock.calls[0]?.[1] ?? [];
+    expect(callArgs).not.toContain('--body');
+  });
+
+  it('cleans up the temp file after creating the report', async () => {
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockResolvedValue(true),
+    }));
+
+    const { shell } = await import('../../src/utils/shell.js');
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'https://github.com/isorensen/lox-brain/issues/50', stderr: '' });
+
+    await offerErrorReport(baseCtx);
+
+    // Extract the temp file path from the shell call args
+    const callArgs = vi.mocked(shell).mock.calls[0]?.[1] ?? [];
+    const bodyFileIdx = callArgs.indexOf('--body-file');
+    const tempFile = callArgs[bodyFileIdx + 1] as string;
+    expect(existsSync(tempFile)).toBe(false);
+  });
+
+  it('cleans up the temp file even when shell() fails', async () => {
+    vi.mock('@inquirer/prompts', () => ({
+      confirm: vi.fn().mockResolvedValue(true),
+    }));
+
+    const { shell } = await import('../../src/utils/shell.js');
+    vi.mocked(shell).mockRejectedValueOnce(new Error('network error'));
+
+    await offerErrorReport(baseCtx);
+
+    // Verify no temp files with our prefix remain in tmpdir
+    const { readdirSync } = await import('node:fs');
+    const remaining = readdirSync(tmpdir()).filter(f => f.startsWith('lox-error-report-'));
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `--strict-host-key-checking=accept_new` is not a valid gcloud value — changed to `no` (valid: ask, no, yes)
- Auto-report issue body was truncated on Windows because `cmd.exe /c` mangles multiline `--body` args — now uses `--body-file` with a temp file
- Temp file uses random suffix (`crypto.randomBytes`) to avoid concurrent collisions

## Test plan
- [x] 111 tests passing
- [x] Type check clean (`tsc --noEmit`)
- [x] Code review completed (reviewer: sonnet)
- [ ] Lara re-tests installer on Windows 11 to confirm both fixes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)