### PR TITLE
feat: command string safety tests for cmd.exe (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.3.0] — 2026-04-04
+
+### Added
+- Command string safety tests for Windows cmd.exe compatibility (#43). Validates all `execSync` command strings for unquoted shell operators (`&&`, `||`, `|`, `>`, `<`, `^`), unquoted `--command` values with spaces, and operators inside `--command="..."`.
+- Exported pure builder functions (`buildWarmupCommand`, `buildSshExecCommand`, `buildScpCommand`, `buildSshExecScriptCommand`) for testable command construction.
+- `assertCmdExeSafe()` utility in `cmd-safety.ts` for reusable cmd.exe safety validation.
+- Regression guards that would have caught issues #38 and #40 before shipping.
+
 ## [0.2.6] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -143,6 +143,36 @@ function baseSshArgs(project: string, zone: string): string[] {
   ];
 }
 
+// --------------------------------------------------------------------------
+// Command builders — pure functions, exported for cross-platform safety tests
+// --------------------------------------------------------------------------
+
+/** Build the gcloud SSH warmup command string. */
+export function buildWarmupCommand(project: string, zone: string): string {
+  const args = baseSshArgs(project, zone);
+  args.push('--command=true');
+  return `gcloud ${args.join(' ')}`;
+}
+
+/** Build the gcloud SSH exec command string. */
+export function buildSshExecCommand(project: string, zone: string, command: string): string {
+  const args = baseSshArgs(project, zone);
+  args.push(`--command="${command}"`);
+  return `gcloud ${args.join(' ')}`;
+}
+
+/** Build the gcloud SCP upload command string. */
+export function buildScpCommand(project: string, zone: string, localPath: string, remotePath: string): string {
+  return `gcloud compute scp "${localPath}" ${VM_NAME}:${remotePath} --zone=${zone} --project=${project} --tunnel-through-iap --quiet`;
+}
+
+/** Build the gcloud SSH script execution command string. */
+export function buildSshExecScriptCommand(project: string, zone: string, remotePath: string): string {
+  const args = baseSshArgs(project, zone);
+  args.push(`--command="bash ${remotePath}"`);
+  return `gcloud ${args.join(' ')}`;
+}
+
 /**
  * Warm-up the SSH connection with stdio inherited so the user can
  * answer interactive prompts (SSH key passphrase, host key verification).
@@ -152,12 +182,10 @@ function baseSshArgs(project: string, zone: string): string[] {
  * string. project/zone originate from gcloud config, not user input.
  */
 function sshWarmup(project: string, zone: string): void {
-  const args = baseSshArgs(project, zone);
-  args.push('--command=true');
   // execSync is required here (not execFile) because stdio: 'inherit'
   // must pass through interactive SSH key generation prompts to the user.
   // stdin/stdout inherited for interactive prompts; stderr piped to capture gcloud errors.
-  execSync(`gcloud ${args.join(' ')}`, {
+  execSync(buildWarmupCommand(project, zone), {
     timeout: SSH_TIMEOUT,
     stdio: ['inherit', 'inherit', 'pipe'],
   });
@@ -180,11 +208,9 @@ async function sshExec(
   command: string,
   timeout?: number,
 ): Promise<string> {
-  const args = baseSshArgs(project, zone);
-  args.push(`--command="${command}"`);
   // execSync is required here (not execFile) to avoid cmd.exe argument
   // parsing issues on Windows — see issue #31.
-  const result = execSync(`gcloud ${args.join(' ')}`, {
+  const result = execSync(buildSshExecCommand(project, zone, command), {
     timeout: timeout ?? SSH_TIMEOUT,
     stdio: 'pipe',
     encoding: 'utf-8',
@@ -219,16 +245,14 @@ async function sshExecScript(
     // Upload script to VM via SCP through IAP tunnel
     // execSync required for same Windows cmd.exe reasons as sshExec.
     execSync(
-      `gcloud compute scp "${localTmp}" ${VM_NAME}:${remotePath} --zone=${zone} --project=${project} --tunnel-through-iap --quiet`,
+      buildScpCommand(project, zone, localTmp, remotePath),
       { timeout: 30_000, stdio: 'pipe' },
     );
 
     // Execute on the remote side. No inline cleanup — && is interpreted
     // as a command separator by cmd.exe on Windows even inside quotes.
     // The temp script in /tmp is cleaned on next VM reboot.
-    const args = baseSshArgs(project, zone);
-    args.push(`--command="bash ${remotePath}"`);
-    const result = execSync(`gcloud ${args.join(' ')}`, {
+    const result = execSync(buildSshExecScriptCommand(project, zone, remotePath), {
       timeout: timeout ?? SSH_TIMEOUT,
       stdio: 'pipe',
       encoding: 'utf-8',

--- a/packages/installer/src/utils/cmd-safety.ts
+++ b/packages/installer/src/utils/cmd-safety.ts
@@ -1,0 +1,71 @@
+/**
+ * cmd.exe safety utilities.
+ *
+ * On Windows, `execSync` uses `cmd.exe /c` which interprets shell operators
+ * (`&&`, `||`, `|`, `>`, `<`, `^`) as command separators even inside double
+ * quotes. These helpers validate that command strings built for gcloud SSH
+ * are safe for cross-platform execution.
+ *
+ * @see https://github.com/isorensen/lox-brain/issues/38
+ * @see https://github.com/isorensen/lox-brain/issues/40
+ */
+
+/**
+ * Regex matching cmd.exe operators that act as command separators.
+ * These must NEVER appear unprotected in a command string passed to execSync.
+ */
+export const CMD_EXE_OPERATORS = /(?:&&|\|\||[|><^])/;
+
+/**
+ * Validate that a command string is safe for cmd.exe execution.
+ *
+ * Rules:
+ * 1. `--command` values containing spaces or operators must be double-quoted
+ * 2. The value inside `--command="..."` must not contain cmd.exe operators
+ * 3. No cmd.exe operators may appear outside of `--command` values
+ *
+ * @throws {Error} If the command string contains unsafe patterns
+ */
+export function assertCmdExeSafe(cmd: string): void {
+  // Check for unquoted --command value with spaces or operators
+  const unquotedMatch = cmd.match(/(?:^|\s)--command=([^\s"]+)/);
+  const quotedMatch = cmd.match(/(?:^|\s)--command="([^"]*)"/);
+
+  if (unquotedMatch && !quotedMatch) {
+    const value = unquotedMatch[1];
+    if (value.includes(' ') || CMD_EXE_OPERATORS.test(value)) {
+      throw new Error(
+        `--command value must be double-quoted when it contains spaces or operators: --command=${value}`,
+      );
+    }
+    // Check if there are trailing tokens after the unquoted value that
+    // are not flags (i.e., look like they should be part of the command).
+    // e.g. --command=echo ok  =>  "ok" is a stray argument, not a flag.
+    const afterCommand = cmd.slice(cmd.indexOf(`--command=${value}`) + `--command=${value}`.length).trim();
+    if (afterCommand) {
+      const nextToken = afterCommand.split(/\s+/)[0];
+      if (nextToken && !nextToken.startsWith('--')) {
+        throw new Error(
+          `--command value appears to have unquoted arguments (space-separated): --command=${value} ${nextToken}`,
+        );
+      }
+    }
+  }
+
+  if (quotedMatch) {
+    const innerValue = quotedMatch[1];
+    if (CMD_EXE_OPERATORS.test(innerValue)) {
+      throw new Error(
+        `--command value contains cmd.exe operator that would be interpreted as command separator: "${innerValue}"`,
+      );
+    }
+  }
+
+  // Check rest of command (outside --command) for operators
+  const withoutCommand = cmd.replace(/--command="[^"]*"/g, '').replace(/--command=\S+/g, '');
+  if (CMD_EXE_OPERATORS.test(withoutCommand)) {
+    throw new Error(
+      `Command contains cmd.exe operator outside --command value: ${withoutCommand.match(CMD_EXE_OPERATORS)?.[0]}`,
+    );
+  }
+}

--- a/packages/installer/tests/steps/command-safety.test.ts
+++ b/packages/installer/tests/steps/command-safety.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildWarmupCommand,
+  buildSshExecCommand,
+  buildScpCommand,
+  buildSshExecScriptCommand,
+} from '../../src/steps/step-vm-setup.js';
+import { assertCmdExeSafe } from '../../src/utils/cmd-safety.js';
+
+const PROJECT = 'test-project';
+const ZONE = 'us-east1-b';
+
+describe('Command string safety for cmd.exe', () => {
+  describe('buildWarmupCommand', () => {
+    it('generates a cmd.exe-safe command', () => {
+      const cmd = buildWarmupCommand(PROJECT, ZONE);
+      assertCmdExeSafe(cmd);
+    });
+
+    it('uses --command=true (no spaces)', () => {
+      const cmd = buildWarmupCommand(PROJECT, ZONE);
+      expect(cmd).toContain('--command=true');
+    });
+
+    it('includes required gcloud SSH flags', () => {
+      const cmd = buildWarmupCommand(PROJECT, ZONE);
+      expect(cmd).toContain('gcloud compute ssh lox-vm');
+      expect(cmd).toContain(`--zone=${ZONE}`);
+      expect(cmd).toContain(`--project=${PROJECT}`);
+      expect(cmd).toContain('--tunnel-through-iap');
+      expect(cmd).toContain('--quiet');
+      expect(cmd).toContain('--strict-host-key-checking=no');
+    });
+  });
+
+  describe('buildSshExecCommand', () => {
+    it('generates a cmd.exe-safe command for simple commands', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'echo hello');
+      assertCmdExeSafe(cmd);
+    });
+
+    it('double-quotes the --command value', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'tail -n 10 /var/log/syslog');
+      expect(cmd).toMatch(/--command="tail -n 10 \/var\/log\/syslog"/);
+    });
+
+    it('rejects commands with && (should use sshExecScript instead)', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'cmd1 && cmd2');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('rejects commands with || (should use sshExecScript instead)', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'cmd1 || cmd2');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('rejects commands with pipe (should use sshExecScript instead)', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'ls | grep foo');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('rejects commands with output redirect', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'echo hello > /tmp/out');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('rejects commands with input redirect', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'cat < /tmp/in');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('accepts simple single commands with flags', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'systemctl status postgresql');
+      assertCmdExeSafe(cmd);
+    });
+  });
+
+  describe('buildScpCommand', () => {
+    it('generates a cmd.exe-safe command', () => {
+      const cmd = buildScpCommand(PROJECT, ZONE, '/tmp/script.sh', '/tmp/remote.sh');
+      assertCmdExeSafe(cmd);
+    });
+
+    it('quotes the local path for Windows paths with spaces', () => {
+      const cmd = buildScpCommand(PROJECT, ZONE, 'C:\\Users\\Name With Spaces\\file.sh', '/tmp/remote.sh');
+      expect(cmd).toContain('"C:\\Users\\Name With Spaces\\file.sh"');
+    });
+
+    it('includes required gcloud SCP flags', () => {
+      const cmd = buildScpCommand(PROJECT, ZONE, '/tmp/local.sh', '/tmp/remote.sh');
+      expect(cmd).toContain('gcloud compute scp');
+      expect(cmd).toContain(`--zone=${ZONE}`);
+      expect(cmd).toContain(`--project=${PROJECT}`);
+      expect(cmd).toContain('--tunnel-through-iap');
+      expect(cmd).toContain('--quiet');
+    });
+
+    it('formats remote path with VM name prefix', () => {
+      const cmd = buildScpCommand(PROJECT, ZONE, '/tmp/local.sh', '/tmp/remote.sh');
+      expect(cmd).toContain('lox-vm:/tmp/remote.sh');
+    });
+  });
+
+  describe('buildSshExecScriptCommand', () => {
+    it('generates a cmd.exe-safe command', () => {
+      const cmd = buildSshExecScriptCommand(PROJECT, ZONE, '/tmp/lox-setup-abc123.sh');
+      assertCmdExeSafe(cmd);
+    });
+
+    it('does not include && (cleanup removed per #40)', () => {
+      const cmd = buildSshExecScriptCommand(PROJECT, ZONE, '/tmp/script.sh');
+      expect(cmd).not.toContain('&&');
+      expect(cmd).not.toContain('rm -f');
+    });
+
+    it('double-quotes the --command value', () => {
+      const cmd = buildSshExecScriptCommand(PROJECT, ZONE, '/tmp/script.sh');
+      expect(cmd).toMatch(/--command="bash \/tmp\/script\.sh"/);
+    });
+
+    it('includes required gcloud SSH flags', () => {
+      const cmd = buildSshExecScriptCommand(PROJECT, ZONE, '/tmp/script.sh');
+      expect(cmd).toContain('gcloud compute ssh lox-vm');
+      expect(cmd).toContain('--tunnel-through-iap');
+      expect(cmd).toContain('--quiet');
+    });
+  });
+
+  describe('regression guards', () => {
+    it('would have caught #38: unquoted space in --command=echo ok', () => {
+      // Simulating the old bug: --command=echo ok (space, no quotes)
+      const badCmd = 'gcloud compute ssh vm --command=echo ok';
+      expect(() => assertCmdExeSafe(badCmd)).toThrow();
+    });
+
+    it('would have caught #40: && inside --command', () => {
+      // Simulating the old bug: --command="bash file.sh && rm -f file.sh"
+      const badCmd = 'gcloud compute ssh vm --command="bash /tmp/file.sh && rm -f /tmp/file.sh"';
+      expect(() => assertCmdExeSafe(badCmd)).toThrow('cmd.exe operator');
+    });
+
+    it('would have caught pipe inside --command', () => {
+      const badCmd = 'gcloud compute ssh vm --command="cat /etc/passwd | grep root"';
+      expect(() => assertCmdExeSafe(badCmd)).toThrow('cmd.exe operator');
+    });
+  });
+
+  describe('assertCmdExeSafe edge cases', () => {
+    it('accepts commands with no --command flag', () => {
+      const cmd = 'gcloud compute ssh vm --zone=us-east1-b --project=test';
+      assertCmdExeSafe(cmd);
+    });
+
+    it('accepts --command=true (no quotes needed for single word)', () => {
+      const cmd = 'gcloud compute ssh vm --command=true';
+      assertCmdExeSafe(cmd);
+    });
+
+    it('rejects caret escape character (cmd.exe special)', () => {
+      const cmd = buildSshExecCommand(PROJECT, ZONE, 'echo ^hello');
+      expect(() => assertCmdExeSafe(cmd)).toThrow('cmd.exe operator');
+    });
+
+    it('accepts --command="" (empty quoted value)', () => {
+      const cmd = 'gcloud compute ssh vm --command=""';
+      assertCmdExeSafe(cmd);
+    });
+
+    it('rejects backslash-quote that could escape the quoted boundary', () => {
+      // On cmd.exe, backslash-quote handling may allow operators to leak
+      const badCmd = 'gcloud compute ssh vm --command="echo \\"hello && rm -rf /"';
+      expect(() => assertCmdExeSafe(badCmd)).toThrow();
+    });
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Extracted 4 pure builder functions from `step-vm-setup.ts` for testable command construction
- Added `assertCmdExeSafe()` validator that detects unsafe shell operators (`&&`, `||`, `|`, `>`, `<`, `^`) in `execSync` command strings
- 27 safety tests including regression guards that would have caught #38 and #40 before shipping
- Standardized builder parameter order to `(project, zone, ...args)`

## Test plan
- [x] 142 tests passing (27 new command safety tests)
- [x] Type check clean
- [x] Code review completed + findings addressed
- [x] Regression guards verified: `--command=echo ok` and `--command="... && ..."` both rejected

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)