### PR TITLE
fix: reliable git sync cron setup on Windows (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.3.8] — 2026-04-04
+
+### Fixed
+- Git sync cron setup on VM no longer fails on Windows. The installer now uploads a setup script via `gcloud compute scp` and executes it with a plain `bash <path>`, avoiding `gcloud --command` arguments with `|`, `(`, `;` that Windows cmd.exe interpreted as its own shell metacharacters (#61)
+
 ## [0.3.7] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -98,6 +98,44 @@ export function isRepoNotFoundError(err: unknown): boolean {
 }
 
 /**
+ * Build the bash script that configures git sync on the VM. The script:
+ *   1. Writes ~/sync-vault.sh with the periodic git pull/commit/push logic.
+ *   2. Installs a crontab entry running every 2 minutes (idempotent — removes
+ *      any matching prior line before adding, so re-runs don't duplicate).
+ *   3. Removes itself after running.
+ *
+ * It is uploaded to the VM as a file and executed with a plain
+ * `bash ~/lox-setup-sync.sh` — this avoids passing shell metacharacters
+ * through `gcloud ... --command`, which fails on Windows cmd.exe (see #61).
+ */
+export function buildVmSetupScript(): string {
+  // cronLine must not contain single quotes — embedded in a single-quoted bash assignment below.
+  const cronLine = '*/2 * * * * ~/sync-vault.sh >> ~/sync-vault.log 2>&1';
+  return [
+    '#!/bin/bash',
+    'set -euo pipefail',
+    '',
+    "cat > ~/sync-vault.sh <<'LOX_SYNC_EOF'",
+    '#!/bin/bash',
+    'set -euo pipefail',
+    'cd ~/lox-vault',
+    'git fetch origin main',
+    'git merge --ff-only origin/main || true',
+    'git add -A',
+    'git diff --cached --quiet || git commit -m "auto-sync $(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+    'git push origin main',
+    'LOX_SYNC_EOF',
+    'chmod +x ~/sync-vault.sh',
+    '',
+    `CRON_LINE='${cronLine}'`,
+    '(crontab -l 2>/dev/null | grep -v -F "$CRON_LINE" || true; echo "$CRON_LINE") | crontab -',
+    '',
+    'rm -- "$0"',
+    '',
+  ].join('\n');
+}
+
+/**
  * Check whether a GitHub repo exists and is accessible to the current user.
  * Returns false only for "not found" errors; rethrows other failures (auth,
  * network, missing `gh`) so they surface with the real cause.
@@ -124,7 +162,8 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
 
   // 1. Ask vault preset
   const { select, input, confirm } = await import('@inquirer/prompts');
-  const { existsSync: fsExistsSync, rmSync } = await import('node:fs');
+  const { existsSync: fsExistsSync, rmSync, writeFileSync, mkdirSync } = await import('node:fs');
+  const { join } = await import('node:path');
   const preset = await select({
     message: strings.step_vault_preset,
     choices: [
@@ -234,8 +273,6 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   );
 
   // 4. Create .gitignore with security patterns
-  const { writeFileSync } = await import('node:fs');
-  const { join } = await import('node:path');
   writeFileSync(join(vaultDir, '.gitignore'), GITIGNORE_CONTENT);
   console.log(chalk.green('  ✓ .gitignore created with security patterns'));
 
@@ -294,41 +331,45 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   await withSpinner(
     'Configuring git sync cron on VM...',
     async () => {
-      const syncScript = [
-        '#!/bin/bash',
-        'set -euo pipefail',
-        'cd ~/lox-vault',
-        'git fetch origin main',
-        'git merge --ff-only origin/main || true',
-        'git add -A',
-        'git diff --cached --quiet || git commit -m "auto-sync $(date -u +%Y-%m-%dT%H:%M:%SZ)"',
-        'git push origin main',
-      ].join('\n');
+      // Write the full setup (create sync-vault.sh + install cron) into a
+      // local temp file, then SCP it to the VM and execute with a plain
+      // `bash <path>` command. This avoids passing `|`, `(`, `;`, `&&` etc.
+      // through gcloud's --command, which cmd.exe on Windows interprets as
+      // its own shell metacharacters and fragments the command (#61).
+      const { tmpdir } = await import('node:os');
+      const setupScript = buildVmSetupScript();
+      const localScriptPath = join(tmpdir(), `lox-setup-sync-${Date.now()}.sh`);
+      writeFileSync(localScriptPath, setupScript);
 
-      // Create sync script on VM
-      await shell('gcloud', [
-        'compute', 'ssh', vmName,
-        '--project', projectId,
-        '--zone', zone,
-        '--tunnel-through-iap',
-        '--command', `echo '${syncScript}' > ~/sync-vault.sh && chmod +x ~/sync-vault.sh`,
-      ]);
+      try {
+        // Upload the setup script to the VM via IAP-tunneled SCP
+        await shell('gcloud', [
+          'compute', 'scp',
+          '--project', projectId,
+          '--zone', zone,
+          '--tunnel-through-iap',
+          localScriptPath,
+          `${vmName}:~/lox-setup-sync.sh`,
+        ], { timeout: 120_000 });
 
-      // Add crontab entry (every 2 minutes)
-      await shell('gcloud', [
-        'compute', 'ssh', vmName,
-        '--project', projectId,
-        '--zone', zone,
-        '--tunnel-through-iap',
-        '--command', '(crontab -l 2>/dev/null; echo "*/2 * * * * ~/sync-vault.sh >> ~/sync-vault.log 2>&1") | sort -u | crontab -',
-      ]);
+        // Execute the script on the VM — the --command value has no shell
+        // metacharacters, so cmd.exe/bash quoting behaves identically.
+        await shell('gcloud', [
+          'compute', 'ssh', vmName,
+          '--project', projectId,
+          '--zone', zone,
+          '--tunnel-through-iap',
+          '--command', 'bash ~/lox-setup-sync.sh',
+        ], { timeout: 120_000 });
+      } finally {
+        try { rmSync(localScriptPath, { force: true }); } catch { /* best-effort cleanup */ }
+      }
     },
   );
 
   // 8. Install gitleaks pre-commit hook
