### PR TITLE
feat: capture PAT and store in GCP Secret Manager (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.4.0] — 2026-04-04
+
+### Added
+- Vault Setup now captures the GitHub Fine-Grained PAT via a masked prompt and stores it directly in GCP Secret Manager (secret `lox-github-pat`). The flow validates format locally, is idempotent on re-runs (adds a new version if the secret already exists), and falls back to a printed manual command if the store call fails (#63)
+
 ## [0.3.8] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -136,6 +136,51 @@ export function buildVmSetupScript(): string {
 }
 
 /**
+ * Validate the shape of a pasted GitHub Personal Access Token.
+ * We don't call GitHub — we just rule out obvious paste corruption
+ * (whitespace, wrong prefix, truncation, stray quotes). A token that
+ * passes this check may still be invalid/expired; that surfaces when
+ * git sync runs on the VM. Returning false here just means "definitely
+ * not a PAT" so we can re-prompt without bothering the GitHub API.
+ *
+ * Accepts both fine-grained (`github_pat_`) and classic (`ghp_`) tokens.
+ * The installer's UI recommends fine-grained, but we don't reject a
+ * working classic PAT over a prefix mismatch.
+ */
+export function isValidPatFormat(token: string): boolean {
+  if (typeof token !== 'string') return false;
+  const trimmed = token.trim();
+  // Fine-grained PATs are ~93+ chars (github_pat_ + 82 chars of payload).
+  // Classic PATs are exactly 40 chars (ghp_ + 36 chars). Use a forgiving
+  // lower bound of 36 characters of suffix to tolerate minor format drift.
+  return /^(github_pat_|ghp_)[A-Za-z0-9_]{36,}$/.test(trimmed);
+}
+
+/**
+ * Check whether a GCP Secret Manager secret already exists in the given project.
+ * Returns true on success, false when the secret is not found, and rethrows on
+ * other failures (auth, billing, API disabled) so real problems surface.
+ */
+export async function gcpSecretExists(secretName: string, projectId: string): Promise<boolean> {
+  try {
+    await shell('gcloud', ['secrets', 'describe', secretName, '--project', projectId]);
+    return true;
+  } catch (err) {
+    const parts: string[] = [];
+    if (err instanceof Error) parts.push(err.message);
+    if (err && typeof err === 'object' && 'stderr' in err) {
+      const stderr = (err as { stderr: unknown }).stderr;
+      if (typeof stderr === 'string') parts.push(stderr);
+    }
+    const isNotFound = parts.some(p =>
+      p.includes('NOT_FOUND') || (p.includes('Secret') && p.includes('was not found')),
+    );
+    if (isNotFound) return false;
+    throw err;
+  }
+}
+
+/**
  * Check whether a GitHub repo exists and is accessible to the current user.
  * Returns false only for "not found" errors; rethrows other failures (auth,
  * network, missing `gh`) so they surface with the real cause.
@@ -161,7 +206,7 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   console.log(renderStepHeader(9, TOTAL_STEPS, strings.step_git_sync));
 
   // 1. Ask vault preset
-  const { select, input, confirm } = await import('@inquirer/prompts');
+  const { select, input, confirm, password } = await import('@inquirer/prompts');
   const { existsSync: fsExistsSync, rmSync, writeFileSync, mkdirSync } = await import('node:fs');
   const { join } = await import('node:path');
   const preset = await select({
@@ -277,6 +322,7 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   console.log(chalk.green('  ✓ .gitignore created with security patterns'));
 
   // 5. Guide fine-grained PAT creation
+  const patSecretName = 'lox-github-pat';
   const patInstructions = renderBox([
     'GitHub Fine-Grained PAT Setup',
     '',
@@ -286,15 +332,66 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
     '4. Permissions: Contents (Read and write), Metadata (Read)',
     '5. Generate and copy the token',
     '',
-    'This PAT will be used for git sync on the VM.',
-    'Store it in GCP Secret Manager after this step.',
+    `The PAT will be stored in GCP Secret Manager as "${patSecretName}"`,
+    'and read by the VM for git sync. Paste it when prompted below.',
   ]);
   console.log(`\n${patInstructions}\n`);
 
-  await input({
-    message: strings.press_enter,
-    default: '',
-  });
+  const gcpProjectId = ctx.gcpProjectId ?? 'lox-project';
+  const manualCmd = `gcloud secrets create ${patSecretName} --data-file=<path> --project=${gcpProjectId}`;
+
+  // Capture the token (masked) and loop on format validation.
+  let patToken = '';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const entered = await password({
+      message: 'Paste your GitHub PAT (input hidden, empty to skip):',
+      mask: '*',
+    });
+    const trimmed = entered.trim();
+    if (trimmed === '') {
+      console.log(chalk.yellow(`  ⚠ Skipped. Store the PAT manually later with:\n    ${manualCmd}`));
+      break;
+    }
+    if (!isValidPatFormat(trimmed)) {
+      console.log(chalk.red('  ✗ That does not look like a GitHub PAT (expected prefix github_pat_ or ghp_). Try again.'));
+      continue;
+    }
+    patToken = trimmed;
+    break;
+  }
+
+  // Store the token in GCP Secret Manager if we captured one.
+  if (patToken !== '') {
+    const { tmpdir } = await import('node:os');
+    const patTempPath = join(tmpdir(), `lox-pat-${Date.now()}.txt`);
+    try {
+      writeFileSync(patTempPath, patToken, { mode: 0o600 });
+      const exists = await gcpSecretExists(patSecretName, gcpProjectId);
+      await withSpinner(
+        `${exists ? 'Adding new version to' : 'Creating'} secret ${patSecretName}...`,
+        async () => {
+          // Pass --data-file as two separate args so paths with spaces
+          // (Windows temp dirs like C:\Users\First Last\...) survive
+          // cmd.exe tokenization correctly.
+          const args = exists
+            ? ['secrets', 'versions', 'add', patSecretName, '--data-file', patTempPath, '--project', gcpProjectId]
+            : ['secrets', 'create', patSecretName, '--data-file', patTempPath, '--project', gcpProjectId, '--replication-policy=automatic'];
+          await shell('gcloud', args);
+        },
+      );
+      console.log(chalk.green(
+        `  ✓ PAT stored in Secret Manager (secret: ${patSecretName}, project: ${gcpProjectId})`,
+      ));
+    } catch (err) {
+      // Never surface the token — only the failure reason.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(chalk.yellow(
+        `  ⚠ Failed to store PAT in Secret Manager: ${msg}\n    Store manually: ${manualCmd}`,
+      ));
+    } finally {
+      try { rmSync(patTempPath, { force: true }); } catch { /* best-effort */ }
+    }
+  }
 
   // 6. Set up branch protection (graceful degradation for GitHub Free + private repos)
   try {

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript } from '../../src/steps/step-vault.js';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -179,5 +179,103 @@ describe('buildVmSetupScript', () => {
     // trailing newline is conventional and ensures POSIX tools treat the
     // last line as a complete line.
     expect(script.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('isValidPatFormat', () => {
+  it('accepts fine-grained PATs (github_pat_ prefix)', () => {
+    // Fine-grained PATs are the recommended format — the installer's UI
+    // points users at the fine-grained token flow specifically.
+    expect(isValidPatFormat('github_pat_' + 'A'.repeat(82))).toBe(true);
+    expect(isValidPatFormat('github_pat_11ABCDE_0123456789abcdefghij_ABCDEFGHIJKLMNOP' + 'q'.repeat(30))).toBe(true);
+  });
+
+  it('accepts classic PATs (ghp_ prefix) as a fallback', () => {
+    // Some users may paste a classic PAT — accept it rather than rejecting
+    // a working token over a prefix mismatch.
+    expect(isValidPatFormat('ghp_' + 'A'.repeat(36))).toBe(true);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    // Copy-paste from browsers often includes a trailing newline
+    expect(isValidPatFormat('  ghp_' + 'A'.repeat(36) + '\n')).toBe(true);
+  });
+
+  it('rejects empty or whitespace-only input', () => {
+    expect(isValidPatFormat('')).toBe(false);
+    expect(isValidPatFormat('   ')).toBe(false);
+    expect(isValidPatFormat('\n\t')).toBe(false);
+  });
+
+  it('rejects tokens without a recognized prefix', () => {
+    // A bare hex/base64 string is almost certainly not a GitHub PAT
+    expect(isValidPatFormat('A'.repeat(40))).toBe(false);
+    expect(isValidPatFormat('sk-live-abcdef1234567890')).toBe(false);
+    expect(isValidPatFormat('Bearer ghp_' + 'A'.repeat(36))).toBe(false);
+  });
+
+  it('rejects tokens that are too short', () => {
+    // GitHub PATs are substantially longer than the prefix — a short suffix
+    // is a clear typo/truncation signal.
+    expect(isValidPatFormat('ghp_short')).toBe(false);
+    expect(isValidPatFormat('github_pat_short')).toBe(false);
+  });
+
+  it('rejects tokens containing invalid characters', () => {
+    // PATs use [A-Za-z0-9_] only; spaces/quotes/special chars mean paste corruption
+    expect(isValidPatFormat('ghp_' + 'A'.repeat(20) + ' ' + 'A'.repeat(15))).toBe(false);
+    expect(isValidPatFormat('ghp_' + 'A'.repeat(20) + '"' + 'A'.repeat(15))).toBe(false);
+  });
+
+  it('rejects non-string input gracefully', () => {
+    expect(isValidPatFormat(null as unknown as string)).toBe(false);
+    expect(isValidPatFormat(undefined as unknown as string)).toBe(false);
+    expect(isValidPatFormat(123 as unknown as string)).toBe(false);
+  });
+});
+
+describe('gcpSecretExists', () => {
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  it('returns true when gcloud secrets describe succeeds', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'name: projects/x/secrets/lox-github-pat', stderr: '' });
+    await expect(gcpSecretExists('lox-github-pat', 'my-project')).resolves.toBe(true);
+    expect(vi.mocked(shell)).toHaveBeenCalledWith('gcloud', [
+      'secrets', 'describe', 'lox-github-pat', '--project', 'my-project',
+    ]);
+  });
+
+  it('returns false when the secret is NOT_FOUND', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(
+      Object.assign(new Error('Command failed'), {
+        stderr: 'ERROR: (gcloud.secrets.describe) NOT_FOUND: Secret [lox-github-pat] was not found',
+      }),
+    );
+    await expect(gcpSecretExists('lox-github-pat', 'my-project')).resolves.toBe(false);
+  });
+
+  it('returns false on the alternate "was not found" phrasing', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(
+      Object.assign(new Error('Command failed'), {
+        stderr: 'Secret [x] was not found in project [y]',
+      }),
+    );
+    await expect(gcpSecretExists('x', 'y')).resolves.toBe(false);
+  });
+
+  it('rethrows unrelated errors (auth, API disabled, billing)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(
+      Object.assign(new Error('Command failed'), {
+        stderr: 'PERMISSION_DENIED: Secret Manager API has not been used',
+      }),
+    );
+    await expect(gcpSecretExists('x', 'y')).rejects.toThrow('Command failed');
+  });
+
+  it('rethrows "Command not found" for missing gcloud', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gcloud'));
+    await expect(gcpSecretExists('x', 'y')).rejects.toThrow('Command not found: gcloud');
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Vault Setup's PAT step previously printed instructions and waited for Enter — it never captured the token and never stored it. Users were left with a token in their clipboard and the cryptic instruction "Store it in GCP Secret Manager after this step."
- Now: masked prompt → format validation → tempfile (0o600) → idempotent Secret Manager store (create/versions add based on existence). Falls back to printing the exact manual command on failure.
- Token is never logged, printed, or passed via CLI args — only via \`--data-file\` tempfile.

## Security
- Token written to tempfile with mode 0o600, deleted in \`finally\`
- \`--data-file\` passed as two args (survives Windows paths w/ spaces per cmd.exe tokenization)
- Never surfaced in error messages (only failure reason printed)

## Test plan
- [x] 13 new unit tests for \`isValidPatFormat\` + \`gcpSecretExists\` (204/204 passing)
- [x] Typecheck clean
- [ ] Manual smoke test: paste valid PAT → see secret created
- [ ] Manual re-run test: secret exists → versions add path

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)