### PR TITLE
fix: skip bug-report prompt on user-actionable step failures (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-04-05
+
+### Fixed
+- User-actionable step failures (like the VPN-not-active check from #93) no longer trigger the "Would you like to report this issue on GitHub?" prompt (#96). Previously any `{success: false}` return from a step caused `handleStepFailure` to offer an auto-report, even for conditions the user could fix themselves (WireGuard not activated, missing prerequisite, etc.), leading to GitHub issues being filed for expected recoverable states. Steps can now mark failures with `actionable: true` to skip the bug-report prompt while still persisting state for resume and printing the guidance message. Applied to the step 12 VPN preflight for now; a follow-up pass will audit other `{success: false}` returns (prerequisites, GCP config missing, etc.).
+
+### Changed
+- Extracted `handleStepFailure` from `src/index.ts` into `src/step-failure.ts` with injected dependencies so the failure-handling logic is directly unit-testable.
+
+
 ## [0.6.4] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -4,7 +4,8 @@ import { renderSplash } from './ui/splash.js';
 import { stepLanguage } from './steps/step-language.js';
 import { runPostInstall } from './steps/step-post-install.js';
 import { STEPS } from './steps/registry.js';
-import { offerErrorReport, extractSubPhase, sourceFileForStep } from './utils/error-report.js';
+import { offerErrorReport } from './utils/error-report.js';
+import { handleStepFailure as handleStepFailureExternal } from './step-failure.js';
 import { formatFatalError } from './utils/format-error.js';
 import { LOX_VERSION } from '@lox-brain/shared';
 import { setLocale, t } from './i18n/index.js';
@@ -12,29 +13,19 @@ import { loadState, saveState, clearState } from './state.js';
 import { promptResume, stepLabel } from './ui/resume-prompt.js';
 import type { InstallerContext } from './steps/types.js';
 
-async function handleStepFailure(
+function handleStepFailure(
   stepName: string,
   stepNum: number,
   message: string | undefined,
   ctx: InstallerContext,
+  actionable: boolean = false,
 ): Promise<never> {
-  // Persist state so the user can resume from this step on the next run.
-  try {
-    saveState(ctx, stepNum - 1, stepNum, LOX_VERSION);
-  } catch {
-    // Non-fatal: state write is a convenience, not a correctness requirement.
-  }
-  console.error(`\n${message ?? 'Unknown error'}`);
-  await offerErrorReport({
-    stepName,
-    errorMessage: message ?? 'Unknown error',
-    subPhase: extractSubPhase(message ?? ''),
-    sourceFile: sourceFileForStep(stepName),
+  return handleStepFailureExternal(stepName, stepNum, message, ctx, actionable, {
     loxVersion: LOX_VERSION,
-    os: `${process.platform} ${process.arch}`,
+    platform: process.platform,
+    arch: process.arch,
     nodeVersion: process.version,
   });
-  process.exit(1);
 }
 
 async function main(): Promise<void> {
@@ -99,7 +90,7 @@ async function main(): Promise<void> {
       throw err;
     }
     if (!result.success) {
-      await handleStepFailure(step.name, step.num, result.message, ctx);
+      await handleStepFailure(step.name, step.num, result.message, ctx, result.actionable);
     }
     // Persist progress after every successful step so a crash mid-run
     // leaves a resumable state file.

--- a/packages/installer/src/step-failure.ts
+++ b/packages/installer/src/step-failure.ts
@@ -1,0 +1,55 @@
+import { saveState } from './state.js';
+import { offerErrorReport, extractSubPhase, sourceFileForStep } from './utils/error-report.js';
+import type { InstallerContext } from './steps/types.js';
+
+/**
+ * Dependencies injected by the main installer loop. Extracted so the
+ * failure-handling logic can be unit-tested without driving the full
+ * installer flow.
+ */
+export interface StepFailureDeps {
+  loxVersion: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  nodeVersion: string;
+}
+
+/**
+ * Handle a step failure: persist state for the resume feature, print the
+ * guidance message, optionally offer to auto-report the failure to GitHub,
+ * and exit. User-actionable failures (`actionable: true`) skip the report
+ * prompt since they aren't installer bugs — just states the user can fix
+ * and retry (see #96).
+ */
+export async function handleStepFailure(
+  stepName: string,
+  stepNum: number,
+  message: string | undefined,
+  ctx: InstallerContext,
+  actionable: boolean,
+  deps: StepFailureDeps,
+): Promise<never> {
+  // Persist state so the user can resume from this step on the next run.
+  // stepNum-1 is the last COMPLETED step (the step that just failed is
+  // `stepNum`, so everything before it finished). The resume prompt uses
+  // `failed_step = stepNum` to default the continue-from selection back
+  // to this exact step.
+  try {
+    saveState(ctx, stepNum - 1, stepNum, deps.loxVersion);
+  } catch {
+    // Non-fatal: state write is a convenience, not a correctness requirement.
+  }
+  console.error(`\n${message ?? 'Unknown error'}`);
+  if (!actionable) {
+    await offerErrorReport({
+      stepName,
+      errorMessage: message ?? 'Unknown error',
+      subPhase: extractSubPhase(message ?? ''),
+      sourceFile: sourceFileForStep(stepName),
+      loxVersion: deps.loxVersion,
+      os: `${deps.platform} ${deps.arch}`,
+      nodeVersion: deps.nodeVersion,
+    });
+  }
+  process.exit(1);
+}

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -204,7 +204,13 @@ export async function stepMcp(ctx: InstallerContext): Promise<StepResult> {
     () => isVpnReachable(vpnServerIp),
   );
   if (!vpnUp) {
-    return { success: false, message: buildVpnUnreachableMessage(vpnServerIp, process.platform) };
+    // actionable=true so the installer doesn't ask the user to file a
+    // GitHub bug report for a user-fixable condition (#96).
+    return {
+      success: false,
+      message: buildVpnUnreachableMessage(vpnServerIp, process.platform),
+      actionable: true,
+    };
   }
   console.log(chalk.green(`  ✓ VPN reachable (${vpnServerIp}:22)`));
 

--- a/packages/installer/src/steps/types.ts
+++ b/packages/installer/src/steps/types.ts
@@ -15,6 +15,24 @@ export interface InstallerContext {
 export interface StepResult {
   success: boolean;
   message?: string;
+  /**
+   * Mark a failure as user-actionable (VPN not active, missing prereq,
+   * missing config field the user must supply, etc.) — something the
+   * user can fix and retry, NOT a bug in the installer. When true,
+   * `handleStepFailure` prints the guidance message and persists state
+   * for the resume feature, but skips the "Would you like to report
+   * this issue on GitHub?" prompt. Defaults to false/undefined, meaning
+   * the failure IS reportable (unknown crashes, transient infra errors,
+   * unexpected state). See #96.
+   *
+   * DO NOT use actionable:true to suppress noise on real crashes or on
+   * errors the user cannot resolve without diagnostic work (API enable
+   * failures, SSH drops, unexpected exit codes, state corruption). The
+   * bar is: "is there ONE concrete thing the user can do RIGHT NOW to
+   * fix this and retry?" If the answer requires reading logs or
+   * debugging, the failure is NOT actionable.
+   */
+  actionable?: boolean;
 }
 
 export type InstallerStep = (ctx: InstallerContext) => Promise<StepResult>;

--- a/packages/installer/tests/step-failure.test.ts
+++ b/packages/installer/tests/step-failure.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { handleStepFailure, type StepFailureDeps } from '../src/step-failure.js';
+import { offerErrorReport } from '../src/utils/error-report.js';
+import { getStatePath } from '../src/state.js';
+import type { InstallerContext } from '../src/steps/types.js';
+
+vi.mock('../src/utils/error-report.js', () => ({
+  offerErrorReport: vi.fn().mockResolvedValue(undefined),
+  extractSubPhase: vi.fn().mockReturnValue(undefined),
+  sourceFileForStep: vi.fn().mockReturnValue(undefined),
+}));
+
+const DEPS: StepFailureDeps = {
+  loxVersion: '9.9.9',
+  platform: 'linux',
+  arch: 'x64',
+  nodeVersion: 'v22.16.0',
+};
+
+function makeCtx(): InstallerContext {
+  return { config: {}, locale: 'en' };
+}
+
+describe('handleStepFailure (#96)', () => {
+  let tmp: string;
+  let originalHome: string | undefined;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'lox-step-fail-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+    vi.mocked(offerErrorReport).mockClear();
+    // process.exit(1) is Promise<never> — throw inside the spy so the await
+    // in tests resolves the rejection and assertions can run afterwards.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('__process_exit__');
+    }) as never);
+    // Silence stderr during tests; we're not asserting on the message print here.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(tmp, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('calls offerErrorReport and exits(1) on a non-actionable failure', async () => {
+    await expect(
+      handleStepFailure('Deploy', 11, 'Something unexpected failed', makeCtx(), false, DEPS),
+    ).rejects.toThrow('__process_exit__');
+    expect(offerErrorReport).toHaveBeenCalledOnce();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('SKIPS offerErrorReport on an actionable failure (#96)', async () => {
+    // VPN not active, missing prereq, etc. — user can fix and retry.
+    // We must not ask them to file a GitHub bug for this.
+    await expect(
+      handleStepFailure('MCP Server', 12, 'VPN is not active', makeCtx(), true, DEPS),
+    ).rejects.toThrow('__process_exit__');
+    expect(offerErrorReport).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('still persists state on an actionable failure so resume works', async () => {
+    // The user's going to fix the issue and re-run; the resume prompt
+    // must offer to continue from this step. State persistence is
+    // independent of whether the failure is actionable.
+    await expect(
+      handleStepFailure('MCP Server', 12, 'VPN is not active', makeCtx(), true, DEPS),
+    ).rejects.toThrow('__process_exit__');
+    expect(existsSync(getStatePath())).toBe(true);
+  });
+
+  it('still persists state on a non-actionable failure', async () => {
+    await expect(
+      handleStepFailure('Deploy', 11, 'Crashed', makeCtx(), false, DEPS),
+    ).rejects.toThrow('__process_exit__');
+    expect(existsSync(getStatePath())).toBe(true);
+  });
+
+  it('falls back to "Unknown error" when message is undefined', async () => {
+    // Fallback to 'Unknown error' when message is undefined — but it's
+    // still a reportable crash, not a user-fixable state.
+    await expect(
+      handleStepFailure('VM Setup', 7, undefined, makeCtx(), false, DEPS),
+    ).rejects.toThrow('__process_exit__');
+    expect(offerErrorReport).toHaveBeenCalledOnce();
+    const call = vi.mocked(offerErrorReport).mock.calls[0]![0];
+    expect(call.errorMessage).toBe('Unknown error');
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Add `actionable?: boolean` to `StepResult` — when true, `handleStepFailure` skips the "Would you like to report this issue on GitHub?" prompt
- Apply `actionable: true` to the step 12 VPN preflight failure (#93)
- Extract `handleStepFailure` from `src/index.ts` into `src/step-failure.ts` with dependency injection so the branching logic is directly unit-testable

Closes #96

## Why

v0.6.4 shipped the VPN preflight (#93), which correctly surfaced clean "your WireGuard tunnel isn't active, here's how to fix it" guidance. But the auto-report prompt fired immediately after, and the user reasonably answered yes — filing a GitHub issue for what was a fully expected, user-recoverable state. The prompt belongs on installer crashes and transient infra errors, not on "activate your VPN and retry."

The docstring on `actionable` is deliberately strict: *"ONE concrete thing the user can do RIGHT NOW to fix this and retry"* — NOT for suppressing noise on real crashes or errors that require diagnostic work.

## Test plan

- [x] 5 new tests: actionable skips offer, non-actionable calls offer, state persisted in both cases, undefined-message fallback
- [x] 352 tests passing (was 347 baseline)
- [x] `tsc --noEmit` clean on all 3 project configs
- [ ] Windows smoke test: Lara re-runs installer with WireGuard still off → sees VPN guidance but NO bug-report prompt this time

## Follow-up

Audit other `{success: false}` returns for the actionable flag:
- `step-prerequisites.ts` — "Missing prerequisites: X. Install them and re-run lox." (clearly actionable)
- `step-gcp-auth.ts` — "GCP authentication failed. Run \`gcloud auth login\` manually..." (actionable)
- `step-vault.ts` — "Vault setup cancelled by user." (user chose to cancel; bug-report prompt is absurd here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)