### PR TITLE
fix: cmd.exe && splitting in sshExecScript (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.2.6] — 2026-04-04
+
+### Fixed
+- `&&` in `--command` interpreted by cmd.exe as command separator on Windows (#40). Removed inline `rm -f` cleanup from `sshExecScript` — temp scripts in `/tmp` are cleaned on VM reboot.
+- Phase and DB setup error handlers now extract gcloud stderr via `extractExecError()` helper, so auto-reports include the actual error instead of generic "Command failed" wrapper.
+- Deduplicated stderr extraction logic into shared `extractExecError()` function (was copy-pasted in 3 catch blocks).
+
 ## [0.2.5] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -109,6 +109,27 @@ const SETUP_PHASES: SetupPhase[] = [
 // --------------------------------------------------------------------------
 
 /**
+ * Extract the meaningful error message from an execSync failure.
+ * Prefers gcloud ERROR: lines from stderr, falls back to first stderr line,
+ * then to the generic err.message.
+ */
+function extractExecError(err: unknown): string {
+  let msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
+  if (err && typeof err === 'object' && 'stderr' in err) {
+    const stderr = Buffer.isBuffer((err as { stderr: unknown }).stderr)
+      ? ((err as { stderr: Buffer }).stderr).toString('utf-8').trim()
+      : String((err as { stderr: unknown }).stderr).trim();
+    if (stderr) {
+      const errorLines = stderr.split('\n').filter(l => l.startsWith('ERROR:'));
+      msg = errorLines.length > 0
+        ? errorLines.join(' ')
+        : (stderr.split('\n')[0] || msg);
+    }
+  }
+  return msg;
+}
+
+/**
  * Base gcloud SSH args shared by all SSH helpers.
  */
 function baseSshArgs(project: string, zone: string): string[] {
@@ -202,9 +223,11 @@ async function sshExecScript(
       { timeout: 30_000, stdio: 'pipe' },
     );
 
-    // Execute and clean up on the remote side
+    // Execute on the remote side. No inline cleanup — && is interpreted
+    // as a command separator by cmd.exe on Windows even inside quotes.
+    // The temp script in /tmp is cleaned on next VM reboot.
     const args = baseSshArgs(project, zone);
-    args.push(`--command="bash ${remotePath} && rm -f ${remotePath}"`);
+    args.push(`--command="bash ${remotePath}"`);
     const result = execSync(`gcloud ${args.join(' ')}`, {
       timeout: timeout ?? SSH_TIMEOUT,
       stdio: 'pipe',
@@ -310,20 +333,7 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
     sshWarmup(project, zone);
     console.log(chalk.green(`  ✓ ${warmupLabel}`));
   } catch (err) {
-    let msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
-    // execSync errors include stderr as a Buffer when stdio is piped
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      const stderr = Buffer.isBuffer((err as { stderr: unknown }).stderr)
-        ? ((err as { stderr: Buffer }).stderr).toString('utf-8').trim()
-        : String((err as { stderr: unknown }).stderr).trim();
-      if (stderr) {
-        const errorLines = stderr.split('\n').filter(l => l.startsWith('ERROR:'));
-        msg = errorLines.length > 0
-          ? errorLines.join(' ')
-          : (stderr.split('\n')[0] || msg);
-      }
-    }
-    return { success: false, message: `SSH warm-up failed: ${msg}` };
+    return { success: false, message: `SSH warm-up failed: ${extractExecError(err)}` };
   }
 
   // Generate a secure DB password
@@ -371,8 +381,7 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
           const msg = `${phaseLabel} timed out after ${timeout / 1000}s`;
           return { success: false, message: msg };
         }
-        const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
-        return { success: false, message: `${phaseLabel} failed: ${msg}` };
+        return { success: false, message: `${phaseLabel} failed: ${extractExecError(err)}` };
       }
     }
   }
@@ -416,8 +425,7 @@ export async function stepVmSetup(ctx: InstallerContext): Promise<StepResult> {
           const msg = `${dbLabel} timed out after ${timeout / 1000}s`;
           return { success: false, message: msg };
         }
-        const msg = err instanceof Error ? err.message.split('\n')[0] : String(err);
-        return { success: false, message: `${dbLabel} failed: ${msg}` };
+        return { success: false, message: `${dbLabel} failed: ${extractExecError(err)}` };
       }
     }
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `&&` in `--command="bash file.sh && rm -f file.sh"` is interpreted by cmd.exe as a command separator, even inside double quotes — breaks all phase execution on Windows
- Removed inline `rm -f` cleanup from `--command` (temp scripts in `/tmp` clean on reboot)
- Extracted `extractExecError()` helper — deduplicates stderr extraction across 3 catch blocks
- All error handlers now capture gcloud stderr for auto-reports

## Test plan
- [x] 115 tests passing
- [x] Type check clean
- [ ] Lara re-tests installer on Windows 11

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)