-  const { existsSync, mkdirSync } = await import('node:fs');
   const hooksDir = join(vaultDir, '.git', 'hooks');
-  if (!existsSync(hooksDir)) {
+  if (!fsExistsSync(hooksDir)) {
     mkdirSync(hooksDir, { recursive: true });
   }
   const hookPath = join(hooksDir, 'pre-commit');

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists } from '../../src/steps/step-vault.js';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -139,5 +139,45 @@ describe('repoExists', () => {
   it('rethrows "Command not found" errors', async () => {
     vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gh'));
     await expect(repoExists('x/y')).rejects.toThrow('Command not found: gh');
+  });
+});
+
+describe('buildVmSetupScript', () => {
+  const script = buildVmSetupScript();
+
+  it('starts with a bash shebang and strict mode', () => {
+    expect(script.startsWith('#!/bin/bash\n')).toBe(true);
+    expect(script).toContain('set -euo pipefail');
+  });
+
+  it('writes ~/sync-vault.sh via heredoc and chmods it', () => {
+    expect(script).toContain("cat > ~/sync-vault.sh <<'LOX_SYNC_EOF'");
+    expect(script).toContain('LOX_SYNC_EOF');
+    expect(script).toContain('chmod +x ~/sync-vault.sh');
+  });
+
+  it('embeds the git sync commands in the heredoc body', () => {
+    expect(script).toContain('cd ~/lox-vault');
+    expect(script).toContain('git fetch origin main');
+    expect(script).toContain('git merge --ff-only origin/main || true');
+    expect(script).toContain('git push origin main');
+  });
+
+  it('installs a 2-minute cron entry for sync-vault.sh', () => {
+    expect(script).toContain('*/2 * * * * ~/sync-vault.sh >> ~/sync-vault.log 2>&1');
+    // Dedup: remove matching line first, then re-add — prevents duplicates on re-run
+    expect(script).toContain('crontab -l 2>/dev/null');
+    expect(script).toContain('crontab -');
+  });
+
+  it('removes itself after running (self-cleanup)', () => {
+    expect(script).toContain('rm -- "$0"');
+  });
+
+  it('ends with a trailing newline', () => {
+    // The script is written to a file and executed via `bash <path>`. A
+    // trailing newline is conventional and ensures POSIX tools treat the
+    // last line as a complete line.
+    expect(script.endsWith('\n')).toBe(true);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Windows installer no longer crashes configuring git sync cron on the VM. Previously the `gcloud ssh --command` arg contained `|`, `(`, `)`, `;` which cmd.exe interpreted as its own metacharacters, fragmenting the command and trying to run `crontab` locally.
- Refactored to build a single bash setup script locally, SCP it to the VM, and execute with a metacharacter-free `--command "bash ~/lox-setup-sync.sh"`.
- Cron install is now idempotent via `grep -v -F + echo` (preserves user's existing crontab order — no more `sort -u`).
- Bumps version to 0.3.8.

## Test plan
- [x] 6 new unit tests for `buildVmSetupScript` (191/191 total passing)
- [x] Typecheck clean across all packages
- [x] CI green on ubuntu + windows
- [ ] Manual smoke test on Windows (Lara's machine)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)