### PR TITLE
fix: step 11 VM git clone + step 10 plugin/sync guidance (#73, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.4.3] — 2026-04-04
+
+### Fixed
+- Step 11 (Deploy) no longer fails with `gh: command not found` on the VM. The VM bootstrap does not install the GitHub CLI, and the upstream `isorensen/lox-brain` is a public repo, so the clone now uses plain `git clone https://github.com/isorensen/lox-brain.git` — anonymous HTTPS, no auth or extra dependency required (#73)
+- Step 10 (Obsidian) post-install instructions no longer claim plugins were "pre-copied to .obsidian/plugins/". Only the plugin *list* (`community-plugins.json`) is seeded; the user has to install each plugin from Obsidian's Community Plugins browser (#74)
+- Step 10 now includes explicit configuration guidance for the `obsidian-git` plugin (vault backup interval, auto-pull, auto-push) — without this the local vault never syncs to the git remote, so VM-side changes never flow back and local edits never reach the embedding index (#74)
+
 ## [0.4.2] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -72,11 +72,12 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
   await withSpinner(
     'Cloning lox-brain repo on VM...',
     async () => {
-      // Use the fully-qualified upstream repo — third-party installers do
-      // not have their own `lox-brain` fork under their GitHub account, so
-      // the unqualified name would resolve to $(gh_user)/lox-brain and 404.
+      // Plain `git clone` over HTTPS — the upstream `isorensen/lox-brain` is
+      // a public repo, so no auth is needed and we avoid depending on `gh`
+      // being installed on the VM (step-vm-setup.ts does not install it, and
+      // anonymous `git clone` of a public repo works everywhere git exists).
       await sshCommand(vmName, projectId, zone,
-        `test -d ${installDir} && (cd ${installDir} && git pull) || gh repo clone isorensen/lox-brain ${installDir}`,
+        `test -d ${installDir} && (cd ${installDir} && git pull) || git clone https://github.com/isorensen/lox-brain.git ${installDir}`,
       );
     },
   );

--- a/packages/installer/src/steps/step-obsidian.ts
+++ b/packages/installer/src/steps/step-obsidian.ts
@@ -155,17 +155,29 @@ export async function stepObsidian(ctx: InstallerContext): Promise<StepResult> {
     },
   );
 
-  // 4. Pause with instructions for manual plugin activation
+  // 4. Pause with instructions for plugin install + obsidian-git configuration
   const pluginInstructions = renderBox([
-    'Obsidian Plugin Activation',
+    'Obsidian Plugin Setup',
     '',
-    '1. Open Obsidian',
-    `2. Open vault: ${localPath}`,
-    '3. Go to Settings → Community Plugins',
-    '4. Enable "Safe Mode" off if prompted',
-    '5. Enable the pre-configured plugins',
+    `1. Open Obsidian and open vault: ${localPath}`,
+    '2. Settings → Community Plugins → Turn on community plugins',
+    '3. Click Browse and install each of these plugins:',
+    '     • obsidian-git       (local vault ↔ git sync)',
+    '     • dataview           (query notes as a database)',
+    '     • omnisearch         (full-text search)',
+    '     • emoji-shortcodes   (inline emoji)',
+    '     • recent-files-obsidian',
+    '4. Settings → Community Plugins → enable each after install',
     '',
-    'Recommended plugins have been pre-copied to .obsidian/plugins/',
+    'obsidian-git — required for vault sync:',
+    '  Settings → Obsidian Git →',
+    '    • Vault backup interval: 2 min',
+    '    • Auto pull on startup: on',
+    '    • Auto pull interval: 2 min',
+    '    • Auto push after commit: on',
+    '',
+    'The plugin list (community-plugins.json) is already seeded,',
+    'so Obsidian will remember your selections after this step.',
   ]);
   console.log(`\n${pluginInstructions}\n`);
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Two fixes bundled from real-user Windows 11 test of v0.4.2:

- **Closes #73** — step 11 was calling `gh repo clone isorensen/lox-brain ...` on the VM, but the VM bootstrap never installs the GitHub CLI (only gcloud/Node/PostgreSQL/pgvector/WireGuard). Since `isorensen/lox-brain` is public, swapping to anonymous `git clone https://github.com/isorensen/lox-brain.git` removes the dependency entirely.
- **Closes #74** — step 10 was telling users "Recommended plugins have been pre-copied to .obsidian/plugins/", which is untrue: only the plugin list (`community-plugins.json`) is seeded. Users who opened Obsidian saw an empty plugins folder and had no guidance to install plugins or configure obsidian-git for vault sync. Replaced the instruction block with accurate Browse-and-install steps plus explicit obsidian-git config values (backup interval, auto-pull, auto-push).

Version: **0.4.2 → 0.4.3** (patch).

## Test plan

- [x] Typecheck clean across shared/core/installer.
- [x] Full suite: 228 passing.
- [x] grep for stale `0.4.2` refs — clean.
- [ ] Windows validation (Lara): step 11 clones the repo cleanly from the VM; step 10 post-install instructions are readable and the obsidian-git config produces working local↔VM sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)