### PR TITLE
fix: preflight VPN connectivity in step 12 (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-04-05
+
+### Fixed
+- Step 12 (MCP Server) now detects an inactive WireGuard VPN tunnel before attempting the launcher upload (#93). Previously the raw `scp lox-vm:...` would hang until its 60s timeout and then surface as an unhandled exception ("Connection timed out" to the VPN IP), leaving the user with a stack trace. A fast TCP preflight probe to `vpn_server_ip:22` now runs first: if the tunnel isn't up, step 12 returns a clean failure with platform-aware activation guidance (Windows: WireGuard GUI app → import client config → Activate; macOS: GUI or `sudo wg-quick up ~/.config/lox/wireguard/wg0.conf`; Linux: `sudo wg-quick up …`). Combined with the resume feature (#81/#92), the user activates WireGuard and re-runs — step 12 picks up where it left off.
+
+
 ## [0.6.3] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { shell } from '../utils/shell.js';
+import { probeTcp } from '../utils/net-probe.js';
 import { t } from '../i18n/index.js';
 import { renderStepHeader } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
@@ -7,6 +8,39 @@ import type { InstallerContext, StepResult } from './types.js';
 import { ensureVmIdentity } from './step-deploy.js';
 
 const TOTAL_STEPS = 12;
+
+/**
+ * Build a platform-aware guidance message shown when the VPN preflight
+ * fails. Exported for tests. Kept in English to match other step failure
+ * messages in the installer (`'GCP project... Run step 3 first.'` etc.).
+ */
+export function buildVpnUnreachableMessage(vpnServerIp: string, platform: NodeJS.Platform): string {
+  const activation =
+    platform === 'win32'
+      ? '  • Open the WireGuard app, import your client config from\n'
+        + '    %USERPROFILE%\\.config\\lox\\wireguard\\wg0.conf, then click Activate.'
+      : platform === 'darwin'
+        ? '  • Open the WireGuard app (or run `sudo wg-quick up ~/.config/lox/wireguard/wg0.conf`).'
+        // Unix fallback: Linux, FreeBSD, OpenBSD, etc. all share wg-quick.
+        : '  • Run: sudo wg-quick up ~/.config/lox/wireguard/wg0.conf';
+  return [
+    `Cannot reach the VM over the WireGuard VPN (${vpnServerIp}:22).`,
+    '',
+    'The VPN tunnel is not active. To fix:',
+    activation,
+    '  • Verify the WireGuard client is connected, then re-run the installer.',
+    '    The resume prompt will offer to continue from step 12.',
+  ].join('\n');
+}
+
+/**
+ * Check that the VPN server is reachable on port 22. Kept as a thin
+ * wrapper so callers/tests don't need to hardcode the timeout or port.
+ * Returns true if a TCP handshake completes within 5s.
+ */
+export async function isVpnReachable(vpnServerIp: string): Promise<boolean> {
+  return probeTcp(vpnServerIp, 22, 5000);
+}
 
 /**
  * Build the SSH config entry for the lox-vm host.
@@ -154,7 +188,26 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
   const strings = t();
   console.log(renderStepHeader(12, TOTAL_STEPS, strings.step_mcp));
 
+  // VPN preflight FIRST (#93). Everything downstream in this step — the
+  // scp upload and the `ssh lox-vm chmod` call — rides the WireGuard
+  // tunnel to `vpnServerIp`. If the client tunnel isn't active, scp
+  // hangs until its 60s timeout and surfaces as an unhandled exception.
+  // A fast TCP probe converts that into a clean, recoverable
+  // {success: false} — the resume feature then lets the user activate
+  // WireGuard and continue from step 12. Runs before any VM identity
+  // work so the user hits the failure (and VPN guidance) in <5s.
+  // Fallback IP matches VPN_SERVER_IP in step-vpn.ts — used only when
+  // step 12 runs standalone and ctx.config.vpn wasn't populated.
   const vpnServerIp = ctx.config.vpn?.server_ip ?? '10.10.0.1';
+  const vpnUp = await withSpinner(
+    `Verifying VPN connectivity to ${vpnServerIp}...`,
+    () => isVpnReachable(vpnServerIp),
+  );
+  if (!vpnUp) {
+    return { success: false, message: buildVpnUnreachableMessage(vpnServerIp, process.platform) };
+  }
+  console.log(chalk.green(`  ✓ VPN reachable (${vpnServerIp}:22)`));
+
   // Reuse the identity resolved in step-deploy (#79). If this step runs
   // standalone (e.g. re-run after a failed step 12), probe the VM directly —
   // the email-prefix derivation would reintroduce the original bug.

--- a/packages/installer/src/utils/net-probe.ts
+++ b/packages/installer/src/utils/net-probe.ts
@@ -1,0 +1,40 @@
+import { createConnection, type Socket } from 'node:net';
+
+/**
+ * Probe whether a TCP port is reachable on `host`. Returns true if the
+ * connection handshake completes within `timeoutMs`, false otherwise.
+ *
+ * Used by step 12 to detect whether the WireGuard VPN tunnel is actually
+ * up before attempting `scp lox-vm:...` — a raw scp against an inactive
+ * tunnel hangs until its own timeout (60s) and then surfaces as an
+ * unhandled exception (#93). A fast TCP probe converts that into a
+ * clean, recoverable "VPN unreachable" signal before we start the scp.
+ *
+ * Never throws — any socket error is normalized to `false`. Callers
+ * receive a boolean and decide how to present the failure.
+ */
+export function probeTcp(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: boolean, socket: Socket): void => {
+      if (settled) return;
+      settled = true;
+      // destroy() is a no-op if the socket is already closed; safe to call
+      // from any of the three terminal branches (connect / error / timeout).
+      socket.destroy();
+      resolve(result);
+    };
+
+    // `timeout` in the options object arms the timer BEFORE the connect
+    // attempt starts, avoiding a theoretical race between createConnection
+    // and a separate setTimeout() call.
+    const socket = createConnection({ host, port, timeout: timeoutMs });
+    socket.once('connect', () => finish(true, socket));
+    socket.once('timeout', () => finish(false, socket));
+    // The 'error' listener is mandatory even though `settled` would ignore
+    // late errors: socket.destroy() can itself emit a follow-up 'error'
+    // event (ECONNRESET, etc.) on some Node versions, and an uncaught
+    // 'error' on a Socket crashes the process. Do NOT remove this line.
+    socket.once('error', () => finish(false, socket));
+  });
+}

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl } from '../../src/steps/step-mcp.js';
+import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl, buildVpnUnreachableMessage } from '../../src/steps/step-mcp.js';
 import { shell } from '../../src/utils/shell.js';
 
 vi.mock('../../src/utils/shell.js', () => ({
@@ -74,6 +74,52 @@ describe('buildMcpLauncherScript', () => {
   it('ends with a trailing newline', () => {
     const script = buildMcpLauncherScript('/home/lox/lox-brain');
     expect(script.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('buildVpnUnreachableMessage (#93)', () => {
+  it('names the unreachable VPN endpoint so the user knows what to activate', () => {
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'linux');
+    expect(msg).toContain('10.10.0.1:22');
+    expect(msg).toContain('WireGuard VPN');
+  });
+
+  it('gives Windows users GUI-flavored activation instructions', () => {
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'win32');
+    expect(msg).toContain('WireGuard app');
+    expect(msg).toContain('Activate');
+    // Reference the Windows-native path using env var, not a user-absolute path.
+    expect(msg).toContain('%USERPROFILE%');
+    // Must not leak a Unix-style activation command to Windows users.
+    expect(msg).not.toContain('wg-quick up');
+  });
+
+  it('tells Linux users to run wg-quick up', () => {
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'linux');
+    expect(msg).toContain('wg-quick up');
+    expect(msg).toContain('~/.config/lox/wireguard/wg0.conf');
+  });
+
+  it('tells macOS users about both the GUI and wg-quick', () => {
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'darwin');
+    expect(msg).toMatch(/WireGuard app/);
+    expect(msg).toContain('wg-quick up');
+  });
+
+  it('falls through to the Unix wg-quick message on unknown platforms', () => {
+    // process.platform is typed as NodeJS.Platform (freebsd, openbsd, etc.).
+    // Anything that isn't win32/darwin must use the wg-quick fallback —
+    // don't let the darwin branch accidentally become the catch-all.
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'freebsd' as NodeJS.Platform);
+    expect(msg).toContain('sudo wg-quick up');
+    expect(msg).not.toContain('WireGuard app');
+  });
+
+  it('points the user at the resume prompt for recovery (#81/#92)', () => {
+    const msg = buildVpnUnreachableMessage('10.10.0.1', 'win32');
+    expect(msg).toMatch(/re-run the installer/i);
+    expect(msg).toMatch(/resume/i);
+    expect(msg).toContain('step 12');
   });
 });
 

--- a/packages/installer/tests/utils/net-probe.test.ts
+++ b/packages/installer/tests/utils/net-probe.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:net';
+import { probeTcp } from '../../src/utils/net-probe.js';
+
+describe('probeTcp', () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  it('returns true when a local server accepts the connection', async () => {
+    server = createServer((socket) => socket.end());
+    const port = await new Promise<number>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => {
+        const addr = server!.address();
+        if (typeof addr === 'object' && addr !== null) resolve(addr.port);
+        else throw new Error('unexpected address');
+      });
+    });
+    expect(await probeTcp('127.0.0.1', port, 2000)).toBe(true);
+  });
+
+  it('returns false when the target port is closed (connection refused)', async () => {
+    // Port 1 is not a listening service on any sane machine. ECONNREFUSED
+    // is emitted almost instantly on localhost — no need for a long timeout.
+    expect(await probeTcp('127.0.0.1', 1, 2000)).toBe(false);
+  });
+
+  it('returns false within the timeout when the host silently drops packets', async () => {
+    // TEST-NET-1 (RFC 5737): documentation-only range, guaranteed not to
+    // route anywhere. Connect attempts hang until timeout — mimics the
+    // exact failure mode of a down WireGuard tunnel (#93).
+    const started = Date.now();
+    const result = await probeTcp('192.0.2.1', 22, 300);
+    const elapsed = Date.now() - started;
+    expect(result).toBe(false);
+    // Allow generous slack for slow CI; the key property is that we time
+    // out rather than hanging for the default socket timeout (minutes).
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('returns false for an unresolvable hostname', async () => {
+    expect(await probeTcp('nonexistent.invalid.', 22, 2000)).toBe(false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Step 12 (MCP Server) now runs a 5s TCP preflight probe to `vpn_server_ip:22` **before** any VM identity work or scp upload
- If the WireGuard tunnel is inactive the step returns `{success: false}` with platform-aware activation guidance (Windows GUI / macOS GUI+wg-quick / Linux wg-quick)
- Combined with the resume feature (#81/#92), the user activates WireGuard and re-runs — step 12 picks up cleanly from where it failed

Closes #93

## Why

Previously `scp lox-vm:...` would hang until its own 60s timeout and surface as an unhandled exception ("Connection timed out" to 10.10.0.1). The user saw a stack trace instead of "your VPN isn't active, here's how to turn it on." This is the scenario Lara hit on Windows — she needs to import the client config into the WireGuard app and click Activate, and the installer never told her.

## Test plan

- [x] `probeTcp` utility unit tests: connect-accepted, connection-refused, timeout (RFC 5737 192.0.2.1), unresolvable hostname
- [x] `buildVpnUnreachableMessage` tests: IP included, Windows GUI guidance, Linux `wg-quick up`, macOS (both), resume-prompt hint, unknown-platform Unix fallback
- [x] 347 tests passing (was 337 baseline)
- [x] `tsc --noEmit` clean on all 3 project configs
- [ ] Windows smoke test: Lara re-runs installer, if WireGuard not active, step 12 shows the GUI activation hint within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)