### PR TITLE
fix: tighten ACLs on gcloud SSH private key on Windows (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-04-05
+
+### Fixed
+- Step 12 (MCP Server) now tightens ACLs on the gcloud-created `~/.ssh/google_compute_engine` private key on Windows (#101). Earlier steps (VM Setup, Deploy) invoke `gcloud compute ssh`, which creates the key with inherited loose Windows ACLs (CREATOR OWNER / BUILTIN\Users). Step 12's `scp lox-vm:...` then failed with "UNPROTECTED PRIVATE KEY FILE! Bad permissions" because OpenSSH on Windows validates identity-file permissions before use. The fix (#83) was already applied to `~/.ssh/` and `~/.ssh/config`, just not to the key itself. Extracted `tightenGcloudSshKey` as a testable helper and added 3 regression tests (no-op when key missing, no-op on non-Windows, invokes icacls on Windows when key exists).
+
+
 ## [0.6.6] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -131,6 +131,29 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
   const { chmodSync } = await import('node:fs');
   chmodSync(configPath, 0o600);
   await fixWindowsSshAcl(configPath);
+
+  await tightenGcloudSshKey(sshDir);
+}
+
+/**
+ * Apply `fixWindowsAcl` to the gcloud-created `~/.ssh/google_compute_engine`
+ * private key if present (#101). Earlier steps (VM setup, deploy) invoke
+ * `gcloud compute ssh`, which creates the key with inherited loose Windows
+ * ACLs (`CREATOR OWNER` / `BUILTIN\Users`). OpenSSH validates identity-file
+ * permissions before use and rejects the scp in step 12 with "UNPROTECTED
+ * PRIVATE KEY FILE". `fixWindowsAcl` is a no-op on non-Windows; on Windows
+ * it restricts access to the current user only. Gated on `existsSync`
+ * because the key may not yet exist when step 12 runs standalone.
+ *
+ * Exported for tests; the only production caller is `configureSshConfig`.
+ */
+export async function tightenGcloudSshKey(sshDir: string): Promise<void> {
+  const { existsSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const keyPath = join(sshDir, 'google_compute_engine');
+  if (existsSync(keyPath)) {
+    await fixWindowsSshAcl(keyPath);
+  }
 }
 
 /**

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl, buildVpnUnreachableMessage } from '../../src/steps/step-mcp.js';
+import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl, buildVpnUnreachableMessage, tightenGcloudSshKey } from '../../src/steps/step-mcp.js';
 import { shell } from '../../src/utils/shell.js';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 vi.mock('../../src/utils/shell.js', () => ({
   shell: vi.fn(),
@@ -74,6 +77,62 @@ describe('buildMcpLauncherScript', () => {
   it('ends with a trailing newline', () => {
     const script = buildMcpLauncherScript('/home/lox/lox-brain');
     expect(script.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('tightenGcloudSshKey (#101)', () => {
+  let tmp: string;
+  const originalPlatform = process.platform;
+  const originalUsername = process.env.USERNAME;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'lox-ssh-key-'));
+    mkdirSync(tmp, { recursive: true });
+    vi.mocked(shell).mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (originalUsername === undefined) delete process.env.USERNAME;
+    else process.env.USERNAME = originalUsername;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('is a no-op when the gcloud private key does not exist', async () => {
+    // Standalone step 12 runs may hit this path if no earlier step has
+    // invoked `gcloud compute ssh` yet — fixWindowsAcl must not be called
+    // on a missing file (icacls would error on a non-existent path).
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.USERNAME = 'alice';
+    await tightenGcloudSshKey(tmp);
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on non-Windows platforms even if the key exists', async () => {
+    // fixWindowsAcl gates internally, but we exercise the happy path here:
+    // Linux/macOS key-perm management is POSIX-based (chmod 600 elsewhere),
+    // not icacls. No shell invocation expected.
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    writeFileSync(path.join(tmp, 'google_compute_engine'), 'fake-key');
+    await tightenGcloudSshKey(tmp);
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it('invokes icacls on the gcloud key path when on Windows and the key exists', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.USERNAME = 'alice';
+    vi.mocked(shell).mockResolvedValue({ stdout: '', stderr: '' });
+    const keyPath = path.join(tmp, 'google_compute_engine');
+    writeFileSync(keyPath, 'fake-key');
+
+    await tightenGcloudSshKey(tmp);
+
+    expect(shell).toHaveBeenCalledOnce();
+    const [cmd, args] = vi.mocked(shell).mock.calls[0]!;
+    expect(cmd).toBe('icacls');
+    // The exact flags are owned by fixWindowsAcl's own tests; here we
+    // just verify the key path was the target.
+    expect(args).toContain(keyPath);
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Extract `tightenGcloudSshKey(sshDir)` helper that applies `fixWindowsAcl` to `~/.ssh/google_compute_engine` if it exists
- Call it from `configureSshConfig` (step 12, before scp)
- 3 new tests: no-op when key missing, no-op on non-Windows, invokes icacls on Windows when key exists

Closes #101

## Why

Step 12 `scp lox-vm:...` was failing on Windows with "UNPROTECTED PRIVATE KEY FILE! Bad permissions" because OpenSSH validates identity-file ACLs before use, and `gcloud compute ssh` creates `~/.ssh/google_compute_engine` with inherited loose Windows ACLs (CREATOR OWNER / BUILTIN\\Users). The #83 fix applied `fixWindowsAcl` to `~/.ssh/` and `~/.ssh/config` but missed the private key itself.

Hit live today with Lara on Windows. Manual workaround is running `icacls` on the key before step 12 — this change does it automatically.

## Test plan

- [x] `tightenGcloudSshKey` no-op when key file doesn't exist
- [x] `tightenGcloudSshKey` no-op on non-Windows (fixWindowsAcl gates internally, but we prove no shell invocation)
- [x] `tightenGcloudSshKey` invokes icacls on Windows with the key path as target
- [x] 362 tests passing (was 359)
- [x] `tsc --noEmit` clean on all 3 projects
- [ ] Windows smoke test: Lara re-runs installer, step 12 scp succeeds without UNPROTECTED PRIVATE KEY FILE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)