### PR TITLE
fix: resolve real VM $USER/$HOME via SSH probe (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.6] — 2026-04-05
+
+### Fixed
+- Step 11 (Deploy) now resolves the real POSIX `$USER` and `$HOME` on the VM via an SSH probe instead of deriving the install path from the email prefix. GCP OS Login creates POSIX usernames as `<email-prefix>_<domain>_<tld>` (dots → underscores), so guessing `/home/<email-prefix>/` produced a path that did not exist on the VM and `git clone` failed with "could not create leading directories: Permission denied" (#79). The resolved identity is persisted on the installer context and reused by step 12 (MCP) for the SSH config entry, launcher upload path, and install directory.
+
+
 ### Changed
 - Prepare repository for open source release
 - Remove personal artifacts and internal documentation

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,13 @@
 
 ## Future Integrations
 
+### Claude Code Skills examples (bundle with the project)
+- **Priority:** Medium
+- **Complexity:** Low-Medium
+- Evaluate shipping a small set of example Claude Code skills alongside the MCP server so users can install them with a single command.
+- Rationale: Lox already exposes semantic+text search + note write/read via MCP. Skills would add reusable workflows on top (e.g. "daily note", "zettelkasten capture", "inbox triage", "weekly review"), making the combo **MCP Server + Obsidian + Claude Code Skills** a more opinionated Second-Brain toolkit.
+- Deliverables to scope: `examples/skills/` folder with 3-5 starter skills, docs on installing them into `~/.claude/skills/`, optional `lox skills install` CLI command.
+
 ### Telegram Bot (ingestão interativa via celular)
 - **Priority:** Medium
 - **Complexity:** Medium — API oficial, gratuita, sem risco de ban

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "lox-brain",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
-  "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
+  "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [
     "packages/shared",
     "packages/core",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,8 +1,8 @@
 {
   "name": "lox",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
-  "description": "Lox installer — set up your personal AI-powered Second Brain",
+  "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {
     "lox": "dist/index.js"
   },

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -186,6 +186,80 @@ async function runRemoteScript(
 }
 
 /**
+ * Parse `$USER:$HOME` output from the VM identity probe. Returns null if the
+ * output does not match the expected `user:/path` format.
+ */
+export function parseVmIdentity(output: string): { user: string; home: string } | null {
+  // Match `username:/absolute/path` — gcloud SSH may prepend MOTD banners or
+  // warnings, so we scan lines and pick the first one that matches the
+  // strict `user:/home/...` shape.
+  const re = /^([a-zA-Z0-9._-]+):(\/[^\s]*)$/;
+  for (const raw of output.split('\n')) {
+    const m = raw.trim().match(re);
+    if (m) {
+      return { user: m[1]!, home: m[2]! };
+    }
+  }
+  return null;
+}
+
+/** Script that echoes the VM's POSIX user and $HOME in `user:/home/path` form. */
+export function buildIdentityProbeScript(): string {
+  return [
+    '#!/bin/bash',
+    'set -euo pipefail',
+    'echo "${USER}:${HOME}"',
+    '',
+  ].join('\n');
+}
+
+/**
+ * SSH to the VM and capture `$USER:$HOME` via the scp+bash pattern (same as
+ * #70). Throws if the probe output cannot be parsed.
+ *
+ * Why: `ctx.gcpUsername` is derived from the email prefix, but GCP OS Login
+ * creates POSIX users as `<email-prefix>_<domain>_<tld>` (dots → underscores).
+ * Guessing the /home path from the email prefix makes `git clone` fail with
+ * "could not create leading directories" (see #79). We cannot pass
+ * `echo "$USER:$HOME"` via `--command` directly because on Windows cmd.exe
+ * reinterprets `$` and `"`, producing literal `$USER:$HOME` back — the exact
+ * class of bug the scp+bash refactor in #70 was introduced to prevent.
+ */
+async function resolveVmIdentity(
+  projectId: string,
+  zone: string,
+  vmName: string,
+): Promise<{ user: string; home: string }> {
+  const stdout = await runRemoteScript(
+    projectId, zone, vmName, 'identity', buildIdentityProbeScript(), { timeout: 60_000 },
+  );
+  const parsed = parseVmIdentity(stdout);
+  if (!parsed) {
+    throw new Error(`Could not parse VM identity from SSH probe output: ${JSON.stringify(stdout)}`);
+  }
+  return parsed;
+}
+
+/**
+ * Ensure `ctx.vmUser` and `ctx.vmHome` are set, resolving them via SSH if
+ * needed. Safe to call from any step — idempotent, caches on context.
+ */
+export async function ensureVmIdentity(
+  ctx: InstallerContext,
+  projectId: string,
+  zone: string,
+  vmName: string,
+): Promise<{ user: string; home: string }> {
+  if (ctx.vmUser && ctx.vmHome) {
+    return { user: ctx.vmUser, home: ctx.vmHome };
+  }
+  const identity = await resolveVmIdentity(projectId, zone, vmName);
+  ctx.vmUser = identity.user;
+  ctx.vmHome = identity.home;
+  return identity;
+}
+
+/**
  * Step 11: Deploy Lox Core to VM
  *
  * Clones the repo, builds, creates env file, installs systemd service,
@@ -198,9 +272,15 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
   const projectId = ctx.gcpProjectId ?? 'lox-project';
   const vmName = ctx.config.gcp?.vm_name ?? 'lox-vm';
   const zone = ctx.config.gcp?.zone ?? 'us-east1-b';
-  const user = ctx.gcpUsername ?? 'lox';
-  const installDir = ctx.config.install_dir ?? `/home/${user}/lox-brain`;
-  const vaultPath = ctx.config.vault?.local_path ?? `/home/${user}/lox-vault`;
+
+  // Resolve the actual POSIX user + $HOME on the VM. Must not derive from the
+  // email — OS Login POSIX names differ from email prefixes (#79).
+  const { user, home: vmHome } = await withSpinner(
+    'Resolving VM user identity...',
+    () => ensureVmIdentity(ctx, projectId, zone, vmName),
+  );
+  const installDir = ctx.config.install_dir ?? `${vmHome}/lox-brain`;
+  const vaultPath = ctx.config.vault?.local_path ?? `${vmHome}/lox-vault`;
 
   // 1. Clone lox-brain repo on VM
   await withSpinner(

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -4,6 +4,7 @@ import { t } from '../i18n/index.js';
 import { renderStepHeader } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
 import type { InstallerContext, StepResult } from './types.js';
+import { ensureVmIdentity } from './step-deploy.js';
 
 const TOTAL_STEPS = 12;
 
@@ -103,12 +104,12 @@ export async function isMcpServerRegistered(name: string): Promise<boolean> {
  * executable. Uses plain `scp`/`ssh` via the SSH config entry written earlier
  * in this step (no gcloud, no IAP tunnel — the VPN is already up by now).
  */
-async function uploadMcpLauncher(sshUser: string, installDir: string): Promise<string> {
+async function uploadMcpLauncher(vmHome: string, installDir: string): Promise<string> {
   const { writeFileSync, rmSync } = await import('node:fs');
   const { tmpdir } = await import('node:os');
   const { join } = await import('node:path');
 
-  const remotePath = `/home/${sshUser}/lox-mcp.sh`;
+  const remotePath = `${vmHome}/lox-mcp.sh`;
   const script = buildMcpLauncherScript(installDir);
   const localScriptPath = join(tmpdir(), `lox-mcp-${Date.now()}.sh`);
   writeFileSync(localScriptPath, script, { mode: 0o755 });
@@ -136,7 +137,16 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
   console.log(renderStepHeader(12, TOTAL_STEPS, strings.step_mcp));
 
   const vpnServerIp = ctx.config.vpn?.server_ip ?? '10.10.0.1';
-  const sshUser = ctx.gcpUsername ?? 'lox';
+  // Reuse the identity resolved in step-deploy (#79). If this step runs
+  // standalone (e.g. re-run after a failed step 12), probe the VM directly —
+  // the email-prefix derivation would reintroduce the original bug.
+  const projectId = ctx.gcpProjectId ?? 'lox-project';
+  const vmName = ctx.config.gcp?.vm_name ?? 'lox-vm';
+  const zone = ctx.config.gcp?.zone ?? 'us-east1-b';
+  const { user: sshUser, home: vmHome } = await withSpinner(
+    'Resolving VM user identity...',
+    () => ensureVmIdentity(ctx, projectId, zone, vmName),
+  );
 
   // 1. Generate SSH config entry
   await withSpinner(
@@ -149,10 +159,10 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
   //    Claude Code will invoke it over SSH with no shell metacharacters in
   //    the argument, so cmd.exe on Windows can't reinterpret `&&`/`source`
   //    when spawning the MCP server.
-  const installDir = ctx.config.install_dir ?? '/home/' + sshUser + '/lox-brain';
+  const installDir = ctx.config.install_dir ?? `${vmHome}/lox-brain`;
   const remoteLauncher = await withSpinner(
     'Uploading MCP launcher to VM...',
-    () => uploadMcpLauncher(sshUser, installDir),
+    () => uploadMcpLauncher(vmHome, installDir),
   );
   console.log(chalk.green(`  ✓ MCP launcher uploaded to ${remoteLauncher}`));
 

--- a/packages/installer/src/steps/types.ts
+++ b/packages/installer/src/steps/types.ts
@@ -5,6 +5,10 @@ export interface InstallerContext {
   locale: 'en' | 'pt-br';
   gcpUsername?: string;
   gcpProjectId?: string;
+  /** Actual POSIX username on the VM (resolved via SSH, not derived from email). */
+  vmUser?: string;
+  /** Actual $HOME on the VM (resolved via SSH). */
+  vmHome?: string;
   vaultPreset?: 'zettelkasten' | 'para';
 }
 

--- a/packages/installer/tests/steps/step-deploy.test.ts
+++ b/packages/installer/tests/steps/step-deploy.test.ts
@@ -7,6 +7,8 @@ import {
   buildSystemdInstallScript,
   buildServiceStartScript,
   buildMcpHealthProbeScript,
+  parseVmIdentity,
+  buildIdentityProbeScript,
 } from '../../src/steps/step-deploy.js';
 
 describe('buildCloneScript', () => {
@@ -94,6 +96,68 @@ describe('buildMcpHealthProbeScript', () => {
     const s = buildMcpHealthProbeScript('/home/lox/lox-brain');
     expect(s).not.toContain('set -euo pipefail');
     expect(s).not.toContain('pipefail');
+  });
+});
+
+describe('parseVmIdentity', () => {
+  it('parses a plain user:/home line', () => {
+    expect(parseVmIdentity('lara_gmail_com:/home/lara_gmail_com\n')).toEqual({
+      user: 'lara_gmail_com',
+      home: '/home/lara_gmail_com',
+    });
+  });
+
+  it('ignores MOTD banners and warnings before the identity line', () => {
+    const stdout = [
+      'Warning: Permanently added ... to the list of known hosts.',
+      'Welcome to Ubuntu 22.04.3 LTS',
+      '',
+      'alice:/home/alice',
+      '',
+    ].join('\n');
+    expect(parseVmIdentity(stdout)).toEqual({ user: 'alice', home: '/home/alice' });
+  });
+
+  it('accepts usernames with digits, dots, dashes, underscores', () => {
+    expect(parseVmIdentity('foo.bar-baz_42:/home/foo.bar-baz_42')).toEqual({
+      user: 'foo.bar-baz_42',
+      home: '/home/foo.bar-baz_42',
+    });
+  });
+
+  it('rejects output with no matching line', () => {
+    expect(parseVmIdentity('command not found\n')).toBeNull();
+    expect(parseVmIdentity('')).toBeNull();
+  });
+
+  it('rejects lines where the home path is not absolute', () => {
+    expect(parseVmIdentity('alice:relative/path')).toBeNull();
+  });
+
+  it('rejects lines where the username contains shell metachars', () => {
+    expect(parseVmIdentity('alice;rm -rf /:/home/alice')).toBeNull();
+    expect(parseVmIdentity('alice $(whoami):/home/alice')).toBeNull();
+  });
+
+  it('rejects lines where the home path contains whitespace', () => {
+    expect(parseVmIdentity('alice:/home/alice extra')).toBeNull();
+  });
+
+  it('handles newline-injection gracefully (first valid match wins)', () => {
+    // A nasty second line cannot override a legitimate first match.
+    expect(parseVmIdentity('alice:/home/alice\nroot:/root')).toEqual({
+      user: 'alice',
+      home: '/home/alice',
+    });
+  });
+});
+
+describe('buildIdentityProbeScript', () => {
+  it('is a bash script that echoes $USER:$HOME, runnable via scp+bash (#70)', () => {
+    const s = buildIdentityProbeScript();
+    expect(s.startsWith('#!/bin/bash')).toBe(true);
+    expect(s).toContain('set -euo pipefail');
+    expect(s).toContain('echo "${USER}:${HOME}"');
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Fix installer failing on Windows with `git clone: could not create leading directories of '/home/<user>/lox-brain': Permission denied`.
- Root cause: `ctx.gcpUsername` comes from the email prefix, but GCP OS Login creates the POSIX user as `<prefix>_<domain>_<tld>` (dots → underscores). `/home/<prefix>/` does not exist on the VM.
- Fix: SSH probe at start of step 11, echoes `$USER:$HOME` via the scp+bash pattern (#70) so Windows `cmd.exe` cannot reinterpret `$`/quotes. Result is cached on the installer context and reused by step 12.
- `step-mcp` now also calls `ensureVmIdentity` so re-running step 12 standalone picks up the real identity instead of reintroducing the bug.
- Bump to 0.4.6 + CHANGELOG entry.

Closes #79

## Test plan
- [x] 253 tests passing (added 9 new for `parseVmIdentity` + `buildIdentityProbeScript`)
- [x] `tsc --noEmit` clean across shared/installer/core
- [ ] End-to-end validation on Windows (Lara) against a fresh GCP project

🤖 Generated with [Claude Code](https://claude.com/claude-code)