### PR TITLE
fix: skip branch protection when GitHub Pro is required (closes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.3.5] — 2026-04-04
+
+### Fixed
+- Installer no longer crashes when branch protection setup is blocked by GitHub Pro requirement on private repos. Emits a warning and continues installation (#55)
+
 ## [0.3.4] — 2026-04-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -7,6 +7,23 @@ import type { InstallerContext, StepResult } from './types.js';
 
 const TOTAL_STEPS = 12;
 
+/**
+ * Detect the GitHub Free plan "upgrade to Pro" gate when setting branch
+ * protection on a private repository. The error text may appear in either
+ * err.message or err.stderr depending on how the child process surfaces it.
+ */
+export function isProPlanGate(err: unknown): boolean {
+  const parts: string[] = [];
+  if (err instanceof Error) parts.push(err.message);
+  if (err && typeof err === 'object' && 'stderr' in err) {
+    const stderr = (err as { stderr: unknown }).stderr;
+    if (typeof stderr === 'string') parts.push(stderr);
+  }
+  // Check each surface independently — both signals must appear in the SAME string
+  // to avoid false positives from unrelated mentions across message and stderr.
+  return parts.some(p => p.includes('HTTP 403') && p.includes('Upgrade to GitHub Pro'));
+}
+
 const GITIGNORE_CONTENT = `# Security — NEVER commit secrets
 .env
 .env.*
@@ -141,22 +158,32 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
     default: '',
   });
 
-  // 6. Set up branch protection
-  await withSpinner(
-    'Setting up branch protection...',
-    async () => {
-      await shell('gh', [
-        'api',
-        `repos/${fullRepo}/branches/main/protection`,
-        '-X', 'PUT',
-        '-H', 'Accept: application/vnd.github+json',
-        '-f', 'required_status_checks=null',
-        '-f', 'enforce_admins=true',
-        '-f', 'required_pull_request_reviews=null',
-        '-f', 'restrictions=null',
-      ]);
-    },
-  );
+  // 6. Set up branch protection (graceful degradation for GitHub Free + private repos)
+  try {
+    await withSpinner(
+      'Setting up branch protection...',
+      async () => {
+        await shell('gh', [
+          'api',
+          `repos/${fullRepo}/branches/main/protection`,
+          '-X', 'PUT',
+          '-H', 'Accept: application/vnd.github+json',
+          '-f', 'required_status_checks=null',
+          '-f', 'enforce_admins=true',
+          '-f', 'required_pull_request_reviews=null',
+          '-f', 'restrictions=null',
+        ]);
+      },
+    );
+  } catch (err) {
+    if (isProPlanGate(err)) {
+      console.log(chalk.yellow(
+        '  ⚠ Branch protection skipped — requires GitHub Pro for private repos. Installation will continue.',
+      ));
+    } else {
+      throw err;
+    }
+  }
 
   // 7. Configure git sync cron on VM (via SSH IAP)
   const projectId = ctx.gcpProjectId ?? 'lox-project';

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { isProPlanGate } from '../../src/steps/step-vault.js';
+
+describe('isProPlanGate', () => {
+  it('detects the Pro upgrade 403 from err.message', () => {
+    const err = new Error(
+      'Command failed: gh api repos/owner/repo/branches/main/protection -X PUT\n' +
+      'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)',
+    );
+    expect(isProPlanGate(err)).toBe(true);
+  });
+
+  it('detects the Pro upgrade 403 from err.stderr', () => {
+    const err = Object.assign(new Error('Command failed'), {
+      stderr: 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)',
+    });
+    expect(isProPlanGate(err)).toBe(true);
+  });
+
+  it('requires both HTTP 403 and the upgrade message', () => {
+    expect(isProPlanGate(new Error('HTTP 403 some other 403 error'))).toBe(false);
+    expect(isProPlanGate(new Error('Upgrade to GitHub Pro (HTTP 402)'))).toBe(false);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isProPlanGate(new Error('HTTP 404 Not Found'))).toBe(false);
+    expect(isProPlanGate(new Error('Network error: ECONNREFUSED'))).toBe(false);
+    expect(isProPlanGate(new Error(''))).toBe(false);
+  });
+
+  it('returns false for other 403 errors (e.g. missing token scopes)', () => {
+    expect(isProPlanGate(new Error('HTTP 403 Resource not accessible by personal access token'))).toBe(false);
+    expect(isProPlanGate(new Error('HTTP 403 Forbidden'))).toBe(false);
+  });
+
+  it('rejects when signals are split across message and stderr (no false positive)', () => {
+    // HTTP 403 in message, Pro message in stderr — should NOT match because
+    // neither surface contains both signals.
+    const err = Object.assign(new Error('HTTP 403 Forbidden'), {
+      stderr: 'Upgrade to GitHub Pro to access this feature',
+    });
+    expect(isProPlanGate(err)).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isProPlanGate(null)).toBe(false);
+    expect(isProPlanGate(undefined)).toBe(false);
+    expect(isProPlanGate('some string')).toBe(false);
+    expect(isProPlanGate({})).toBe(false);
+  });
+
+  it('handles objects with non-string stderr gracefully', () => {
+    const err = Object.assign(new Error('Command failed'), { stderr: Buffer.from('HTTP 403') });
+    // Buffer stderr is not a string — helper only checks typeof string
+    expect(isProPlanGate(err)).toBe(false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Closes #55. Installer crashed fatally during vault setup when the GitHub API refused to enable branch protection on private repos under a GitHub Free account (HTTP 403, "Upgrade to GitHub Pro").

For single-user private vaults, branch protection is a nice-to-have — not a hard requirement. This fix:
- Detects the specific Pro-gate 403 via a pure helper \`isProPlanGate(err)\`
- Warns the user and continues installation
- Still fails on other 403 errors (e.g. missing token scopes)

## Test plan

- [x] 8 new tests for \`isProPlanGate\` covering true positives, negatives, split-signal edge case, and non-string stderr
- [x] 166 total tests passing
- [x] TypeScript clean across shared/core/installer
- [ ] Manual verification: Lara re-runs installer on Windows with her private vault + Free account — step 9 should show warning and continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)