### PR TITLE
fix: SSH service name sshd → ssh for Debian (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.3.1] — 2026-04-04
+
+### Fixed
+- SSH hardening phase fails with `Unit sshd.service not found` (#44). On Debian/Ubuntu the service is `ssh`, not `sshd`. Changed `systemctl restart sshd` → `systemctl restart ssh`.
+
 ## [0.3.0] — 2026-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -91,7 +91,7 @@ const SETUP_PHASES: SetupPhase[] = [
       'sudo sed -i "s/PasswordAuthentication yes/PasswordAuthentication no/" /etc/ssh/sshd_config',
       'sudo sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin no/" /etc/ssh/sshd_config',
       'sudo sed -i "s/PermitRootLogin yes/PermitRootLogin no/" /etc/ssh/sshd_config',
-      'sudo systemctl restart sshd',
+      'sudo systemctl restart ssh',
     ],
     timeout: 60_000, // 1 min
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- SSH hardening phase calls `systemctl restart sshd` but Debian/Ubuntu uses `ssh.service`
- One-line fix: `sshd` → `ssh`

## Test plan
- [x] 142 tests passing
- [x] Type check clean
- [ ] Lara re-tests installer on Windows — this time it should pass SSH hardening

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)