### PR TITLE
fix: source /etc/lox/secrets.env in MCP health probe (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.11] — 2026-04-05
+
+### Fixed
+- **Step 11 — MCP health probe sourced no environment variables (#116).** The post-deploy probe invoked `node packages/core/dist/mcp/index.js` without loading `/etc/lox/secrets.env`, so `VAULT_PATH`, `OPENAI_API_KEY`, `PG_PASSWORD`, and other required env vars were absent. The MCP server aborted at startup with "VAULT_PATH environment variable is required", causing a false-negative `⚠ MCP server did not respond` warning on every install. The systemd watcher service was unaffected (it loads the env file via `EnvironmentFile=`). Fix prepends `[ -f /etc/lox/secrets.env ] && { set -a; source /etc/lox/secrets.env; set +a; }` before the node invocation. The file-existence guard ensures that a missing secrets.env (e.g. installer aborted before step 11) falls through to reporting unhealthy rather than aborting the script before the probe runs.
+
+
 ## [0.6.10] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-deploy.ts
+++ b/packages/installer/src/steps/step-deploy.ts
@@ -166,9 +166,16 @@ export function buildMcpHealthProbeScript(installDir: string): string {
   // would abort before `head -1` reads any output, hiding diagnostic info
   // from the caller which inspects stdout to decide health. The enclosing
   // TypeScript wraps this call in try/catch and treats any throw as unhealthy.
+  //
+  // Load secrets so VAULT_PATH, OPENAI_API_KEY, PG_PASSWORD, etc. are present
+  // when the MCP server starts. The watcher gets these via systemd's
+  // EnvironmentFile= — this one-off probe must source them explicitly (#116).
+  // Guard with [ -f ] so a missing secrets.env falls through to "unhealthy"
+  // rather than aborting the script before the probe even runs.
   return [
     '#!/bin/bash',
     `cd "${installDir}" || exit 1`,
+    '[ -f /etc/lox/secrets.env ] && { set -a; source /etc/lox/secrets.env; set +a; }',
     'echo \'{"jsonrpc":"2.0","method":"tools/list","id":1}\' | timeout 10 node packages/core/dist/mcp/index.js 2>/dev/null | head -1',
     '',
   ].join('\n');

--- a/packages/installer/tests/steps/step-deploy.test.ts
+++ b/packages/installer/tests/steps/step-deploy.test.ts
@@ -164,6 +164,26 @@ describe('buildMcpHealthProbeScript', () => {
     expect(s).not.toContain('set -euo pipefail');
     expect(s).not.toContain('pipefail');
   });
+
+  it('sources /etc/lox/secrets.env before running node so env vars are available (#116)', () => {
+    // The watcher gets VAULT_PATH, OPENAI_API_KEY, PG_PASSWORD etc. via
+    // systemd EnvironmentFile=. This one-off probe must source them explicitly,
+    // otherwise the MCP server aborts at startup and every install shows a
+    // false-negative "MCP server did not respond" warning.
+    const s = buildMcpHealthProbeScript('/home/lox/lox-brain');
+    expect(s).toContain('source /etc/lox/secrets.env');
+    // The source must appear BEFORE the node invocation line.
+    const sourceIdx = s.indexOf('source /etc/lox/secrets.env');
+    const nodeIdx = s.indexOf('node packages/core/dist/mcp/index.js');
+    expect(sourceIdx).toBeLessThan(nodeIdx);
+  });
+
+  it('guards the source with a file-existence check so a missing secrets.env does not abort the probe', () => {
+    // If /etc/lox/secrets.env is missing the probe should fall through and
+    // report unhealthy (no output), not abort the script before node runs.
+    const s = buildMcpHealthProbeScript('/home/lox/lox-brain');
+    expect(s).toContain('[ -f /etc/lox/secrets.env ]');
+  });
 });
 
 describe('parseVmIdentity', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Bug

The post-deploy MCP health probe (step 11) invoked `node packages/core/dist/mcp/index.js` without loading `/etc/lox/secrets.env`. The MCP server requires `VAULT_PATH`, `OPENAI_API_KEY`, and `PG_PASSWORD` at startup — without them it exits immediately with:

```
Error: VAULT_PATH environment variable is required
```

This caused a false-negative `⚠ MCP server did not respond` warning on **every** install, even when the watcher and server were otherwise working correctly.

The systemd watcher service was unaffected — it loads the env file via `EnvironmentFile=/etc/lox/secrets.env` in its unit. Only this one-off probe script was missing the sourcing step.

## Fix

`packages/installer/src/steps/step-deploy.ts` — `buildMcpHealthProbeScript()`:

Prepend the following line before the `node` invocation:

```bash
[ -f /etc/lox/secrets.env ] && { set -a; source /etc/lox/secrets.env; set +a; }
```

- `set -a` exports every variable defined by the source, making them available to the child `node` process.
- The `[ -f ]` guard ensures that a missing `secrets.env` (e.g. installer aborted before step 11 wrote the file) causes the probe to fall through and report unhealthy — rather than aborting the script before `node` even runs.
- `set -euo pipefail` is deliberately absent in this script (existing design); `set -a`/`set +a` are scoped to the source step only.

## Tests

`packages/installer/tests/steps/step-deploy.test.ts` — `describe('buildMcpHealthProbeScript', …)`:

Two new assertions added to the existing `describe` block:

1. **Sources `/etc/lox/secrets.env` before `node`** — verifies the source line is present and its index precedes the `node` invocation index.
2. **Guards with `[ -f /etc/lox/secrets.env ]`** — verifies a missing file does not abort the probe.

All existing assertions are preserved. Full suite: **381 tests passed**.

## Version

Patch bump: `0.6.10` → `0.6.11`. All `package.json` files and `CHANGELOG.md` updated.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)