### PR TITLE
fix: Obsidian install timeout + step 10-12 idempotency (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.4.2] — 2026-04-04
+
+### Fixed
+- Obsidian install no longer times out on Windows. `winget install Obsidian.Obsidian` (and the brew/snap equivalents) now runs with an initial 5-minute timeout, and if it still times out the user is prompted (default=yes) to extend to 10 minutes — same pattern we already use for VM setup phases (#68)
+- Step 10 (Obsidian) is now re-run safe: pre-checks via `brew list --cask`, `winget list -e`, or `snap list` and skips install when Obsidian is already present, skips `gh repo clone` when the target vault dir already exists, and copies plugin templates with Node's `fs.cpSync` instead of `cp -r` (which does not exist on Windows)
+- Step 11 (Deploy) now clones from the fully-qualified `isorensen/lox-brain` on the VM. The previous unqualified `gh repo clone lox-brain` resolved to the VM user's own GitHub namespace, which 404s for third-party installers who do not have their own fork
+- Step 12 (MCP) is now idempotent: detects an existing `lox-brain` entry in `claude mcp list` and removes it before re-adding, so re-running the installer no longer fails on the `claude mcp add` step
+
+### Added
+- `utils/extendable-timeout.ts` — reusable helper for long-running operations that should prompt the user to extend timeout on first failure
+
 ## [0.4.1] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -91,6 +91,7 @@ export interface I18nStrings {
 
   // VM setup
   vm_setup_timeout: string;
+  install_timeout_extend: string;
   vm_phase_system_update: string;
   vm_phase_nodejs: string;
   vm_phase_postgresql: string;
@@ -202,6 +203,7 @@ export const en: I18nStrings = {
 
   // VM setup
   vm_setup_timeout: 'VM setup is taking longer than expected. Continue waiting?',
+  install_timeout_extend: 'taking longer than expected. Continue waiting?',
   vm_phase_system_update: 'Updating system packages',
   vm_phase_nodejs: 'Installing Node.js 22',
   vm_phase_postgresql: 'Installing PostgreSQL 16',

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -93,6 +93,7 @@ export const ptBr: I18nStrings = {
 
   // VM setup
   vm_setup_timeout: 'A configuracao da VM esta demorando mais que o esperado. Continuar aguardando?',
+  install_timeout_extend: 'esta demorando mais que o esperado. Continuar aguardando?',
   vm_phase_system_update: 'Atualizando pacotes do sistema',
   vm_phase_nodejs: 'Instalando Node.js 22',
   vm_phase_postgresql: 'Instalando PostgreSQL 16',

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -72,8 +72,11 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
   await withSpinner(
     'Cloning lox-brain repo on VM...',
     async () => {
+      // Use the fully-qualified upstream repo — third-party installers do
+      // not have their own `lox-brain` fork under their GitHub account, so
+      // the unqualified name would resolve to $(gh_user)/lox-brain and 404.
       await sshCommand(vmName, projectId, zone,
-        `test -d ${installDir} && (cd ${installDir} && git pull) || gh repo clone lox-brain ${installDir}`,
+        `test -d ${installDir} && (cd ${installDir} && git pull) || gh repo clone isorensen/lox-brain ${installDir}`,
       );
     },
   );

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -57,6 +57,24 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
 }
 
 /**
+ * Check whether an MCP server is already registered with Claude Code at the
+ * user scope. `claude mcp list` returns non-zero in some environments, so we
+ * treat any failure as "not registered" and let the downstream add call run.
+ */
+export async function isMcpServerRegistered(name: string): Promise<boolean> {
+  try {
+    const { stdout } = await shell('claude', ['mcp', 'list']);
+    // `claude mcp list` prints one server per line. Match on a word boundary
+    // so we don't false-positive on `lox-brain-foo` when looking for `lox-brain`.
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`(^|\\s)${escapedName}(\\s|:|$)`, 'm');
+    return pattern.test(stdout);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Step 12: Configure Claude Code MCP
  *
  * Generates SSH config entry, registers the MCP server with Claude Code,
@@ -79,6 +97,18 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
   // 2. Register MCP server with Claude Code
   const installDir = ctx.config.install_dir ?? '/home/' + sshUser + '/lox-brain';
   const mcpCommand = `cd ${installDir} && set -a && source /etc/lox/secrets.env && set +a && node packages/core/dist/mcp/index.js`;
+
+  // Idempotency: `claude mcp add` fails when a server with the same name is
+  // already registered. Detect that and remove the prior entry so re-runs
+  // re-register cleanly (picks up changed installDir / lox-vm config).
+  const alreadyRegistered = await isMcpServerRegistered('lox-brain');
+  if (alreadyRegistered) {
+    try {
+      await shell('claude', ['mcp', 'remove', '--scope', 'user', 'lox-brain']);
+    } catch {
+      // Fall through: if remove fails we still try add; add's own error will surface.
+    }
+  }
 
   await withSpinner(
     'Registering lox-brain MCP server with Claude Code...',

--- a/packages/installer/src/steps/step-obsidian.ts
+++ b/packages/installer/src/steps/step-obsidian.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { shell, getPlatform } from '../utils/shell.js';
+import { withExtendableTimeout } from '../utils/extendable-timeout.js';
 import { t } from '../i18n/index.js';
 import { renderStepHeader, renderBox } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
@@ -7,29 +8,86 @@ import type { InstallerContext, StepResult } from './types.js';
 
 const TOTAL_STEPS = 12;
 
+/** Initial timeout for package-manager installs (5 min). */
+const INSTALL_TIMEOUT_MS = 300_000;
+/** Upper-bound timeout when the user chooses to keep waiting (10 min). */
+const INSTALL_MAX_TIMEOUT_MS = 600_000;
+
+type Platform = 'windows' | 'macos' | 'linux';
+
+/**
+ * Detect whether Obsidian is already installed via the platform's package
+ * manager. Returns false when the check itself fails (command missing,
+ * unknown platform) so the installer falls through to the install path.
+ */
+export async function isObsidianInstalled(platform: Platform): Promise<boolean> {
+  try {
+    switch (platform) {
+      case 'macos': {
+        const { stdout } = await shell('brew', ['list', '--cask', 'obsidian']);
+        return stdout.length > 0;
+      }
+      case 'windows': {
+        const { stdout } = await shell('winget', ['list', '--id', 'Obsidian.Obsidian', '-e']);
+        return stdout.includes('Obsidian.Obsidian');
+      }
+      case 'linux': {
+        const { stdout } = await shell('snap', ['list', 'obsidian']);
+        return stdout.includes('obsidian');
+      }
+    }
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Install Obsidian using the platform-appropriate package manager.
+ * Idempotent: skips install when Obsidian is already present. The package
+ * manager call runs with a 5-minute timeout; if it still times out, the user
+ * is prompted (default=yes) to extend to 10 minutes.
  */
-async function installObsidian(): Promise<void> {
+async function installObsidian(): Promise<boolean> {
+  const strings = t();
   const platform = getPlatform();
-  switch (platform) {
-    case 'macos':
-      await shell('brew', ['install', '--cask', 'obsidian']);
-      break;
-    case 'windows':
-      await shell('winget', ['install', 'Obsidian.Obsidian', '--accept-source-agreements', '--accept-package-agreements']);
-      break;
-    case 'linux':
-      try {
-        await shell('snap', ['install', 'obsidian', '--classic']);
-      } catch {
-        throw new Error(
-          'Could not install Obsidian via snap. ' +
-          'Please install manually: https://obsidian.md/download',
-        );
-      }
-      break;
+
+  if (await isObsidianInstalled(platform)) {
+    return false; // already installed — nothing to do
   }
+
+  await withExtendableTimeout(
+    async (timeout) => {
+      switch (platform) {
+        case 'macos':
+          await shell('brew', ['install', '--cask', 'obsidian'], { timeout });
+          break;
+        case 'windows':
+          await shell(
+            'winget',
+            ['install', 'Obsidian.Obsidian', '--accept-source-agreements', '--accept-package-agreements'],
+            { timeout },
+          );
+          break;
+        case 'linux':
+          try {
+            await shell('snap', ['install', 'obsidian', '--classic'], { timeout });
+          } catch {
+            throw new Error(
+              'Could not install Obsidian via snap. ' +
+              'Please install manually: https://obsidian.md/download',
+            );
+          }
+          break;
+      }
+    },
+    {
+      label: 'Obsidian install',
+      initialTimeout: INSTALL_TIMEOUT_MS,
+      maxTimeout: INSTALL_MAX_TIMEOUT_MS,
+      promptMessage: strings.install_timeout_extend,
+    },
+  );
+  return true;
 }
 
 /**
@@ -42,12 +100,12 @@ export async function stepObsidian(ctx: InstallerContext): Promise<StepResult> {
   const strings = t();
   console.log(renderStepHeader(10, TOTAL_STEPS, 'Obsidian'));
 
-  // 1. Install Obsidian
-  await withSpinner(
+  // 1. Install Obsidian (skips when already present)
+  const installed = await withSpinner(
     `${strings.installing} Obsidian...`,
     () => installObsidian(),
   );
-  console.log(chalk.green('  ✓ Obsidian installed'));
+  console.log(chalk.green(installed ? '  ✓ Obsidian installed' : '  ✓ Obsidian already installed'));
 
   // 2. Clone vault repo locally to ~/Obsidian/Lox
   const vaultRepo = ctx.config.vault?.repo;
@@ -70,19 +128,30 @@ export async function stepObsidian(ctx: InstallerContext): Promise<StepResult> {
       if (!existsSync(parentDir)) {
         mkdirSync(parentDir, { recursive: true });
       }
+      // Idempotency: if the target path already contains a clone from a
+      // prior run, skip clone. `gh repo clone` fails on an existing dir,
+      // which would break re-runs of the installer.
+      if (existsSync(expandedPath)) {
+        return;
+      }
       await shell('gh', ['repo', 'clone', vaultRepo, expandedPath]);
     },
   );
 
-  // 3. Copy .obsidian/ config with plugins
+  // 3. Copy .obsidian/ config with plugins (use Node fs so Windows works too —
+  //    `cp -r` does not exist on Windows).
   await withSpinner(
     'Copying Obsidian plugin configuration...',
     async () => {
-      try {
-        await shell('cp', ['-r', 'templates/obsidian-plugins/.', `${expandedPath}/.obsidian`]);
-      } catch {
+      const { cpSync, existsSync } = await import('node:fs');
+      const { join } = await import('node:path');
+      const src = join('templates', 'obsidian-plugins');
+      if (!existsSync(src)) {
         console.log(chalk.yellow('  → Plugin templates not found, skipping plugin copy.'));
+        return;
       }
+      const dest = join(expandedPath, '.obsidian');
+      cpSync(src, dest, { recursive: true });
     },
   );
 

--- a/packages/installer/src/utils/extendable-timeout.ts
+++ b/packages/installer/src/utils/extendable-timeout.ts
@@ -1,0 +1,77 @@
+/**
+ * Utility to run a long-running async operation with a timeout that the user
+ * can choose to extend once. Follows the pattern established in step-vm-setup.ts:
+ * on timeout, prompt the user (default=yes) and retry with a larger timeout.
+ *
+ * The caller passes a function that accepts the current timeout (in ms) and
+ * returns a promise; it is responsible for forwarding that timeout to its
+ * underlying shell/fetch/etc. call.
+ */
+
+/**
+ * Returns true when an error is caused by a process timeout (SIGTERM / killed
+ * by the child_process timeout option, or shell() wrapping with "timed out").
+ */
+export function isTimeoutError(err: unknown): boolean {
+  if (err instanceof Error) {
+    return (
+      err.message.includes('timed out') ||
+      err.message.includes('SIGTERM') ||
+      ('killed' in err && (err as unknown as { killed: boolean }).killed === true)
+    );
+  }
+  if (err !== null && typeof err === 'object' && 'killed' in err) {
+    return (err as { killed: boolean }).killed === true;
+  }
+  return false;
+}
+
+export interface ExtendableTimeoutOptions {
+  /** Short label used in the confirmation prompt (e.g. "Obsidian install"). */
+  label: string;
+  /** First attempt timeout, in milliseconds. */
+  initialTimeout: number;
+  /** Upper bound timeout used on retry, in milliseconds. */
+  maxTimeout: number;
+  /** Localized prompt shown when the first attempt times out. */
+  promptMessage: string;
+  /**
+   * Optional injected confirmation. Defaults to @inquirer/prompts.confirm
+   * with default=true ("keep waiting" unless the user explicitly declines).
+   * Exposed for testing.
+   */
+  confirmFn?: (message: string) => Promise<boolean>;
+}
+
+/**
+ * Run `fn(timeout)` with the initial timeout. If it throws a timeout error,
+ * prompt the user (default=yes) to extend; on confirmation, retry once with
+ * maxTimeout. Non-timeout errors and declines propagate immediately.
+ */
+export async function withExtendableTimeout<T>(
+  fn: (timeout: number) => Promise<T>,
+  options: ExtendableTimeoutOptions,
+): Promise<T> {
+  const { label, initialTimeout, maxTimeout, promptMessage } = options;
+  let timeout = initialTimeout;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn(timeout);
+    } catch (err) {
+      if (isTimeoutError(err) && timeout < maxTimeout) {
+        const confirmFn = options.confirmFn ?? (async (message: string) => {
+          const { confirm } = await import('@inquirer/prompts');
+          return confirm({ message, default: true });
+        });
+        const shouldRetry = await confirmFn(`${label}: ${promptMessage}`);
+        if (shouldRetry) {
+          timeout = maxTimeout;
+          continue;
+        }
+      }
+      throw err;
+    }
+  }
+}

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isMcpServerRegistered } from '../../src/steps/step-mcp.js';
+import { shell } from '../../src/utils/shell.js';
+
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+}));
+
+describe('isMcpServerRegistered', () => {
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  it('returns true when the server name appears in claude mcp list', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'lox-brain: ssh lox-vm cd /home/lox/lox-brain && node ...\nother: node foo.js',
+      stderr: '',
+    });
+    expect(await isMcpServerRegistered('lox-brain')).toBe(true);
+  });
+
+  it('returns false when the server name is not present', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'other-server: node foo.js\nanother: node bar.js',
+      stderr: '',
+    });
+    expect(await isMcpServerRegistered('lox-brain')).toBe(false);
+  });
+
+  it('returns false when claude mcp list is empty', async () => {
+    vi.mocked(shell).mockResolvedValue({ stdout: '', stderr: '' });
+    expect(await isMcpServerRegistered('lox-brain')).toBe(false);
+  });
+
+  it('does not false-positive on a name that contains the target as a substring', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'lox-brain-staging: node foo.js',
+      stderr: '',
+    });
+    expect(await isMcpServerRegistered('lox-brain')).toBe(false);
+  });
+
+  it('returns false when claude mcp list throws', async () => {
+    vi.mocked(shell).mockRejectedValue(new Error('claude: command not found'));
+    expect(await isMcpServerRegistered('lox-brain')).toBe(false);
+  });
+});

