### PR TITLE
fix: use absolute /tmp path for VM setup script on Windows (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.4.1] — 2026-04-04
+
+### Fixed
+- VM cron setup no longer fails on Windows at the SCP step. `pscp.exe` (bundled with the Cloud SDK on Windows) does not perform server-side tilde expansion, so `lox-vm:~/lox-setup-sync.sh` landed in a literal `~` directory and crashed. Uses `/tmp/lox-setup-sync.sh` as an absolute remote path now (#64)
+
 ## [0.4.0] — 2026-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -105,9 +105,11 @@ export function isRepoNotFoundError(err: unknown): boolean {
  *   3. Removes itself after running.
  *
  * It is uploaded to the VM as a file and executed with a plain
- * `bash ~/lox-setup-sync.sh` — this avoids passing shell metacharacters
+ * `bash /tmp/lox-setup-sync.sh` — this avoids passing shell metacharacters
  * through `gcloud ... --command`, which fails on Windows cmd.exe (see #61).
  */
+export const VM_SETUP_SCRIPT_REMOTE_PATH = '/tmp/lox-setup-sync.sh';
+
 export function buildVmSetupScript(): string {
   // cronLine must not contain single quotes — embedded in a single-quoted bash assignment below.
   const cronLine = '*/2 * * * * ~/sync-vault.sh >> ~/sync-vault.log 2>&1';
@@ -439,14 +441,17 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
       writeFileSync(localScriptPath, setupScript);
 
       try {
-        // Upload the setup script to the VM via IAP-tunneled SCP
+        // Upload the setup script to the VM via IAP-tunneled SCP. Use an
+        // absolute remote path (/tmp) — pscp.exe (Windows Cloud SDK) does
+        // not perform tilde expansion, so `~/...` destinations land in a
+        // literal directory named "~" and fail (see #64).
         await shell('gcloud', [
           'compute', 'scp',
           '--project', projectId,
           '--zone', zone,
           '--tunnel-through-iap',
           localScriptPath,
-          `${vmName}:~/lox-setup-sync.sh`,
+          `${vmName}:${VM_SETUP_SCRIPT_REMOTE_PATH}`,
         ], { timeout: 120_000 });
 
         // Execute the script on the VM — the --command value has no shell
@@ -456,7 +461,7 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
           '--project', projectId,
           '--zone', zone,
           '--tunnel-through-iap',
-          '--command', 'bash ~/lox-setup-sync.sh',
+          '--command', `bash ${VM_SETUP_SCRIPT_REMOTE_PATH}`,
         ], { timeout: 120_000 });
       } finally {
         try { rmSync(localScriptPath, { force: true }); } catch { /* best-effort cleanup */ }

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists } from '../../src/steps/step-vault.js';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -172,6 +172,15 @@ describe('buildVmSetupScript', () => {
 
   it('removes itself after running (self-cleanup)', () => {
     expect(script).toContain('rm -- "$0"');
+  });
+
+  it('VM_SETUP_SCRIPT_REMOTE_PATH is an absolute POSIX path', () => {
+    // pscp.exe (Windows Cloud SDK) does not perform tilde expansion — a
+    // destination like lox-vm:~/file.sh lands in a literal "~" directory
+    // and fails. The remote path must start with "/" and contain no "~"
+    // (see #64).
+    expect(VM_SETUP_SCRIPT_REMOTE_PATH.startsWith('/')).toBe(true);
+    expect(VM_SETUP_SCRIPT_REMOTE_PATH).not.toContain('~');
   });
 
   it('ends with a trailing newline', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- \`pscp.exe\` (Windows Cloud SDK) does NOT expand \`~\` server-side, so the v0.3.8 scp destination \`lox-vm:~/lox-setup-sync.sh\` tried to open a file in a literal \`~\` directory and crashed.
- Switched to \`/tmp/lox-setup-sync.sh\` (absolute path, always writable, no expansion). Extracted as a single exported constant so scp dest + ssh command can't drift.
- Regression test pins the \"absolute + no tilde\" contract.

## Test plan
- [x] Regression test for VM_SETUP_SCRIPT_REMOTE_PATH (205/205 passing)
- [x] Typecheck clean
- [ ] Manual smoke test on Windows

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)