### PR TITLE
fix: upload MCP launcher to VM (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - Update README with badges, improved splash, and public install instructions
 - Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and GitHub issue/PR templates
 
+## [0.4.4] — 2026-04-04
+
+### Changed
+- Step 12 (MCP) now uploads a small VM-side launcher script (`/home/<user>/lox-mcp.sh`) and registers Claude Code to invoke `ssh lox-vm /home/<user>/lox-mcp.sh`. Previously the full command body (`cd ... && set -a && source /etc/lox/secrets.env && set +a && node ...`) was passed as a single SSH argument, which Claude Code on Windows would re-spawn through `cmd.exe` and cmd.exe reinterprets `&&` as its own separator — breaking the MCP server startup. The registered command is now metachar-free, so spawning it works on every host Claude Code runs on (#71)
+
 ## [0.4.3] — 2026-04-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "description": "Lox installer — set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -25,6 +25,30 @@ Host lox-vm
 }
 
 /**
+ * Build the VM-side launcher script that Claude Code invokes over SSH to
+ * start the MCP server. Keeping all the shell metacharacters (`&&`, `source`,
+ * `set -a`) inside this script means the argument Claude Code passes to the
+ * local `ssh` binary is just a single path — no tokens for `cmd.exe` to
+ * reinterpret on Windows (see #61 for the same class of bug).
+ *
+ * The script is idempotent: it `cd`s into the install dir, loads the env
+ * file, and `exec`s node so the MCP server replaces the shell and responds
+ * to signals directly.
+ */
+export function buildMcpLauncherScript(installDir: string): string {
+  return [
+    '#!/bin/bash',
+    'set -euo pipefail',
+    `cd ${installDir}`,
+    'set -a',
+    'source /etc/lox/secrets.env',
+    'set +a',
+    'exec node packages/core/dist/mcp/index.js',
+    '',
+  ].join('\n');
+}
+
+/**
  * Ensure ~/.ssh/config exists and append the lox-vm entry if not present.
  */
 async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise<void> {
@@ -75,6 +99,33 @@ export async function isMcpServerRegistered(name: string): Promise<boolean> {
 }
 
 /**
+ * Upload the MCP launcher script to the VM at an absolute path and make it
+ * executable. Uses plain `scp`/`ssh` via the SSH config entry written earlier
+ * in this step (no gcloud, no IAP tunnel — the VPN is already up by now).
+ */
+async function uploadMcpLauncher(sshUser: string, installDir: string): Promise<string> {
+  const { writeFileSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+
+  const remotePath = `/home/${sshUser}/lox-mcp.sh`;
+  const script = buildMcpLauncherScript(installDir);
+  const localScriptPath = join(tmpdir(), `lox-mcp-${Date.now()}.sh`);
+  writeFileSync(localScriptPath, script, { mode: 0o755 });
+
+  try {
+    // Absolute remote paths only — pscp.exe (Windows Cloud SDK) does not
+    // expand `~` (see #64). `/home/<user>/...` works on every platform.
+    await shell('scp', [localScriptPath, `lox-vm:${remotePath}`], { timeout: 60_000 });
+    await shell('ssh', ['lox-vm', 'chmod', '+x', remotePath], { timeout: 30_000 });
+  } finally {
+    try { rmSync(localScriptPath, { force: true }); } catch { /* best-effort */ }
+  }
+
+  return remotePath;
+}
+
+/**
  * Step 12: Configure Claude Code MCP
  *
  * Generates SSH config entry, registers the MCP server with Claude Code,
@@ -94,13 +145,22 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
   );
   console.log(chalk.green('  ✓ SSH config entry for lox-vm added'));
 
-  // 2. Register MCP server with Claude Code
+  // 2. Upload the VM-side MCP launcher script.
+  //    Claude Code will invoke it over SSH with no shell metacharacters in
+  //    the argument, so cmd.exe on Windows can't reinterpret `&&`/`source`
+  //    when spawning the MCP server.
   const installDir = ctx.config.install_dir ?? '/home/' + sshUser + '/lox-brain';
-  const mcpCommand = `cd ${installDir} && set -a && source /etc/lox/secrets.env && set +a && node packages/core/dist/mcp/index.js`;
+  const remoteLauncher = await withSpinner(
+    'Uploading MCP launcher to VM...',
+    () => uploadMcpLauncher(sshUser, installDir),
+  );
+  console.log(chalk.green(`  ✓ MCP launcher uploaded to ${remoteLauncher}`));
 
-  // Idempotency: `claude mcp add` fails when a server with the same name is
-  // already registered. Detect that and remove the prior entry so re-runs
-  // re-register cleanly (picks up changed installDir / lox-vm config).
+  // 3. Register MCP server with Claude Code.
+  //    Idempotency: `claude mcp add` fails when a server with the same name
+  //    is already registered. Detect that and remove the prior entry so
+  //    re-runs re-register cleanly (picks up changed installDir / lox-vm
+  //    config).
   const alreadyRegistered = await isMcpServerRegistered('lox-brain');
   if (alreadyRegistered) {
     try {
@@ -118,12 +178,12 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
         '--scope', 'user',
         'lox-brain',
         '--',
-        'ssh', 'lox-vm', mcpCommand,
+        'ssh', 'lox-vm', remoteLauncher,
       ]);
     },
   );
 
-  // 3. Verify registration
+  // 4. Verify registration
   const verified = await withSpinner(
     'Verifying MCP registration...',
     async () => {

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isMcpServerRegistered } from '../../src/steps/step-mcp.js';
+import { isMcpServerRegistered, buildMcpLauncherScript } from '../../src/steps/step-mcp.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -43,5 +43,36 @@ describe('isMcpServerRegistered', () => {
   it('returns false when claude mcp list throws', async () => {
     vi.mocked(shell).mockRejectedValue(new Error('claude: command not found'));
     expect(await isMcpServerRegistered('lox-brain')).toBe(false);
+  });
+});
+
+describe('buildMcpLauncherScript', () => {
+  it('starts with a bash shebang and fail-fast flags', () => {
+    const script = buildMcpLauncherScript('/home/lox/lox-brain');
+    const lines = script.split('\n');
+    expect(lines[0]).toBe('#!/bin/bash');
+    expect(lines[1]).toBe('set -euo pipefail');
+  });
+
+  it('cds into the provided install dir verbatim', () => {
+    expect(buildMcpLauncherScript('/opt/lox')).toContain('cd /opt/lox\n');
+    expect(buildMcpLauncherScript('/home/alice/lox-brain')).toContain('cd /home/alice/lox-brain\n');
+  });
+
+  it('loads secrets.env with set -a / set +a', () => {
+    const script = buildMcpLauncherScript('/home/lox/lox-brain');
+    expect(script).toContain('set -a');
+    expect(script).toContain('source /etc/lox/secrets.env');
+    expect(script).toContain('set +a');
+  });
+
+  it('execs node on the MCP entrypoint (replaces the shell)', () => {
+    const script = buildMcpLauncherScript('/home/lox/lox-brain');
+    expect(script).toContain('exec node packages/core/dist/mcp/index.js');
+  });
+
+  it('ends with a trailing newline', () => {
+    const script = buildMcpLauncherScript('/home/lox/lox-brain');
+    expect(script.endsWith('\n')).toBe(true);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Closes #71. Moves the MCP launch command body into a VM-side script so Claude Code spawns it with a metachar-free argument on every platform.

**Before:** Step 12 registered the MCP server with \`ssh lox-vm \"cd ... && set -a && source /etc/lox/secrets.env && set +a && node ...\"\`. On Windows, when Claude Code re-spawns that string through \`cmd.exe\`, \`&&\` is interpreted as a command separator — the server never actually runs.

**After:** Step 12 now:
1. Builds a small \`lox-mcp.sh\` (cd, load secrets.env, \`exec node\`)
2. \`scp\`s it to \`/home/<user>/lox-mcp.sh\` on the VM (absolute path, mode 755)
3. Registers Claude with \`ssh lox-vm /home/<user>/lox-mcp.sh\` — single path argument, no metachars

Same class of fix as #61 (step-vault.ts scp+bash pattern).

Version: **0.4.3 → 0.4.4** (patch).

## Test plan

- [x] 5 new unit tests for \`buildMcpLauncherScript\` (shebang, set -euo, cd with custom installDir, source secrets.env with set -a/+a, exec node, trailing newline).
- [x] Full suite: 233 passing.
- [x] Typecheck clean.
- [ ] Windows validation (Lara): MCP server starts and \`claude mcp list\` shows lox-brain after re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)