--- a/packages/installer/tests/steps/step-obsidian.test.ts
+++ b/packages/installer/tests/steps/step-obsidian.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isObsidianInstalled } from '../../src/steps/step-obsidian.js';
+import { shell } from '../../src/utils/shell.js';
+
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+  getPlatform: vi.fn(),
+}));
+
+describe('isObsidianInstalled', () => {
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  it('returns true when brew list --cask obsidian succeeds (macos)', async () => {
+    vi.mocked(shell).mockResolvedValue({ stdout: 'obsidian', stderr: '' });
+    expect(await isObsidianInstalled('macos')).toBe(true);
+    expect(shell).toHaveBeenCalledWith('brew', ['list', '--cask', 'obsidian']);
+  });
+
+  it('returns false when brew list --cask obsidian fails (macos)', async () => {
+    vi.mocked(shell).mockRejectedValue(new Error('No such cask: obsidian'));
+    expect(await isObsidianInstalled('macos')).toBe(false);
+  });
+
+  it('returns true when winget list contains Obsidian.Obsidian (windows)', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'Name                        Id                 Version\nObsidian                    Obsidian.Obsidian  1.5.12',
+      stderr: '',
+    });
+    expect(await isObsidianInstalled('windows')).toBe(true);
+    expect(shell).toHaveBeenCalledWith('winget', ['list', '--id', 'Obsidian.Obsidian', '-e']);
+  });
+
+  it('returns false when winget list does not contain the id (windows)', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'No installed package found matching input criteria.',
+      stderr: '',
+    });
+    expect(await isObsidianInstalled('windows')).toBe(false);
+  });
+
+  it('returns false when winget throws (windows)', async () => {
+    vi.mocked(shell).mockRejectedValue(new Error('Command not found: winget'));
+    expect(await isObsidianInstalled('windows')).toBe(false);
+  });
+
+  it('returns true when snap list contains obsidian (linux)', async () => {
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'Name      Version  Rev   Tracking  Publisher  Notes\nobsidian  1.5.12   42    latest/stable  obsidianmd  classic',
+      stderr: '',
+    });
+    expect(await isObsidianInstalled('linux')).toBe(true);
+    expect(shell).toHaveBeenCalledWith('snap', ['list', 'obsidian']);
+  });
+
+  it('returns false when snap list throws (linux)', async () => {
+    vi.mocked(shell).mockRejectedValue(new Error('error: no matching snaps installed'));
+    expect(await isObsidianInstalled('linux')).toBe(false);
+  });
+});

