### PR TITLE
fix: retry transient SSH drops + persist state on throws (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-04-05
+
+### Fixed
+- Step 11 (Deploy) now retries transient SSH / IAP tunnel drops up to 3 times with 2s/4s backoff before failing (#87). GCP's IAP relay occasionally drops long-lived \`gcloud compute ssh --tunnel-through-iap\` connections mid-command (errors like "Remote side unexpectedly closed network connection", \`ECONNRESET\`, \`kex_exchange_identification\`, IAP \`4003\`/\`4033\` codes), which previously failed the install on any flake. Non-transient errors (permission, missing script, quota) still fail immediately without wasted retries.
+- The main installer loop now catches thrown exceptions from any step and persists state (failed_step) before re-throwing, so the v0.5.0 resume prompt can offer to restart from the exact step that threw. Previously only returned \`{success: false}\` failures saved state; throws bubbled up without a resumable checkpoint.
+
+
 ## [0.6.0] — 2026-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -84,7 +84,20 @@ async function main(): Promise<void> {
 
   for (const step of STEPS) {
     if (step.num < startFromStep) continue;
-    const result = await step.fn(ctx);
+    let result: Awaited<ReturnType<typeof step.fn>>;
+    try {
+      result = await step.fn(ctx);
+    } catch (err) {
+      // Thrown exceptions (e.g. transient SSH drops from runRemoteScript
+      // after exhausting retries) must also persist state so the v0.5.0
+      // resume prompt can offer to restart from this exact step (#87).
+      // Save first, then re-throw so the existing outer handler still
+      // offers the error report and exits.
+      try {
+        saveState(ctx, step.num - 1, step.num, LOX_VERSION);
+      } catch { /* best-effort */ }
+      throw err;
+    }
     if (!result.success) {
       await handleStepFailure(step.name, step.num, result.message, ctx);
     }

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -135,6 +135,41 @@ export function buildMcpHealthProbeScript(installDir: string): string {
 }
 
 /**
+ * Patterns that indicate a transient SSH / IAP tunnel drop worth retrying.
+ * Sourced from real install failures and the gcloud / OpenSSH error corpus.
+ * Matched against the full error message (case-insensitive).
+ */
+const RETRYABLE_SSH_PATTERNS: readonly RegExp[] = [
+  /Remote side unexpectedly closed/i,
+  /Connection reset by peer/i,
+  /ECONNRESET/,
+  /kex_exchange_identification/i,
+  /Connection closed by remote host/i,
+  // GCP IAP tunnel closed by the relay (4003 = idle, 4033 = peer-closed).
+  // Anchor the IAP codes to avoid matching bare numbers in unrelated output.
+  /4003: The connection to the (instance|remote host) ended/i,
+  /\b4033\b.*tunnel|IAP.*\b4033\b/i,
+  /IAP Desktop.*tunnel/i,
+  /Operation timed out/i,
+  /Handshake failed/i,
+  // NOTE: "Connection refused" is deliberately NOT in this set. It
+  // usually means sshd is genuinely unavailable (VM stopped / booting /
+  // SSH disabled), and retrying 3× would just waste ~6s before surfacing
+  // the real problem to the user.
+];
+
+/**
+ * Return true if `err` looks like a transient SSH/IAP drop that's safe to
+ * retry. Exported for unit testing.
+ */
+export function isRetryableSshError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return RETRYABLE_SSH_PATTERNS.some((re) => re.test(msg));
+}
+
+const RETRY_DELAYS_MS: readonly number[] = [2_000, 4_000];
+
+/**
  * Write `script` to a local temp file, scp it to the VM via IAP, execute it
  * with `bash /tmp/lox-deploy-<phase>.sh`, and clean the local temp file.
  *
@@ -142,6 +177,10 @@ export function buildMcpHealthProbeScript(installDir: string): string {
  * metacharacters leak through cmd.exe on Windows (#61). The local path lives
  * in os.tmpdir() and is always absolute (#64). Returns captured stdout so
  * callers can inspect script output (used by the MCP health probe).
+ *
+ * Retries up to 3 times on transient IAP tunnel drops (#87). Each retry
+ * re-scps the script (cheap) and re-runs the ssh command. Non-transient
+ * errors (script bugs, auth failures, quota) fail immediately without retry.
  */
 async function runRemoteScript(
   projectId: string,
@@ -171,23 +210,42 @@ async function runRemoteScript(
   writeFileSync(localPath, scriptWithCleanup, { mode: 0o600 });
 
   try {
-    await shell('gcloud', [
-      'compute', 'scp',
-      '--project', projectId,
-      '--zone', zone,
-      '--tunnel-through-iap',
-      localPath, `${vmName}:${remotePath}`,
-    ], { timeout });
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+      try {
+        await shell('gcloud', [
+          'compute', 'scp',
+          '--project', projectId,
+          '--zone', zone,
+          '--tunnel-through-iap',
+          localPath, `${vmName}:${remotePath}`,
+        ], { timeout });
 
-    const { stdout } = await shell('gcloud', [
-      'compute', 'ssh', vmName,
-      '--project', projectId,
-      '--zone', zone,
-      '--tunnel-through-iap',
-      '--command', `bash ${remotePath}`,
-    ], { timeout });
+        const { stdout } = await shell('gcloud', [
+          'compute', 'ssh', vmName,
+          '--project', projectId,
+          '--zone', zone,
+          '--tunnel-through-iap',
+          '--command', `bash ${remotePath}`,
+        ], { timeout });
 
-    return stdout;
+        return stdout;
+      } catch (err) {
+        lastErr = err;
+        if (!isRetryableSshError(err) || attempt >= RETRY_DELAYS_MS.length) {
+          throw err;
+        }
+        const delay = RETRY_DELAYS_MS[attempt]!;
+        console.log(
+          chalk.yellow(
+            `  ⚠ SSH/IAP drop on phase "${phaseName}" (attempt ${attempt + 1}). Retrying in ${delay / 1000}s...`,
+          ),
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+    // Unreachable — the loop either returns or throws, but TS cannot infer it.
+    throw lastErr;
   } finally {
     try { rmSync(localPath, { force: true }); } catch { /* best-effort */ }
   }

--- a/packages/installer/tests/steps/step-deploy.test.ts
+++ b/packages/installer/tests/steps/step-deploy.test.ts
@@ -9,6 +9,7 @@ import {
   buildMcpHealthProbeScript,
   parseVmIdentity,
   buildIdentityProbeScript,
+  isRetryableSshError,
 } from '../../src/steps/step-deploy.js';
 
 describe('buildCloneScript', () => {
@@ -166,5 +167,79 @@ describe('buildWatcherService', () => {
     const unit = buildWatcherService('alice', '/opt/lox');
     expect(unit).toContain('User=alice');
     expect(unit).toContain('WorkingDirectory=/opt/lox');
+  });
+});
+
+describe('isRetryableSshError (#87)', () => {
+  it('flags "Remote side unexpectedly closed" as retryable', () => {
+    expect(isRetryableSshError(new Error(
+      'Command failed: gcloud compute ssh ...\nFATAL ERROR: Remote side unexpectedly closed network connection',
+    ))).toBe(true);
+  });
+
+  it('flags ECONNRESET as retryable', () => {
+    expect(isRetryableSshError(new Error('read ECONNRESET'))).toBe(true);
+  });
+
+  it('flags "Connection reset by peer" as retryable', () => {
+    expect(isRetryableSshError(new Error('ssh: Connection reset by peer'))).toBe(true);
+  });
+
+  it('does NOT flag "Connection refused" (usually sshd down, not transient)', () => {
+    expect(isRetryableSshError(new Error('ssh: connect to host foo port 22: Connection refused'))).toBe(false);
+  });
+
+  it('flags "kex_exchange_identification" as retryable', () => {
+    expect(isRetryableSshError(new Error(
+      'kex_exchange_identification: Connection closed by remote host',
+    ))).toBe(true);
+  });
+
+  it('flags the IAP 4003 tunnel-closed code as retryable', () => {
+    expect(isRetryableSshError(new Error(
+      'ERROR: 4003: The connection to the instance ended unexpectedly.',
+    ))).toBe(true);
+  });
+
+  it('flags the IAP 4033 code when it appears in a tunnel-context message', () => {
+    expect(isRetryableSshError(new Error('IAP Desktop 4033: tunnel closed'))).toBe(true);
+    expect(isRetryableSshError(new Error('ERROR: 4033 tunnel connection failed'))).toBe(true);
+  });
+
+  it('does NOT flag a bare "4033" appearing in unrelated output', () => {
+    // The anchored pattern rejects plain 4033 that is just an exit code
+    // or port number with no IAP/tunnel context (review fix).
+    expect(isRetryableSshError(new Error('build failed: test-id-4033 exited 1'))).toBe(false);
+    expect(isRetryableSshError(new Error('npm ERR! 4033'))).toBe(false);
+  });
+
+  it('flags "Operation timed out" as retryable', () => {
+    expect(isRetryableSshError(new Error('ssh: connect: Operation timed out'))).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isRetryableSshError(new Error('REMOTE SIDE UNEXPECTEDLY CLOSED'))).toBe(true);
+  });
+
+  it('does NOT flag permission errors', () => {
+    expect(isRetryableSshError(new Error('Permission denied (publickey)'))).toBe(false);
+  });
+
+  it('does NOT flag "command not found" / script errors', () => {
+    expect(isRetryableSshError(new Error('bash: /tmp/lox-deploy.sh: No such file or directory'))).toBe(false);
+  });
+
+  it('does NOT flag arbitrary stderr output', () => {
+    expect(isRetryableSshError(new Error('npm ERR! code E404'))).toBe(false);
+  });
+
+  it('handles non-Error thrown values (string)', () => {
+    expect(isRetryableSshError('read ECONNRESET')).toBe(true);
+    expect(isRetryableSshError('arbitrary string')).toBe(false);
+  });
+
+  it('handles null and undefined without throwing', () => {
+    expect(isRetryableSshError(null)).toBe(false);
+    expect(isRetryableSshError(undefined)).toBe(false);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Step 11's \`runRemoteScript\` now retries up to 3 times (2s/4s backoff) on transient SSH/IAP drops. GCP's IAP relay occasionally drops long-lived \`gcloud compute ssh --tunnel-through-iap\` connections mid-command, which previously failed the install on any single flake.
- Retryable patterns: "Remote side unexpectedly closed", \`ECONNRESET\`, "Connection reset by peer", \`kex_exchange_identification\`, IAP 4003/4033 codes, "Operation timed out", "Handshake failed".
- Non-transient errors (permission, missing file, quota, "Connection refused") fail fast without wasted retries.
- Main installer loop now catches thrown exceptions from any step and persists state (\`failed_step\`) before re-throwing, so the v0.5.0 resume prompt can offer to restart from the exact step that threw. Previously only \`{success: false}\` returns saved state.

Closes #87

## Test plan
- [x] 327 tests passing (+15 new for \`isRetryableSshError\`)
- [x] \`tsc --noEmit\` clean
- [ ] Windows validation (Lara): confirm step 11 recovers from a transient IAP drop on retry; confirm re-running \`lox\` after a genuine throw now offers to resume from step 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)