### PR TITLE
fix: always tighten gcloud SSH key ACL in step 12 (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.9] — 2026-04-05
+
+### Fixed
+- Step 12 now tightens the gcloud `~/.ssh/google_compute_engine` private key ACLs on every re-run (#109). v0.6.7's `tightenGcloudSshKey` call was placed AFTER an early-return path in `configureSshConfig` that fires whenever `~/.ssh/config` already has the `Host lox-vm` entry — i.e. on every re-run. Meanwhile `ensureVmIdentity` (which runs earlier in step 12) calls `gcloud compute ssh`, which regenerates the key with fresh inherited loose Windows ACLs every single time. Net result: re-runs always failed with "UNPROTECTED PRIVATE KEY FILE! CREATOR OWNER (S-1-3-4)" — the fix from v0.6.7/v0.6.8 was unreachable. Restructured the branch so `tightenGcloudSshKey` runs unconditionally at the end. Exported `configureSshConfig` and added 2 regression tests (both branches invoke the tightening).
+
+
 ## [0.6.8] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-mcp.ts
+++ b/packages/installer/src/steps/step-mcp.ts
@@ -93,8 +93,11 @@ import { fixWindowsAcl as fixWindowsSshAcl } from '../utils/windows-acl.js';
 
 /**
  * Ensure ~/.ssh/config exists and append the lox-vm entry if not present.
+ * Exported for tests — the #109 regression requires verifying that
+ * `tightenGcloudSshKey` runs on BOTH the new-entry AND already-configured
+ * paths (previously a bug skipped it on re-runs).
  */
-async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise<void> {
+export async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise<void> {
   const { readFileSync, writeFileSync, existsSync, mkdirSync } = await import('node:fs');
   const { join } = await import('node:path');
 
@@ -122,16 +125,22 @@ async function configureSshConfig(vpnServerIp: string, sshUser: string): Promise
     // never have been fixed, and OpenSSH validates the parent dir too.
     await fixWindowsSshAcl(sshDir);
     await fixWindowsSshAcl(configPath);
-    return;
+  } else {
+    const entry = buildSshConfigEntry(vpnServerIp, sshUser);
+    writeFileSync(configPath, existing + entry);
+    // Ensure correct permissions on SSH config
+    const { chmodSync } = await import('node:fs');
+    chmodSync(configPath, 0o600);
+    await fixWindowsSshAcl(configPath);
   }
 
-  const entry = buildSshConfigEntry(vpnServerIp, sshUser);
-  writeFileSync(configPath, existing + entry);
-  // Ensure correct permissions on SSH config
-  const { chmodSync } = await import('node:fs');
-  chmodSync(configPath, 0o600);
-  await fixWindowsSshAcl(configPath);
-
+  // ALWAYS tighten the gcloud private key (#109). `gcloud compute ssh` in
+  // earlier steps — and inside step 12's own `ensureVmIdentity` call —
+  // regenerates ~/.ssh/google_compute_engine with fresh inherited loose
+  // Windows ACLs EVERY TIME it runs. So even if a previous step 12 run
+  // tightened the key, a subsequent re-run would re-loosen it via
+  // ensureVmIdentity, then skip the tightening via the early-return
+  // above. Must run unconditionally AFTER the config-entry branch.
   await tightenGcloudSshKey(sshDir);
 }
 

--- a/packages/installer/tests/steps/step-mcp.test.ts
+++ b/packages/installer/tests/steps/step-mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl, buildVpnUnreachableMessage, tightenGcloudSshKey } from '../../src/steps/step-mcp.js';
+import { isMcpServerRegistered, buildMcpLauncherScript, fixWindowsSshAcl, buildVpnUnreachableMessage, tightenGcloudSshKey, configureSshConfig } from '../../src/steps/step-mcp.js';
 import { shell } from '../../src/utils/shell.js';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -136,6 +136,83 @@ describe('tightenGcloudSshKey (#101)', () => {
       expect(call[0]).toBe('icacls');
       expect(call[1]).toContain(keyPath);
     }
+  });
+});
+
+describe('configureSshConfig (#109 re-run regression)', () => {
+  let tmp: string;
+  const originalPlatform = process.platform;
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalUsername = process.env.USERNAME;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'lox-ssh-cfg-'));
+    // Point HOME (and USERPROFILE on Windows CI) to our tmp dir so
+    // configureSshConfig reads/writes under there instead of $HOME.
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+    vi.mocked(shell).mockReset();
+    vi.mocked(shell).mockResolvedValue({ stdout: '', stderr: '' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalUsername === undefined) delete process.env.USERNAME;
+    else process.env.USERNAME = originalUsername;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('calls tightenGcloudSshKey when lox-vm is ALREADY in ~/.ssh/config (re-run path, #109)', async () => {
+    // This is the bug scenario: user re-runs the installer, ~/.ssh/config
+    // already has `Host lox-vm`, so configureSshConfig took an early
+    // return and NEVER tightened the gcloud key ACLs. Ship-blocker for
+    // every Windows re-run.
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.USERNAME = 'alice';
+
+    // Seed an existing ~/.ssh/config with the Host lox-vm entry and the
+    // gcloud private key file. configureSshConfig must tighten the key
+    // despite taking the "already configured" branch.
+    const sshDir = path.join(tmp, '.ssh');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(path.join(sshDir, 'config'), 'Host lox-vm\n  HostName 10.10.0.1\n');
+    writeFileSync(path.join(sshDir, 'google_compute_engine'), 'fake-key');
+
+    await configureSshConfig('10.10.0.1', 'alice');
+
+    // fixWindowsAcl runs on each target (sshDir, configPath, keyPath) via
+    // the #101 6-call icacls sequence. We just need to prove the KEY path
+    // was among the icacls targets — that's what #109 was breaking.
+    const keyPath = path.join(sshDir, 'google_compute_engine');
+    const icaclsCalls = vi.mocked(shell).mock.calls.filter(
+      (c) => c[0] === 'icacls' && c[1]?.includes(keyPath),
+    );
+    expect(icaclsCalls.length).toBeGreaterThan(0);
+  });
+
+  it('calls tightenGcloudSshKey on the fresh-config path too', async () => {
+    // The other branch: no existing Host lox-vm entry. The tightening
+    // must still run. Both paths matter — don't regress the NEW code path
+    // while fixing the re-run path.
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env.USERNAME = 'alice';
+    const sshDir = path.join(tmp, '.ssh');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(path.join(sshDir, 'google_compute_engine'), 'fake-key');
+    // NO existing config file.
+
+    await configureSshConfig('10.10.0.1', 'alice');
+
+    const keyPath = path.join(sshDir, 'google_compute_engine');
+    const icaclsCalls = vi.mocked(shell).mock.calls.filter(
+      (c) => c[0] === 'icacls' && c[1]?.includes(keyPath),
+    );
+    expect(icaclsCalls.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

`configureSshConfig` had an early `return` that skipped `tightenGcloudSshKey` on every installer re-run (when `~/.ssh/config` already had `Host lox-vm`). Compounding: `ensureVmIdentity` runs BEFORE in step 12 and calls `gcloud compute ssh`, which regenerates `~/.ssh/google_compute_engine` with fresh inherited loose Windows ACLs every time. Net effect: re-runs always failed with "UNPROTECTED PRIVATE KEY FILE! CREATOR OWNER (S-1-3-4)" — v0.6.7/v0.6.8 fixes were never reached.

Closes #109

## Root cause diagnosed live

User ran manual icacls after v0.6.8 step 12 failure:

```
DIREITOS DO PROPRIETÁRIO:(I)(F)   ← CREATOR OWNER, (I)=inherited
```

All 3 ACEs were `(I)` (inherited). A single `/inheritance:r` would have removed them — confirmed by running it manually. Which means **the installer never actually ran icacls**. Traced to the early-return in `configureSshConfig`.

## Fix

Restructured the branch so `tightenGcloudSshKey` runs at the end regardless of which path was taken:

```typescript
if (existing.includes('Host lox-vm')) {
  // already-configured branch
} else {
  // new-entry branch
}
await tightenGcloudSshKey(sshDir);  // unconditionally
```

## Test plan

- [x] Exported `configureSshConfig` for testability
- [x] 2 new regression tests — both the "already configured" and "fresh config" paths MUST invoke icacls on `google_compute_engine`. Uses real tmp dirs so filesystem path logic is exercised.
- [x] 377 tests passing (was 375)
- [x] `tsc --noEmit` clean
- [ ] Windows smoke test: Lara re-runs v0.6.9, step 12 scp succeeds without UNPROTECTED PRIVATE KEY FILE

🤖 Generated with [Claude Code](https://claude.com/claude-code)