--- a/packages/installer/tests/utils/extendable-timeout.test.ts
+++ b/packages/installer/tests/utils/extendable-timeout.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isTimeoutError, withExtendableTimeout } from '../../src/utils/extendable-timeout.js';
+
+describe('isTimeoutError', () => {
+  it('matches Error.message containing "timed out"', () => {
+    expect(isTimeoutError(new Error('Command timed out after 30000ms: winget'))).toBe(true);
+  });
+
+  it('matches Error.message containing SIGTERM', () => {
+    expect(isTimeoutError(new Error('Process killed by SIGTERM'))).toBe(true);
+  });
+
+  it('matches objects with killed === true', () => {
+    expect(isTimeoutError({ killed: true })).toBe(true);
+  });
+
+  it('matches Errors with killed === true', () => {
+    const err = Object.assign(new Error('boom'), { killed: true });
+    expect(isTimeoutError(err)).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isTimeoutError(new Error('ENOENT'))).toBe(false);
+    expect(isTimeoutError(new Error(''))).toBe(false);
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError('timed out')).toBe(false);
+    expect(isTimeoutError({ killed: false })).toBe(false);
+  });
+});
+
+describe('withExtendableTimeout', () => {
+  it('returns fn result on first success without prompting', async () => {
+    const confirmFn = vi.fn(async () => true);
+    const result = await withExtendableTimeout(
+      async (_t) => 'ok',
+      {
+        label: 'test',
+        initialTimeout: 1000,
+        maxTimeout: 2000,
+        promptMessage: 'retry?',
+        confirmFn,
+      },
+    );
+    expect(result).toBe('ok');
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+
+  it('retries with maxTimeout when user confirms after a timeout', async () => {
+    const timeouts: number[] = [];
+    let calls = 0;
+    const confirmFn = vi.fn(async () => true);
+
+    const result = await withExtendableTimeout(
+      async (timeout) => {
+        timeouts.push(timeout);
+        calls++;
+        if (calls === 1) {
+          throw new Error('Command timed out after 1000ms: winget');
+        }
+        return 'done';
+      },
+      {
+        label: 'Obsidian install',
+        initialTimeout: 1000,
+        maxTimeout: 5000,
+        promptMessage: 'keep waiting?',
+        confirmFn,
+      },
+    );
+
+    expect(result).toBe('done');
+    expect(timeouts).toEqual([1000, 5000]);
+    expect(confirmFn).toHaveBeenCalledWith('Obsidian install: keep waiting?');
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when user declines to extend', async () => {
+    const confirmFn = vi.fn(async () => false);
+    await expect(
+      withExtendableTimeout(
+        async () => { throw new Error('Command timed out after 1000ms: brew'); },
+        {
+          label: 'brew install',
+          initialTimeout: 1000,
+          maxTimeout: 5000,
+          promptMessage: 'keep waiting?',
+          confirmFn,
+        },
+      ),
+    ).rejects.toThrow('timed out');
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry and rethrows on non-timeout errors', async () => {
+    const confirmFn = vi.fn(async () => true);
+    await expect(
+      withExtendableTimeout(
+        async () => { throw new Error('Command not found: winget'); },
+        {
+          label: 'winget',
+          initialTimeout: 1000,
+          maxTimeout: 5000,
+          promptMessage: 'keep waiting?',
+          confirmFn,
+        },
+      ),
+    ).rejects.toThrow('Command not found');
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when already at maxTimeout', async () => {
+    const confirmFn = vi.fn(async () => true);
+    await expect(
+      withExtendableTimeout(
+        async () => { throw new Error('Command timed out after 5000ms: winget'); },
+        {
+          label: 'winget',
+          initialTimeout: 5000,
+          maxTimeout: 5000,
+          promptMessage: 'keep waiting?',
+          confirmFn,
+        },
+      ),
+    ).rejects.toThrow('timed out');
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+
+  it('only retries once — a second timeout on the extended attempt rethrows', async () => {
+    const confirmFn = vi.fn(async () => true);
+    let calls = 0;
+    await expect(
+      withExtendableTimeout(
+        async () => {
+          calls++;
+          throw new Error('Command timed out after 5000ms: winget');
+        },
+        {
+          label: 'winget',
+          initialTimeout: 1000,
+          maxTimeout: 5000,
+          promptMessage: 'keep waiting?',
+          confirmFn,
+        },
+      ),
+    ).rejects.toThrow('timed out');
+    expect(calls).toBe(2);
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Closes #68 (auto-reported from Windows v0.4.1: `winget install Obsidian.Obsidian` timed out at 30s default). Bundles adjacent idempotency gaps in steps 10–12 that would break re-runs of the installer.

- **Obsidian install timeout (#68):** 5-minute initial timeout, one-shot user-confirmed extension to 10 minutes (default=yes). Same pattern as `step-vm-setup.ts`. Extracted into new reusable `utils/extendable-timeout.ts`.
- **Step 10 idempotency:** pre-checks `brew list --cask` / `winget list -e` / `snap list` before installing Obsidian; skips `gh repo clone` when the vault dir already exists; copies plugin templates with `fs.cpSync` (Windows has no `cp -r`).
- **Step 11 (minimal):** `gh repo clone lox-brain` → `gh repo clone isorensen/lox-brain`. The unqualified name resolves to the VM user's own namespace and 404s for third-party installers. (Remaining step 11 Windows-metachar bugs in `--command` strings are deferred — will be filed as a follow-up issue matching the #61 scp+bash pattern.)
- **Step 12 idempotency:** detects an existing `lox-brain` entry in `claude mcp list` and removes before re-adding, so re-runs don't fail on `claude mcp add`.

Version: **0.4.1 → 0.4.2** (patch).

## Test plan

- [x] 23 new unit tests (`extendable-timeout`, `isObsidianInstalled`, `isMcpServerRegistered`) — cover retry logic, decline-to-extend, non-timeout errors, substring false-positives.
- [x] Full suite: **228 passing, 0 failing**.
- [x] `tsc --noEmit` clean across shared/core/installer.
- [x] grep for stale `0.4.1` refs — clean.
- [ ] Windows validation (Lara) — installer re-run on Windows 11 with Obsidian already installed should skip install cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)