### PR TITLE
fix: accept installer state across Lox versions (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.3] — 2026-04-05
+
+### Fixed
+- Installer resume now works across Lox releases (#92). Previously `loadState` strict-rejected any saved state whose `lox_version` did not match the currently running installer, so re-running `irm .../install.ps1 | iex` after a new release shipped (install.ps1 always pulls the latest tarball) silently skipped the resume prompt and restarted from step 1. `schema_version` — bumped whenever `InstallerContext` changes shape — is now the sole compatibility gate. The `lox_version` field stays in the state file (and is shown in the resume-prompt summary as "Saved: … (Lox vX.Y.Z)") so the user can see when state comes from a previous release.
+
+
 ## [0.6.2] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
   // Check for a resumable previous installation before asking for language —
   // we reuse the saved locale so the resume prompt appears in the user's
   // chosen language without re-asking (#81).
-  const savedState = loadState(LOX_VERSION);
+  const savedState = loadState();
   if (savedState) {
     setLocale(savedState.ctx.locale);
     ctx = savedState.ctx;

--- a/packages/installer/src/state.ts
+++ b/packages/installer/src/state.ts
@@ -21,7 +21,12 @@ export interface InstallerState {
   failed_step: number | null;
   /** ISO 8601 timestamp of when this state was written. */
   timestamp: string;
-  /** Lox version that produced this state — state is rejected on version mismatch. */
+  /** Lox version that produced this state. Informational only — kept for
+   * the resume-prompt UI and debugging. The real compatibility gate is
+   * `schema_version`, which is bumped whenever `InstallerContext` changes
+   * shape. This lets a user who failed on vX.Y.Z and re-ran `install.ps1`
+   * (which always fetches the latest tarball) resume their install on
+   * vX.Y.Z+1 instead of starting from step 1. See #92. */
   lox_version: string;
   /** Serialized installer context, minus any transient fields. */
   ctx: InstallerContext;
@@ -70,9 +75,16 @@ export function saveState(
 
 /**
  * Load and validate installer state. Returns null if the file is missing,
- * unreadable, malformed, or belongs to a different schema/version.
+ * unreadable, malformed, or belongs to a different `schema_version`.
+ *
+ * `lox_version` is NOT a compatibility gate — see #92. `install.ps1` always
+ * downloads the latest tarball, so a user who failed on vX.Y.Z and re-ran
+ * `irm .../install.ps1 | iex` is now running vX.Y.Z+1 with state saved by
+ * vX.Y.Z. Rejecting on version mismatch would silently skip the resume
+ * prompt on every cross-release recovery. `schema_version` is the real
+ * gate, bumped whenever `InstallerContext` changes shape.
  */
-export function loadState(expectedLoxVersion: string): InstallerState | null {
+export function loadState(): InstallerState | null {
   const statePath = getStatePath();
   if (!existsSync(statePath)) return null;
   let raw: string;
@@ -89,7 +101,6 @@ export function loadState(expectedLoxVersion: string): InstallerState | null {
   }
   if (!isInstallerState(parsed)) return null;
   if (parsed.schema_version !== STATE_SCHEMA_VERSION) return null;
-  if (parsed.lox_version !== expectedLoxVersion) return null;
   return parsed;
 }
 

--- a/packages/installer/src/ui/resume-prompt.ts
+++ b/packages/installer/src/ui/resume-prompt.ts
@@ -62,7 +62,11 @@ export function renderResumeSummary(state: InstallerState): string[] {
   if (state.failed_step !== null) {
     lines.push(`  ${strings.resume_failed_at}: ${stepLabel(state.failed_step)}`);
   }
-  lines.push(`  ${strings.resume_saved_at}: ${state.timestamp}`);
+  // Include lox_version so the user can tell when saved state came from a
+  // different release than the installer they're currently running (#92).
+  // "(Lox vX.Y.Z)" is an untranslated product-version token on purpose —
+  // the product name and SemVer format are the same in every locale.
+  lines.push(`  ${strings.resume_saved_at}: ${state.timestamp} (Lox v${state.lox_version})`);
   return lines;
 }
 

--- a/packages/installer/tests/state.test.ts
+++ b/packages/installer/tests/state.test.ts
@@ -63,7 +63,7 @@ describe('installer state persistence', () => {
   it('saveState creates ~/.lox/ if missing and round-trips with loadState', () => {
     const ctx = makeCtx();
     saveState(ctx, 5, null, FAKE_VERSION);
-    const loaded = loadState(FAKE_VERSION);
+    const loaded = loadState();
     expect(loaded).not.toBeNull();
     expect(loaded!.schema_version).toBe(STATE_SCHEMA_VERSION);
     expect(loaded!.last_completed_step).toBe(5);
@@ -92,19 +92,42 @@ describe('installer state persistence', () => {
   });
 
   it('loadState returns null when the file does not exist', () => {
-    expect(loadState(FAKE_VERSION)).toBeNull();
+    expect(loadState()).toBeNull();
   });
 
   it('loadState returns null for malformed JSON', () => {
     const statePath = getStatePath();
     mkdirSync(path.dirname(statePath), { recursive: true });
     writeFileSync(statePath, '{ not valid json');
-    expect(loadState(FAKE_VERSION)).toBeNull();
+    expect(loadState()).toBeNull();
   });
 
-  it('loadState rejects state from a different lox_version', () => {
-    saveState(makeCtx(), 1, null, '0.4.5');
-    expect(loadState('0.4.6')).toBeNull();
+  it('loadState accepts state from a different lox_version (patch bump)', () => {
+    // State written by 0.6.1 must still load on 0.6.2 — install.ps1 always
+    // pulls the latest tarball, so every cross-release re-run looks like a
+    // version mismatch. schema_version is the real gate. See #92.
+    saveState(makeCtx(), 1, null, '0.6.1');
+    const loaded = loadState();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.lox_version).toBe('0.6.1');
+    expect(loaded!.last_completed_step).toBe(1);
+  });
+
+  it('loadState accepts state from a different lox_version (minor bump)', () => {
+    // Matches the Lara-upgrade path 0.5.0 → 0.6.0. Minor bumps do not change
+    // InstallerContext shape (schema_version is still 1).
+    saveState(makeCtx(), 3, 4, '0.5.0');
+    const loaded = loadState();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.lox_version).toBe('0.5.0');
+    expect(loaded!.failed_step).toBe(4);
+  });
+
+  it('loadState accepts state from the same lox_version', () => {
+    saveState(makeCtx(), 2, null, FAKE_VERSION);
+    const loaded = loadState();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.lox_version).toBe(FAKE_VERSION);
   });
 
   it('loadState rejects state with a stale schema_version', () => {
@@ -118,14 +141,14 @@ describe('installer state persistence', () => {
       lox_version: FAKE_VERSION,
       ctx: makeCtx(),
     }));
-    expect(loadState(FAKE_VERSION)).toBeNull();
+    expect(loadState()).toBeNull();
   });
 
   it('loadState rejects state with missing required fields', () => {
     const statePath = getStatePath();
     mkdirSync(path.dirname(statePath), { recursive: true });
     writeFileSync(statePath, JSON.stringify({ schema_version: 1 }));
-    expect(loadState(FAKE_VERSION)).toBeNull();
+    expect(loadState()).toBeNull();
   });
 
   it('clearState removes the file and is a no-op when already absent', () => {
@@ -139,14 +162,14 @@ describe('installer state persistence', () => {
 
   it('saveState records failed_step when a step errored', () => {
     saveState(makeCtx(), 10, 11, FAKE_VERSION);
-    const loaded = loadState(FAKE_VERSION);
+    const loaded = loadState();
     expect(loaded!.last_completed_step).toBe(10);
     expect(loaded!.failed_step).toBe(11);
   });
 
   it('persists vmUser and vmHome so the next run can skip SSH probe', () => {
     saveState(makeCtx(), 11, 12, FAKE_VERSION);
-    const loaded = loadState(FAKE_VERSION);
+    const loaded = loadState();
     // These fields carry the fix from #79 across runs so step-mcp
     // does not reprobe identity when resuming.
     expect(loaded!.ctx.vmUser).toBe('demo_example_com');
@@ -157,13 +180,13 @@ describe('installer state persistence', () => {
     const ctx = makeCtx();
     ctx.config.gcp = { project: 'p', region: 'r', zone: 'z', vm_name: 'v', service_account: 'sa' };
     saveState(ctx, 6, null, FAKE_VERSION);
-    const loaded = loadState(FAKE_VERSION);
+    const loaded = loadState();
     expect(loaded!.ctx.config.gcp).toEqual(ctx.config.gcp);
   });
 
   it('timestamp is a parseable ISO 8601 string', () => {
     saveState(makeCtx(), 1, null, FAKE_VERSION);
-    const loaded = loadState(FAKE_VERSION);
+    const loaded = loadState();
     expect(Number.isNaN(Date.parse(loaded!.timestamp))).toBe(false);
   });
 

--- a/packages/installer/tests/ui/resume-prompt.test.ts
+++ b/packages/installer/tests/ui/resume-prompt.test.ts
@@ -66,6 +66,13 @@ describe('renderResumeSummary', () => {
     expect(out).toContain('Step 11');
   });
 
+  it('includes the lox_version so the user sees when state is cross-release', () => {
+    // After #92 state is no longer version-gated; surfacing the version
+    // in the summary lets the user notice 0.5.0 state loaded into 0.6.x.
+    const out = renderResumeSummary(makeState({ lox_version: '0.5.0' })).join('\n');
+    expect(out).toContain('Lox v0.5.0');
+  });
+
   it('omits the "failed at" line when there is no failure', () => {
     const out = renderResumeSummary(makeState({ last_completed_step: 5, failed_step: null })).join('\n');
     // English label — the test runs with default locale 'en'.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- `loadState` no longer strict-rejects saved state on `lox_version` mismatch — `schema_version` is now the sole compatibility gate
- Resume-prompt summary now surfaces the saved `lox_version` as `(Lox vX.Y.Z)` so the user can see when state came from a different release
- v0.5.0 resume feature now actually works across releases (the common case: `install.ps1` always fetches the latest tarball, so every cross-release re-run is a version mismatch)

Closes #92

## Why

Lara's installer went 0.4.5 → 0.5.0 → 0.5.1 → 0.6.1 → 0.6.2 across 4 re-runs this week. The resume feature shipped in v0.5.0 to help recover from mid-install failures, but it was silently bypassed on every single re-run because `loadState` rejected the state file on `lox_version !== expectedLoxVersion`. `schema_version` (already in place, bumped whenever `InstallerContext` shape changes) is the correct gate — `lox_version` was over-strict for patch/minor bumps.

## Test plan

- [x] Unit tests cover same-version, patch-bump, and minor-bump loads
- [x] Unit test asserts stale `schema_version` is still rejected (unchanged behavior)
- [x] Unit test asserts `lox_version` is rendered in the resume summary
- [x] All 337 installer tests pass
- [x] `tsc --noEmit` clean on all 3 project configs
- [ ] Windows smoke test: Lara re-runs `install.ps1` on 0.6.3, hits a failure on some step, re-runs again on a hypothetical 0.6.4 — resume prompt appears and shows `(Lox v0.6.3)` in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)