### PR TITLE
fix: strip inherited NTFS ACLs from ~/.ssh/config on Windows (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-04-05
+
+### Fixed
+- Step 12 (MCP) now strips inherited NTFS ACLs from `~/.ssh/config` on Windows via `icacls /inheritance:r /grant:r "<USERNAME>":F` after writing the file. OpenSSH refuses to read configs with inherited ACEs (e.g. the "Owner Rights" SID S-1-3-4), so `scp`/`ssh lox-vm` failed with "Bad owner or permissions" even after `chmodSync(path, 0o600)` — Windows `chmod` does not touch NTFS ACLs (#83). The same fix is applied to `~/.ssh/` when the installer creates it, and to the config file on resume runs where the entry was already present from a previous failed install.
+- The error-reporter's Windows user-path redactor now handles mixed separators (`C:\Users\<name>/.ssh/...`) that OpenSSH emits on Windows, so auto-reports no longer leak the user's Windows account name when scp/ssh errors reference `.ssh/config`.
+
+
 ## [0.5.0] — 2026-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -50,6 +50,39 @@ export function buildMcpLauncherScript(installDir: string): string {
 }
 
 /**
+ * On Windows, OpenSSH refuses to read a config file whose NTFS ACLs
+ * include inherited permissions beyond the owner (e.g. the "Owner Rights"
+ * SID S-1-3-4 that new files inherit from `%USERPROFILE%`). POSIX-style
+ * `chmod 0600` does NOT strip those ACLs — it only maps loosely to the
+ * file mode bits, and scp/ssh still fail with "Bad owner or permissions"
+ * (#83).
+ *
+ * Strip inheritance and grant only the current user Full control using
+ * the built-in `icacls` command. Returns without error on non-Windows.
+ * Best-effort: on failure we log-and-continue so a partial fix does not
+ * block the install — the subsequent scp will surface the real error.
+ */
+export async function fixWindowsSshAcl(targetPath: string): Promise<void> {
+  if (process.platform !== 'win32') return;
+  // `||` instead of `??` — an empty-string USERNAME must also fall through
+  // (some CI / restricted shells set it blank, which would otherwise
+  // produce a syntactically invalid `:F` principal for icacls).
+  const username = (process.env.USERNAME?.trim() || process.env.USER?.trim());
+  if (!username) return; // cannot grant without a principal
+  // NOTE: For domain users, icacls resolves 'alice' to the domain account
+  // if no local account with that name exists. Explicit DOMAIN\user is
+  // unnecessary for the typical single-user install scenario.
+  try {
+    // /inheritance:r  — remove all inherited ACEs.
+    // /grant:r "<user>":F  — grant Full control, replacing prior grants
+    //   for the same principal (idempotent on re-runs).
+    await shell('icacls', [targetPath, '/inheritance:r', '/grant:r', `${username}:F`]);
+  } catch {
+    // Surfaced by the downstream scp/ssh error if it still fails.
+  }
+}
+
+/**
  * Ensure ~/.ssh/config exists and append the lox-vm entry if not present.
  */
 async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise<void> {
@@ -60,8 +93,12 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
   const sshDir = join(home, '.ssh');
   const configPath = join(sshDir, 'config');
 
-  if (!existsSync(sshDir)) {
+  const sshDirCreated = !existsSync(sshDir);
+  if (sshDirCreated) {
     mkdirSync(sshDir, { mode: 0o700, recursive: true });
+    // Only tighten ACLs if WE just created the dir. If it already existed,
+    // the user may have configured it themselves and we should not clobber.
+    await fixWindowsSshAcl(sshDir);
   }
 
   let existing = '';
@@ -70,7 +107,12 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
   }
 
   if (existing.includes('Host lox-vm')) {
-    // Already configured — skip
+    // Already configured — skip body write, but still ensure ACLs are
+    // correct on both the file AND the dir. On a re-run after a previous
+    // failed install, the config entry may be present but the ACLs may
+    // never have been fixed, and OpenSSH validates the parent dir too.
+    await fixWindowsSshAcl(sshDir);
+    await fixWindowsSshAcl(configPath);
     return;
   }
 
@@ -79,6 +121,7 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
   // Ensure correct permissions on SSH config
   const { chmodSync } = await import('node:fs');
   chmodSync(configPath, 0o600);
+  await fixWindowsSshAcl(configPath);
 }
 
 /**

--- a/packages/installer/src/utils/error-report.ts
+++ b/packages/installer/src/utils/error-report.ts
@@ -70,9 +70,14 @@ export function sanitize(text: string): string {
     '<REDACTED>@<REDACTED>.iam.gserviceaccount.com',
   );
 
-  // Windows user paths: C:\Users\<name>\
+  // Windows user paths: C:\Users\<name>\  OR  C:\Users\<name>/ (OpenSSH
+  // on Windows mixes separators, e.g. "C:\Users\alice/.ssh/config" in
+  // `scp` error output, so the terminator can be either \ or /).
+  // Usernames can contain spaces ("First Last"), so the class excludes
+  // only separators, not whitespace — the terminator `[\\/]` bounds the
+  // match so the greedy `+` cannot overshoot the username segment.
   result = result.replace(
-    /C:\\Users\\[^\\]+\\/gi,
+    /C:\\Users\\[^\\/]+[\\/]/gi,
     'C:\\Users\\<REDACTED>\\',
   );
 

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isMcpServerRegistered, buildMcpLauncherScript } from '../../src/steps/step-mcp.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl } from '../../src/steps/step-mcp.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -74,5 +74,94 @@ describe('buildMcpLauncherScript', () => {
   it('ends with a trailing newline', () => {
     const script = buildMcpLauncherScript('/home/lox/lox-brain');
     expect(script.endsWith('\n')).toBe(true);
+  });
+});
+
+describe("fixWindowsSshAcl (#83)", () => {
+  const originalPlatform = process.platform;
+  const originalUsername = process.env.USERNAME;
+  const originalUser = process.env.USER;
+
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    if (originalUsername === undefined) delete process.env.USERNAME;
+    else process.env.USERNAME = originalUsername;
+    if (originalUser === undefined) delete process.env.USER;
+    else process.env.USER = originalUser;
+  });
+
+  it("is a no-op on non-Windows platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    process.env.USERNAME = "alice";
+    await fixWindowsSshAcl("/home/alice/.ssh/config");
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it("runs icacls with /inheritance:r and /grant:r USERNAME:F on Windows", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.USERNAME = "alice";
+    vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
+    await fixWindowsSshAcl("C:\\Users\\alice\\.ssh\\config");
+    expect(shell).toHaveBeenCalledWith("icacls", [
+      "C:\\Users\\alice\\.ssh\\config",
+      "/inheritance:r",
+      "/grant:r",
+      "alice:F",
+    ]);
+  });
+
+  it("falls back to USER if USERNAME is unset (edge case)", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    delete process.env.USERNAME;
+    process.env.USER = "bob";
+    vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
+    await fixWindowsSshAcl("C:\\path");
+    expect(shell).toHaveBeenCalledWith("icacls", [
+      "C:\\path",
+      "/inheritance:r",
+      "/grant:r",
+      "bob:F",
+    ]);
+  });
+
+  it("treats an empty USERNAME env var as unset and falls back to USER", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.USERNAME = "";
+    process.env.USER = "alice";
+    vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
+    await fixWindowsSshAcl("C:\\path");
+    expect(shell).toHaveBeenCalledWith("icacls", [
+      "C:\\path",
+      "/inheritance:r",
+      "/grant:r",
+      "alice:F",
+    ]);
+  });
+
+  it("trims whitespace-only USERNAME/USER before treating as unset", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.USERNAME = "   ";
+    process.env.USER = "   ";
+    await fixWindowsSshAcl("C:\\path");
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when no username can be resolved", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    delete process.env.USERNAME;
+    delete process.env.USER;
+    await fixWindowsSshAcl("C:\\path");
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it("swallows icacls failures (best-effort)", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.USERNAME = "alice";
+    vi.mocked(shell).mockRejectedValue(new Error("icacls exited with code 1"));
+    await expect(fixWindowsSshAcl("C:\\path")).resolves.toBeUndefined();
   });
 });

--- a/packages/installer/tests/utils/error-report.test.ts
+++ b/packages/installer/tests/utils/error-report.test.ts
@@ -33,6 +33,34 @@ describe('sanitize', () => {
     expect(result).not.toContain('Eduardo');
   });
 
+  it('redacts Windows user paths even when the terminator is a forward slash (#83)', () => {
+    // OpenSSH on Windows emits paths with mixed separators, e.g.
+    // `C:\Users\alice/.ssh/config`. The redactor must still match.
+    const input = 'Bad owner or permissions on C:\\Users\\alice/.ssh/config';
+    const result = sanitize(input);
+    expect(result).not.toContain('alice');
+    expect(result).toContain('<REDACTED>');
+  });
+
+  it('redacts Windows usernames containing spaces', () => {
+    // Windows permits usernames with spaces like "First Last"; the
+    // redactor must not leak the surname after the space boundary.
+    const input = 'Bad owner or permissions on C:\\Users\\First Last\\.ssh\\config';
+    const result = sanitize(input);
+    expect(result).not.toContain('First');
+    expect(result).not.toContain('Last');
+    expect(result).toContain('<REDACTED>');
+  });
+
+  it('redacts Windows user paths from OpenSSH icacls hints', () => {
+    const input = 'Try removing permissions... on file C:/Users/bob/.ssh/config.';
+    const result = sanitize(input);
+    // Forward-slash-only C:/Users/... is covered by the unix home regex;
+    // the important assertion is that the username is gone.
+    expect(result).not.toContain('bob');
+    expect(result).toContain('<REDACTED>');
+  });
+
   it('redacts Windows user paths case-insensitively', () => {
     const input = 'c:\\users\\Lara\\Documents\\vault';
     const result = sanitize(input);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Fix Windows installer failing at step 12 with \`scp: Bad owner or permissions on C:\Users\<user>/.ssh/config\`.
- Root cause: OpenSSH on Windows strictly validates NTFS ACLs; new files inherit ACEs from %USERPROFILE% (e.g. "Owner Rights" SID S-1-3-4) that OpenSSH rejects. Node's \`chmodSync(path, 0o600)\` does not touch NTFS ACLs — it only maps loosely to POSIX mode bits.
- Fix: new \`fixWindowsSshAcl()\` runs \`icacls /inheritance:r /grant:r <USERNAME>:F\` on Windows after creating \`~/.ssh/\`, writing the config, or detecting an existing lox-vm entry on resume runs (both the file and the parent dir, since OpenSSH validates both).
- Secondary fix: the error-reporter's Windows user-path redactor missed mixed-separator paths (`C:\Users\alice/.ssh/...`) which leaked the username into the auto-report body of #83. Broadened to accept either `\\` or `/` as the terminator, and usernames with spaces.

Closes #83

## Test plan
- [x] 294 tests passing (+10 new)
- [x] \`tsc --noEmit\` clean
- [ ] Windows validation (Lara): confirm step 12 scp now succeeds after a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)