### PR TITLE
fix: SSH warmup quoting and stderr capture (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.5] — 2026-04-04
+
+### Fixed
+- SSH warmup `--command=echo ok` fails on Windows: gcloud parses the space as a separate argument (#38). Changed warmup to `--command=true` and added double-quote wrapping to all `--command` values in sshExec/sshExecScript.
+- Auto-report missing actual gcloud error (#38). SSH warmup now captures stderr via `stdio: ['inherit','inherit','pipe']` and the error handler extracts gcloud `ERROR:` lines instead of the generic Node.js wrapper message.
+
 ## [0.2.4] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -132,12 +132,13 @@ function baseSshArgs(project: string, zone: string): string[] {
  */
 function sshWarmup(project: string, zone: string): void {
   const args = baseSshArgs(project, zone);
-  args.push('--command=echo ok');
+  args.push('--command=true');
   // execSync is required here (not execFile) because stdio: 'inherit'
   // must pass through interactive SSH key generation prompts to the user.
+  // stdin/stdout inherited for interactive prompts; stderr piped to capture gcloud errors.
   execSync(`gcloud ${args.join(' ')}`, {
     timeout: SSH_TIMEOUT,
-    stdio: 'inherit',
+    stdio: ['inherit', 'inherit', 'pipe'],
   });
 }
 
@@ -159,7 +160,7 @@ async function sshExec(
   timeout?: number,
 ): Promise<string> {
   const args = baseSshArgs(project, zone);
-  args.push(`--command=${command}`);
+  args.push(`--command="${command}"`);
   // execSync is required here (not execFile) to avoid cmd.exe argument
   // parsing issues on Windows — see issue #31.
   const result = execSync(`gcloud ${args.join(' ')}`, {
@@ -197,13 +198,13 @@ async function sshExecScript(
     // Upload script to VM via SCP through IAP tunnel
     // execSync required for same Windows cmd.exe reasons as sshExec.
     execSync(
-      `gcloud compute scp ${localTmp} ${VM_NAME}:${remotePath} --zone=${zone} --project=${project} --tunnel-through-iap --quiet`,
+      `gcloud compute scp "${localTmp}" ${VM_NAME}:${remotePath} --zone=${zone} --project=${project} --tunnel-through-iap --quiet`,
       { timeout: 30_000, stdio: 'pipe' },
     );
 
     // Execute and clean up on the remote side
     const args = baseSshArgs(project, zone);
-    args.push(`--command=bash ${remotePath} && rm -f ${remotePath}`);
+    args.push(`--command="bash ${remotePath} && rm -f ${remotePath}"`);
     const result = execSync(`gcloud ${args.join(' ')}`, {
       timeout: timeout ?? SSH_TIMEOUT,
       stdio: 'pipe',
@@ -229,7 +230,9 @@ function generatePassword(length = 32): string {
  */
 async function fetchVmLogs(project: string, zone: string): Promise<string | null> {
   try {
-    const output = await sshExec(
+    // Uses sshExecScript (not sshExec) because the command contains
+    // double quotes and || chains that break cmd.exe parsing on Windows.
+    const output = await sshExecScript(
       project,
       zone,
       'tail -20 /var/log/apt/term.log 2>/dev/null || journalctl -n 20 --no-pager 2>/dev/null || echo "No logs available"',
@@ -307,7 +310,19 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
     sshWarmup(project, zone);
     console.log(chalk.green(`  ✓ ${warmupLabel}`));
   } catch (err) {
-    const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    let msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    // execSync errors include stderr as a Buffer when stdio is piped
+    if (err && typeof err === 'object' && 'stderr' in err) {
+      const stderr = Buffer.isBuffer((err as { stderr: unknown }).stderr)
+        ? ((err as { stderr: Buffer }).stderr).toString('utf-8').trim()
+        : String((err as { stderr: unknown }).stderr).trim();
+      if (stderr) {
+        const errorLines = stderr.split('\n').filter(l => l.startsWith('ERROR:'));
+        msg = errorLines.length > 0
+          ? errorLines.join(' ')
+          : (stderr.split('\n')[0] || msg);
+      }
+    }
     return { success: false, message: `SSH warm-up failed: ${msg}` };
   }
 

--- a/packages/installer/tests/steps/step-vm-setup.test.ts
+++ b/packages/installer/tests/steps/step-vm-setup.test.ts
@@ -97,7 +97,7 @@ function makeCtx(overrides: Partial<InstallerContext> = {}): InstallerContext {
 
 /** Check if an execSync call is the SSH warm-up. */
 function isWarmupCall(cmd: string): boolean {
-  return cmd.includes('compute ssh') && cmd.includes('--command=echo ok');
+  return cmd.includes('compute ssh') && cmd.includes('--command=true');
 }
 
 /** Check if an execSync call is an SCP upload. */
@@ -196,9 +196,9 @@ describe('stepVmSetup -- SSH warm-up', () => {
     expect(cmd).toContain('--quiet');
     expect(cmd).toContain('strict-host-key-checking=no');
 
-    // Warm-up uses stdio: 'inherit' for interactive prompts
+    // Warm-up uses inherited stdin/stdout + piped stderr for error capture
     const opts = firstCall[1] as Record<string, unknown>;
-    expect(opts.stdio).toBe('inherit');
+    expect(opts.stdio).toEqual(['inherit', 'inherit', 'pipe']);
   });
 
   it('returns failure when warm-up fails', async () => {
@@ -210,6 +210,43 @@ describe('stepVmSetup -- SSH warm-up', () => {
     expect(result.success).toBe(false);
     expect(result.message).toContain('SSH warm-up failed');
     expect(result.message).toContain('SSH key generation failed');
+  });
+
+  it('extracts gcloud stderr from warm-up error when available', async () => {
+    const err = Object.assign(new Error('Command failed'), {
+      stderr: Buffer.from('ERROR: (gcloud.compute.ssh) unrecognized arguments: ok\n'),
+    });
+    execSyncMock.mockImplementationOnce(() => { throw err; });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('SSH warm-up failed');
+    expect(result.message).toContain('ERROR: (gcloud.compute.ssh) unrecognized arguments: ok');
+    // Should NOT contain the generic Node wrapper
+    expect(result.message).not.toContain('Command failed');
+  });
+
+  it('falls back to err.message when stderr is empty', async () => {
+    const err = Object.assign(new Error('Connection reset by peer'), {
+      stderr: Buffer.from(''),
+    });
+    execSyncMock.mockImplementationOnce(() => { throw err; });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Connection reset by peer');
+  });
+
+  it('falls back to first stderr line when no ERROR: prefix', async () => {
+    const err = Object.assign(new Error('Command failed'), {
+      stderr: Buffer.from('WARNING: something went wrong\ndetail line'),
+    });
+    execSyncMock.mockImplementationOnce(() => { throw err; });
+
+    const result = await stepVmSetup(makeCtx());
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('WARNING: something went wrong');
+    expect(result.message).not.toContain('detail line');
   });
 });
 
@@ -305,6 +342,19 @@ describe('stepVmSetup -- phased execution via SCP', () => {
     expect(result.message).toContain('Installing PostgreSQL 16');
     expect(result.message).toContain('failed');
     expect(result.message).toContain('apt-get failed');
+  });
+
+  it('wraps --command value in double quotes for shell safety', async () => {
+    mockAllPhasesSuccess();
+
+    await stepVmSetup(makeCtx());
+
+    const sshCalls = getSshExecCalls();
+    for (const call of sshCalls) {
+      const cmd = call[0] as string;
+      // --command value must be wrapped in double quotes to prevent shell splitting
+      expect(cmd).toMatch(/--command="[^"]+"/);
+    }
   });
 
   it('includes set -euo pipefail in each phase script', async () => {
@@ -446,24 +496,22 @@ describe('stepVmSetup -- fetchVmLogs on timeout', () => {
     execSyncMock.mockImplementationOnce(() => {
       throw Object.assign(new Error('timed out'), { killed: true });
     });
-    // fetchVmLogs succeeds (uses sshExec, not sshExecScript — no SCP)
-    execSyncMock.mockReturnValueOnce('apt log line 1\napt log line 2');
+    // fetchVmLogs succeeds (uses sshExecScript: SCP upload + SSH exec)
+    execSyncMock.mockReturnValueOnce(undefined); // SCP upload
+    execSyncMock.mockReturnValueOnce('apt log line 1\napt log line 2'); // SSH exec
 
     confirmMock.mockResolvedValueOnce(false);
 
     await stepVmSetup(makeCtx());
 
-    // Verify fetchVmLogs SSH call was made
+    // Verify fetchVmLogs used sshExecScript (SCP + SSH exec)
+    // The last two execSync calls should be from fetchVmLogs:
+    //   [n-2] SCP upload of the log script
+    //   [n-1] SSH exec with 15_000 timeout
     const allCalls = execSyncMock.mock.calls;
-    const logCall = allCalls.find(
-      (call: unknown[]) => {
-        const cmd = call[0] as string;
-        return cmd.includes('tail -20');
-      },
-    );
-    expect(logCall).toBeDefined();
-    // fetchVmLogs uses 15_000 timeout
-    const logOpts = logCall![1] as { timeout: number };
+    const lastSshCall = allCalls[allCalls.length - 1];
+    expect(lastSshCall).toBeDefined();
+    const logOpts = lastSshCall![1] as { timeout: number };
     expect(logOpts.timeout).toBe(15_000);
   });
 
@@ -475,10 +523,11 @@ describe('stepVmSetup -- fetchVmLogs on timeout', () => {
     execSyncMock.mockImplementationOnce(() => {
       throw Object.assign(new Error('timed out'), { killed: true });
     });
-    // fetchVmLogs also fails
+    // fetchVmLogs also fails (SCP upload fails)
     execSyncMock.mockImplementationOnce(() => {
       throw new Error('SSH connection lost');
     });
+    // Note: SSH exec won't be called since SCP failed
 
     confirmMock.mockResolvedValueOnce(false);
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `--command=echo ok` split by shell on Windows — gcloud sees `ok` as separate arg. Changed to `--command=true`
- All `--command` values now double-quoted for shell safety
- `localTmp` path quoted in SCP for Windows paths with spaces
- Warmup now captures stderr via `stdio: ['inherit','inherit','pipe']` — actual gcloud errors reach auto-reports
- `fetchVmLogs` migrated from `sshExec` to `sshExecScript` to avoid cmd.exe breaking on internal double quotes

## Test plan
- [x] 115 tests passing
- [x] Type check clean
- [x] Code review completed + findings addressed
- [ ] Lara re-tests installer on Windows 11

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)