### PR TITLE
fix: unblock watcher startup — 5 related install-chain bugs (v0.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.8] — 2026-04-05
+
+### Fixed
+- **Step 11 — `PG_PASSWORD` missing from `/etc/lox/secrets.env` (#103).** The DB password that step 7 (VM Setup) generates and stores in Secret Manager as `lox-db-password` was never read back by step 11. The watcher crashed on every install with "PG_PASSWORD environment variable or explicit password is required" and systemd restart-looped it forever. Step 11 now fetches `lox-db-password` from Secret Manager and includes it in secrets.env. If the secret is missing, returns an actionable failure pointing the user at step 7.
+- **Step 11 — `VAULT_PATH` used the user's LOCAL Obsidian folder (#104-A).** `ctx.config.vault.local_path` is the user's Obsidian path on their Windows/macOS machine (e.g. `~/Obsidian/Lox`). Step 11 wrongly copied that into the VM's `VAULT_PATH`. systemd's `EnvironmentFile=` doesn't expand `~`, and the VM doesn't have the user's Obsidian layout anyway. Now always uses the VM-side absolute path `${vmHome}/lox-vault`.
+- **Step 9 — VM never cloned the vault repo (#104-B).** `buildVmSetupScript` wrote `~/sync-vault.sh` with `cd ~/lox-vault` but nothing in the installer ever ran `git clone` on the VM. Cron fired silently every 2 minutes, watcher watched a missing directory, Node exited cleanly with no events, systemd restart-looped. Added a one-time idempotent clone at the top of the VM setup script (checks `~/lox-vault/.git` first, fetches PAT from Secret Manager on the VM, embeds it in the remote URL so subsequent `git fetch`/`push` in sync-vault.sh work without a credential helper).
+- **Step 9 — template copy silently failed on Windows (#105).** `cp -r templates/<preset>/. <vaultDir>` invoked `cp` which doesn't exist on Windows. The generic `try/catch` swallowed the error and printed the MISLEADING message "Template directory not found" even though the templates existed. Replaced with `fs.cpSync(..., { recursive: true, force: true })` (no shell, cross-platform by construction). Dropped the swallowing catch so a real packaging regression would surface loudly.
+- **Step 12 — `fixWindowsAcl` hardening for gcloud SSH key (#101 follow-up).** v0.6.7's `/inheritance:r` + `/grant:r user:F` only stripped inherited ACEs, leaving EXPLICIT `CREATOR OWNER` / `BUILTIN\Users` ACEs on the gcloud-created key file intact. OpenSSH still rejected the key with "UNPROTECTED PRIVATE KEY FILE". Now also explicitly removes the 4 common loose principals (CREATOR OWNER, BUILTIN\Users, Authenticated Users, Everyone) via `icacls /remove` before granting the current user.
+
+
 ## [0.6.7] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -71,6 +71,41 @@ export function buildBuildScript(installDir: string): string {
 }
 
 /**
+ * Build the literal contents of /etc/lox/secrets.env — every line the
+ * lox-watcher and MCP server need at runtime.
+ *
+ * Exported so tests can lock the invariants that every field is present
+ * (PG_PASSWORD, VAULT_PATH, etc.) and uses the VM-side absolute paths
+ * rather than the user's local config. See #103 (missing PG_PASSWORD)
+ * and #104 (VAULT_PATH was using Obsidian local path).
+ */
+export interface SecretsEnvInput {
+  dbUser: string;
+  dbPassword: string;
+  dbHost: string;
+  dbPort: number;
+  dbName: string;
+  openaiKey: string;
+  /** MUST be an absolute POSIX path on the VM (e.g. /home/user/lox-vault) —
+   * systemd's EnvironmentFile doesn't expand `~`, and the user's local
+   * Obsidian path is irrelevant on the VM. */
+  vaultPath: string;
+}
+
+export function buildSecretsEnvContent(input: SecretsEnvInput): string {
+  return [
+    `DATABASE_URL=postgresql://${input.dbUser}@${input.dbHost}:${input.dbPort}/${input.dbName}?sslmode=require`,
+    // Plain password env var — node-postgres reads process.env.PG_PASSWORD
+    // via createPool() in packages/core/src/lib/create-pool.ts.
+    `PG_PASSWORD=${input.dbPassword}`,
+    `OPENAI_API_KEY=${input.openaiKey}`,
+    `VAULT_PATH=${input.vaultPath}`,
+    'NODE_ENV=production',
+    'LOG_LEVEL=info',
+  ].join('\n');
+}
+
+/**
  * Write /etc/lox/secrets.env with tight perms. The env content is embedded
  * verbatim via a quoted heredoc — the local temp script owns the whole
  * payload so we never pass multi-line content through `gcloud --command`.
@@ -351,7 +386,11 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
     () => ensureVmIdentity(ctx, projectId, zone, vmName),
   );
   const installDir = ctx.config.install_dir ?? `${vmHome}/lox-brain`;
-  const vaultPath = ctx.config.vault?.local_path ?? `${vmHome}/lox-vault`;
+  // VM-side absolute path — NEVER reuse ctx.config.vault.local_path, which
+  // is the user's LOCAL Obsidian folder (e.g. ~/Obsidian/Lox on Windows).
+  // systemd's EnvironmentFile doesn't expand `~`, and the VM doesn't have
+  // the user's local Obsidian layout anyway. See #104.
+  const vaultPath = `${vmHome}/lox-vault`;
 
   // 1. Clone lox-brain repo on VM
   await withSpinner(
@@ -374,6 +413,38 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
     console.log(chalk.green(`  ✓ ${strings.openai_saved_to_secret_manager}`));
   }
 
+  // Fetch the DB password from Secret Manager BEFORE building secrets.env (#103).
+  // Step 7 (VM Setup) generated a random password, created the postgres user
+  // with it, and stored it as the `lox-db-password` secret. Without this line,
+  // /etc/lox/secrets.env never gets PG_PASSWORD and the watcher crash-loops on
+  // startup ("PG_PASSWORD environment variable or explicit password is required").
+  const dbPassword = await withSpinner(
+    'Fetching database password from Secret Manager...',
+    async () => {
+      const { stdout } = await shell('gcloud', [
+        'secrets', 'versions', 'access', 'latest',
+        '--secret', 'lox-db-password',
+        '--project', projectId,
+      ]);
+      return stdout.trim();
+    },
+  ).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
+  });
+  if (typeof dbPassword !== 'string') {
+    return {
+      success: false,
+      actionable: true,
+      message:
+        `Could not read the DB password from Secret Manager (secret "lox-db-password").\n`
+        + `  ${dbPassword.error}\n\n`
+        + `This is populated by step 7 (VM Setup). To recover:\n`
+        + `  • Re-run the installer and pick "Step 7 (VM Setup)" in the resume prompt, OR\n`
+        + `  • Manually create it: gcloud secrets create lox-db-password --data-file=<file> --project=${projectId}`,
+    };
+  }
+
   // 4. Create .env on VM from config (NOT in repo — in /etc/lox/secrets.env)
   await withSpinner(
     `${strings.configuring} secrets on VM...`,
@@ -383,13 +454,15 @@ export async function stepDeploy(ctx: InstallerContext): Promise<StepResult> {
       const dbHost = ctx.config.database?.host ?? '127.0.0.1';
       const dbPort = ctx.config.database?.port ?? 5432;
 
-      const envContent = [
-        `DATABASE_URL=postgresql://${dbUser}@${dbHost}:${dbPort}/${dbName}?sslmode=require`,
-        `OPENAI_API_KEY=${openaiResult.key ?? OPENAI_KEY_PLACEHOLDER}`,
-        `VAULT_PATH=${vaultPath}`,
-        'NODE_ENV=production',
-        'LOG_LEVEL=info',
-      ].join('\n');
+      const envContent = buildSecretsEnvContent({
+        dbUser,
+        dbPassword,
+        dbHost,
+        dbPort,
+        dbName,
+        openaiKey: openaiResult.key ?? OPENAI_KEY_PLACEHOLDER,
+        vaultPath,
+      });
 
       await runRemoteScript(projectId, zone, vmName, 'secrets', buildSecretsEnvScript(envContent, user));
     },

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -1,9 +1,25 @@
 import chalk from 'chalk';
-import { shell, getPlatform } from '../utils/shell.js';
+import { shell } from '../utils/shell.js';
 import { t } from '../i18n/index.js';
 import { renderStepHeader, renderBox } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
 import type { InstallerContext, StepResult } from './types.js';
+import { cpSync, existsSync } from 'node:fs';
+import { resolve as pathResolve } from 'node:path';
+
+/**
+ * Locate the bundled templates directory relative to THIS compiled module
+ * (not CWD — the installer may be invoked from any directory). Compiled
+ * layout: `packages/installer/dist/steps/step-vault.js` → go up 4 dirs to
+ * the repo root where `templates/<preset>/` lives.
+ *
+ * Uses CommonJS `__dirname` (the installer ships as CJS via
+ * `"type": "commonjs"` in packages/installer/package.json). Exported for
+ * tests which assert path resolution without depending on working dir.
+ */
+export function resolveTemplatesDir(preset: string): string {
+  return pathResolve(__dirname, '..', '..', '..', '..', 'templates', preset);
+}
 
 const TOTAL_STEPS = 12;
 
@@ -110,12 +126,47 @@ export function isRepoNotFoundError(err: unknown): boolean {
  */
 export const VM_SETUP_SCRIPT_REMOTE_PATH = '/tmp/lox-setup-sync.sh';
 
-export function buildVmSetupScript(): string {
+export interface VmSetupScriptInput {
+  /** GitHub handle that owns the vault repo (used to build the clone URL). */
+  githubUser: string;
+  /** Vault repo name on GitHub (default 'lox-vault'). */
+  repoName: string;
+  /** GCP Secret Manager secret name holding the fine-grained PAT. */
+  patSecretName: string;
+}
+
+export function buildVmSetupScript(input: VmSetupScriptInput): string {
   // cronLine must not contain single quotes — embedded in a single-quoted bash assignment below.
   const cronLine = '*/2 * * * * ~/sync-vault.sh >> ~/sync-vault.log 2>&1';
+  // Shell-injection guard on template strings: these values flow from
+  // GitHub API + user input. Trust is not guaranteed in user-controlled
+  // fields (repoName is user-entered), so restrict the format to the set
+  // GitHub actually allows (alphanumeric, dash, dot, underscore).
+  const safeRepo = input.repoName.replace(/[^A-Za-z0-9._-]/g, '');
+  const safeUser = input.githubUser.replace(/[^A-Za-z0-9-]/g, '');
+  // GCP Secret Manager allows underscores in secret names — must include
+  // `_` or a user with a secret like `lox_github_pat` gets silent truncation.
+  const safeSecret = input.patSecretName.replace(/[^A-Za-z0-9_-]/g, '');
   return [
     '#!/bin/bash',
     'set -euo pipefail',
+    '',
+    // #104-B: initial clone of the vault repo on the VM. sync-vault.sh
+    // (written below) does `cd ~/lox-vault` and assumes it exists — but
+    // step 9 only ever clones the repo on the user's local machine, never
+    // on the VM. Without this block, sync-vault.sh fails silently on
+    // every cron tick, the vault never appears, and the watcher exits
+    // cleanly (chokidar on a missing dir = no-op event loop). Idempotent:
+    // skipped if ~/lox-vault/.git already exists.
+    'if [ ! -d "$HOME/lox-vault/.git" ]; then',
+    '  echo "[lox] Cloning vault repo to ~/lox-vault (one-time)..."',
+    `  GH_PAT=$(gcloud secrets versions access latest --secret=${safeSecret})`,
+    // PAT embedded in the clone URL so subsequent `git fetch` / `git push`
+    // in sync-vault.sh work without a credential helper. The token stays
+    // in ~/lox-vault/.git/config, which is 0600 on the VM (single-user).
+    `  git clone "https://\${GH_PAT}@github.com/${safeUser}/${safeRepo}.git" "$HOME/lox-vault"`,
+    '  unset GH_PAT',
+    'fi',
     '',
     "cat > ~/sync-vault.sh <<'LOX_SYNC_EOF'",
     '#!/bin/bash',
@@ -304,18 +355,25 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
     );
   }
 
-  // 3. Copy template files
+  // 3. Copy template files (#105). Uses fs.cpSync — cross-platform,
+  // no shell dependency. Previously invoked `cp -r` which doesn't exist
+  // on Windows; the silent try/catch then printed a misleading
+  // "Template directory not found" message when the real cause was
+  // cp missing from PATH. Now we let errors surface and say what's
+  // actually missing.
   await withSpinner(
     `Copying ${preset} template files...`,
     async () => {
-      // Template copy is best-effort; templates may not exist yet in early phases
-      try {
-        const platform = getPlatform();
-        const cpCmd = platform === 'macos' ? 'cp' : 'cp';
-        await shell(cpCmd, ['-r', `templates/${preset}/.`, vaultDir]);
-      } catch {
-        console.log(chalk.yellow('  → Template directory not found, creating empty vault structure.'));
+      const templatesSrc = resolveTemplatesDir(preset);
+      if (!existsSync(templatesSrc)) {
+        // Genuinely missing templates is a packaging/bundling regression —
+        // fail loudly instead of silently producing an empty vault.
+        throw new Error(
+          `Template directory not found: ${templatesSrc}. `
+          + `Check the installer package includes templates/${preset}/.`,
+        );
       }
+      cpSync(templatesSrc, vaultDir, { recursive: true, force: true });
     },
   );
 
@@ -436,7 +494,11 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
       // through gcloud's --command, which cmd.exe on Windows interprets as
       // its own shell metacharacters and fragments the command (#61).
       const { tmpdir } = await import('node:os');
-      const setupScript = buildVmSetupScript();
+      const setupScript = buildVmSetupScript({
+        githubUser: ghUser,
+        repoName,
+        patSecretName,
+      });
       const localScriptPath = join(tmpdir(), `lox-setup-sync-${Date.now()}.sh`);
       writeFileSync(localScriptPath, setupScript);
 

--- a/packages/installer/src/utils/windows-acl.ts
+++ b/packages/installer/src/utils/windows-acl.ts
@@ -27,8 +27,35 @@ export async function fixWindowsAcl(targetPath: string): Promise<void> {
   // NOTE: For domain users, icacls resolves the bare name to the
   // domain account if no local account exists. Explicit DOMAIN\user
   // is unnecessary for the typical single-user install scenario.
+  //
+  // Three-step hardening (#101 follow-up):
+  //   1. `/inheritance:r` — strip INHERITED ACEs from the parent dir
+  //   2. `/remove` the common loose principals as EXPLICIT ACEs — step 1
+  //      only touches inherited ones, but CREATOR OWNER / BUILTIN\Users
+  //      frequently end up as explicit ACEs on files Windows creates
+  //      inside %USERPROFILE%\.ssh. OpenSSH rejects the key file if ANY
+  //      of these principals has access, so `/inheritance:r` alone is
+  //      not enough (seen on Windows 11, pt-BR locale, Lox v0.6.7).
+  //   3. `/grant:r user:F` — grant only the current user Full control.
+  //
+  // Each call is independent so a failure on one removal (e.g. the
+  // principal wasn't present) doesn't abort the rest.
+  const loosePrincipals = [
+    'CREATOR OWNER',
+    'BUILTIN\\Users',
+    'Authenticated Users',
+    'Everyone',
+  ];
   try {
-    await shell('icacls', [targetPath, '/inheritance:r', '/grant:r', `${username}:F`]);
+    await shell('icacls', [targetPath, '/inheritance:r']);
+  } catch { /* best-effort */ }
+  for (const principal of loosePrincipals) {
+    try {
+      await shell('icacls', [targetPath, '/remove', principal]);
+    } catch { /* principal may not be on this ACL */ }
+  }
+  try {
+    await shell('icacls', [targetPath, '/grant:r', `${username}:(F)`]);
   } catch {
     // Surfaced by the downstream operation if it still fails.
   }

--- a/packages/installer/tests/steps/step-deploy.test.ts
+++ b/packages/installer/tests/steps/step-deploy.test.ts
@@ -4,6 +4,7 @@ import {
   buildCloneScript,
   buildBuildScript,
   buildSecretsEnvScript,
+  buildSecretsEnvContent,
   buildSystemdInstallScript,
   buildServiceStartScript,
   buildMcpHealthProbeScript,
@@ -60,6 +61,63 @@ describe('buildSecretsEnvScript', () => {
     // Single-quoted heredoc delimiter suppresses variable/command expansion
     expect(s).toContain("<<'LOX_ENV_EOF'");
     expect(s).toContain('PASS=$ecret`bq`');
+  });
+});
+
+describe('buildSecretsEnvContent (#103 + #104-A)', () => {
+  const baseInput = {
+    dbUser: 'lox',
+    dbPassword: 'p@ssw0rd-rand',
+    dbHost: '127.0.0.1',
+    dbPort: 5432,
+    dbName: 'lox_brain',
+    openaiKey: 'sk-test',
+    vaultPath: '/home/alice/lox-vault',
+  };
+
+  it('includes PG_PASSWORD — critical for the watcher (#103)', () => {
+    // Without PG_PASSWORD, createPool() throws on startup and the
+    // lox-watcher systemd service crash-loops. DO NOT ever remove this
+    // line from the env content builder. See #103.
+    const content = buildSecretsEnvContent(baseInput);
+    expect(content).toContain('PG_PASSWORD=p@ssw0rd-rand');
+  });
+
+  it('uses the VM-side absolute VAULT_PATH, not the user local path (#104-A)', () => {
+    // Before #104-A, VAULT_PATH was set to ctx.config.vault.local_path
+    // which is the user's LOCAL Obsidian folder (e.g. ~/Obsidian/Lox).
+    // systemd's EnvironmentFile doesn't expand `~`, and the VM doesn't
+    // have the user's local Obsidian layout anyway. Lock the contract.
+    const content = buildSecretsEnvContent(baseInput);
+    expect(content).toContain('VAULT_PATH=/home/alice/lox-vault');
+    expect(content).not.toContain('~/');
+    expect(content).not.toContain('Obsidian');
+  });
+
+  it('builds the DATABASE_URL with SSL required', () => {
+    const content = buildSecretsEnvContent(baseInput);
+    expect(content).toContain('DATABASE_URL=postgresql://lox@127.0.0.1:5432/lox_brain?sslmode=require');
+  });
+
+  it('includes OPENAI_API_KEY verbatim', () => {
+    const content = buildSecretsEnvContent(baseInput);
+    expect(content).toContain('OPENAI_API_KEY=sk-test');
+  });
+
+  it('sets NODE_ENV=production and LOG_LEVEL=info', () => {
+    const content = buildSecretsEnvContent(baseInput);
+    expect(content).toContain('NODE_ENV=production');
+    expect(content).toContain('LOG_LEVEL=info');
+  });
+
+  it('emits each key on its own line (systemd EnvironmentFile format)', () => {
+    const content = buildSecretsEnvContent(baseInput);
+    const lines = content.split('\n');
+    // 6 env vars = 6 lines, no blanks.
+    expect(lines).toHaveLength(6);
+    for (const line of lines) {
+      expect(line).toMatch(/^[A-Z_]+=/);
+    }
   });
 });
 

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -127,12 +127,15 @@ describe('tightenGcloudSshKey (#101)', () => {
 
     await tightenGcloudSshKey(tmp);
 
-    expect(shell).toHaveBeenCalledOnce();
-    const [cmd, args] = vi.mocked(shell).mock.calls[0]!;
-    expect(cmd).toBe('icacls');
-    // The exact flags are owned by fixWindowsAcl's own tests; here we
-    // just verify the key path was the target.
-    expect(args).toContain(keyPath);
+    // Post-#101-followup: fixWindowsAcl now runs 6 icacls calls (inherit
+    // strip + 4 principal removals + grant). The exact sequence is owned
+    // by fixWindowsAcl's own tests; here we just verify ALL invocations
+    // were icacls targeting the gcloud key path.
+    expect(shell).toHaveBeenCalledTimes(6);
+    for (const call of vi.mocked(shell).mock.calls) {
+      expect(call[0]).toBe('icacls');
+      expect(call[1]).toContain(keyPath);
+    }
   });
 });
 
@@ -206,17 +209,26 @@ describe("fixWindowsSshAcl (#83)", () => {
     expect(shell).not.toHaveBeenCalled();
   });
 
-  it("runs icacls with /inheritance:r and /grant:r USERNAME:F on Windows", async () => {
+  it("runs the full icacls hardening sequence on Windows (#101 follow-up)", async () => {
+    // Hardening added after v0.6.7: /inheritance:r alone was leaving
+    // EXPLICIT CREATOR OWNER / BUILTIN\Users ACEs on gcloud-created key
+    // files, and OpenSSH still rejected them. We now:
+    //   1. strip inherited ACEs
+    //   2. explicitly /remove the 4 common loose principals
+    //   3. grant the current user Full control
+    // = 6 total icacls invocations.
     Object.defineProperty(process, "platform", { value: "win32" });
     process.env.USERNAME = "alice";
     vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
-    await fixWindowsSshAcl("C:\\Users\\alice\\.ssh\\config");
-    expect(shell).toHaveBeenCalledWith("icacls", [
-      "C:\\Users\\alice\\.ssh\\config",
-      "/inheritance:r",
-      "/grant:r",
-      "alice:F",
-    ]);
+    const target = "C:\\Users\\alice\\.ssh\\google_compute_engine";
+    await fixWindowsSshAcl(target);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/inheritance:r"]);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/remove", "CREATOR OWNER"]);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/remove", "BUILTIN\\Users"]);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/remove", "Authenticated Users"]);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/remove", "Everyone"]);
+    expect(shell).toHaveBeenCalledWith("icacls", [target, "/grant:r", "alice:(F)"]);
+    expect(shell).toHaveBeenCalledTimes(6);
   });
 
   it("falls back to USER if USERNAME is unset (edge case)", async () => {
@@ -225,12 +237,7 @@ describe("fixWindowsSshAcl (#83)", () => {
     process.env.USER = "bob";
     vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
     await fixWindowsSshAcl("C:\\path");
-    expect(shell).toHaveBeenCalledWith("icacls", [
-      "C:\\path",
-      "/inheritance:r",
-      "/grant:r",
-      "bob:F",
-    ]);
+    expect(shell).toHaveBeenCalledWith("icacls", ["C:\\path", "/grant:r", "bob:(F)"]);
   });
 
   it("treats an empty USERNAME env var as unset and falls back to USER", async () => {
@@ -239,12 +246,24 @@ describe("fixWindowsSshAcl (#83)", () => {
     process.env.USER = "alice";
     vi.mocked(shell).mockResolvedValue({ stdout: "", stderr: "" });
     await fixWindowsSshAcl("C:\\path");
-    expect(shell).toHaveBeenCalledWith("icacls", [
-      "C:\\path",
-      "/inheritance:r",
-      "/grant:r",
-      "alice:F",
-    ]);
+    expect(shell).toHaveBeenCalledWith("icacls", ["C:\\path", "/grant:r", "alice:(F)"]);
+  });
+
+  it("continues the sequence even if a /remove call fails (principal absent)", async () => {
+    // On a file whose ACL doesn't have CREATOR OWNER, `icacls /remove` exits
+    // non-zero. That must NOT abort the rest of the sequence — the user
+    // grant still needs to be applied.
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.USERNAME = "alice";
+    vi.mocked(shell).mockImplementation(async (_cmd, args) => {
+      if (args?.includes("CREATOR OWNER")) {
+        throw new Error("icacls: No mapping between account names and security IDs was done.");
+      }
+      return { stdout: "", stderr: "" };
+    });
+    await fixWindowsSshAcl("C:\\path");
+    // The /grant:r must still fire despite the earlier /remove failure.
+    expect(shell).toHaveBeenCalledWith("icacls", ["C:\\path", "/grant:r", "alice:(F)"]);
   });
 
   it("trims whitespace-only USERNAME/USER before treating as unset", async () => {

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH } from '../../src/steps/step-vault.js';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH, resolveTemplatesDir } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
+import { existsSync } from 'node:fs';
 
 vi.mock('../../src/utils/shell.js', () => ({
   shell: vi.fn(),
@@ -143,7 +144,11 @@ describe('repoExists', () => {
 });
 
 describe('buildVmSetupScript', () => {
-  const script = buildVmSetupScript();
+  const script = buildVmSetupScript({
+    githubUser: 'alice',
+    repoName: 'lox-vault',
+    patSecretName: 'lox-github-pat',
+  });
 
   it('starts with a bash shebang and strict mode', () => {
     expect(script.startsWith('#!/bin/bash\n')).toBe(true);
@@ -174,6 +179,55 @@ describe('buildVmSetupScript', () => {
     expect(script).toContain('rm -- "$0"');
   });
 
+  it('clones the vault repo to ~/lox-vault if missing (#104-B)', () => {
+    // Before #104-B, sync-vault.sh did `cd ~/lox-vault` against a
+    // directory that the installer never created on the VM — cron
+    // failed silently forever. Now the setup script clones the repo
+    // as a one-time bootstrap.
+    expect(script).toContain('if [ ! -d "$HOME/lox-vault/.git" ]; then');
+    expect(script).toContain('git clone');
+    expect(script).toContain('github.com/alice/lox-vault.git');
+    expect(script).toContain('$HOME/lox-vault');
+  });
+
+  it('fetches the PAT from Secret Manager and unsets it after clone', () => {
+    // The token must be scrubbed from the shell env after the clone so
+    // it doesn't linger for subsequent lines in the setup script.
+    expect(script).toContain('gcloud secrets versions access latest --secret=lox-github-pat');
+    expect(script).toContain('unset GH_PAT');
+  });
+
+  it('sanitizes repoName / githubUser / patSecretName against shell injection', () => {
+    // Defense in depth: even though githubUser comes from the GitHub API
+    // and repoName passes through input validation, we strip anything
+    // outside the alphanumeric + allowed-punct set before interpolating.
+    const malicious = buildVmSetupScript({
+      githubUser: 'alice; rm -rf /',
+      repoName: 'lox-vault && curl evil',
+      patSecretName: 'x$(whoami)',
+    });
+    // Stripped to their safe character sets.
+    expect(malicious).toContain('github.com/alicerm-rf/lox-vaultcurlevil.git');
+    expect(malicious).toContain('--secret=xwhoami');
+    // Must NOT contain the raw injection metachars.
+    expect(malicious).not.toContain('; rm -rf /');
+    expect(malicious).not.toContain('&& curl');
+    expect(malicious).not.toContain('$(whoami)');
+  });
+
+  it('preserves underscores in patSecretName (GCP Secret Manager allows them)', () => {
+    // GCP allows [A-Za-z0-9_-] in secret names per
+    // https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets
+    // Stripping underscores would silently break users whose secret names
+    // look like `lox_github_pat` instead of `lox-github-pat`.
+    const s = buildVmSetupScript({
+      githubUser: 'alice',
+      repoName: 'lox-vault',
+      patSecretName: 'lox_github_pat_2026',
+    });
+    expect(s).toContain('--secret=lox_github_pat_2026');
+  });
+
   it('VM_SETUP_SCRIPT_REMOTE_PATH is an absolute POSIX path', () => {
     // pscp.exe (Windows Cloud SDK) does not perform tilde expansion — a
     // destination like lox-vm:~/file.sh lands in a literal "~" directory
@@ -188,6 +242,25 @@ describe('buildVmSetupScript', () => {
     // trailing newline is conventional and ensures POSIX tools treat the
     // last line as a complete line.
     expect(script.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('resolveTemplatesDir (#105)', () => {
+  it('resolves to an absolute path independent of CWD', () => {
+    const paraPath = resolveTemplatesDir('para');
+    expect(paraPath).toMatch(/templates[/\\]para$/);
+    // Not a relative path — must not depend on process.cwd().
+    expect(paraPath.startsWith('/') || /^[A-Z]:\\/.test(paraPath)).toBe(true);
+  });
+
+  it('resolves to actual template directories that exist in the repo', () => {
+    // End-to-end check: the path resolution isn't just syntactic — the
+    // templates MUST exist on disk for the installer to copy them.
+    // This would have caught the #105 silent-failure bug: the old code
+    // tried `cp -r templates/para/.` (CWD-relative), failed on Windows,
+    // and swallowed the error. The new path MUST reach a real folder.
+    expect(existsSync(resolveTemplatesDir('para'))).toBe(true);
+    expect(existsSync(resolveTemplatesDir('zettelkasten'))).toBe(true);
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Five related bugs in the install chain (step 9 → step 11 → step 12 → watcher startup) that collectively prevented the watcher from functioning on a fresh install. Discovered live today while validating Lara's end-to-end install on Windows.

Closes #103, closes #104, closes #105, hardens #101.

## The 5 fixes

| Issue | Bug | Fix |
|---|---|---|
| **#103** | `PG_PASSWORD` missing from `/etc/lox/secrets.env` — watcher crash-looped forever | Step 11 fetches `lox-db-password` from Secret Manager, injects `PG_PASSWORD=` |
| **#104-A** | `VAULT_PATH` used user's LOCAL Obsidian path (`~/Obsidian/Lox`) — `~` not expanded, path doesn't exist on VM | Always use `${vmHome}/lox-vault` (VM-side absolute) |
| **#104-B** | VM never cloned the vault repo — `sync-vault.sh` did `cd ~/lox-vault` against nothing, cron failed silently | `buildVmSetupScript` emits an idempotent one-time `git clone` at the top |
| **#105** | Template copy used `cp -r` on Windows (cp not in PATH), `try/catch` printed misleading "Template directory not found" | Replaced with `fs.cpSync(..., { recursive: true, force: true })`, dropped silent catch |
| **#101 follow-up** | `icacls /inheritance:r` didn't strip EXPLICIT `CREATOR OWNER` ACEs, OpenSSH still rejected the gcloud key | Added explicit `/remove` for 4 loose principals before `/grant:r` |

## Files changed

- `packages/installer/src/steps/step-deploy.ts` — PG_PASSWORD fetch + `buildSecretsEnvContent` helper + `SecretsEnvInput` interface
- `packages/installer/src/steps/step-vault.ts` — `buildVmSetupScript` now takes `{githubUser, repoName, patSecretName}` + emits git clone block + shell-injection sanitization on all 3 params + `resolveTemplatesDir` + `cpSync` replacing `cp -r`
- `packages/installer/src/utils/windows-acl.ts` — 6-call icacls hardening (inherit-strip + 4 principal removals + grant)
- 12 new tests

## Test plan

- [x] 375 tests passing (was 362 + 13 new)
- [x] `tsc --noEmit` clean on all 3 projects
- [x] Reviewer-flagged regex bug fixed: `safeSecret` now includes `_` (GCP Secret Manager allows underscores)
- [ ] End-to-end Windows smoke test: Lara re-runs install from step 9, validates watcher comes up `Active: active (running)` without any manual workarounds

## Follow-up (not in this PR)

- **PAT in `.git/config` remote URL** (noted by reviewer): on the VM, `git clone https://<PAT>@github.com/.../lox-vault.git` leaves the PAT in plaintext in `~/lox-vault/.git/config`. Acceptable trade-off for single-user VPN-only setup, but worth tracking for future replacement by a credential helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)