### PR TITLE
fix: add Claude Code CLI as installer prerequisite (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.12] — 2026-04-05
+
+### Fixed
+- Add Claude Code CLI (`@anthropic-ai/claude-code`) as a prerequisite check so the installer fails fast at step 1 with `npm install -g @anthropic-ai/claude-code` instead of crashing at step 12 after 20+ minutes of VM provisioning (#115). Previously the installer invoked `claude mcp add` at the final sub-step of step 12 without ever verifying that `claude` was on `PATH`, causing a cryptic "command not found" error for users who had not yet installed Claude Code.
+
+
 ## [0.6.11] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/checks/prerequisites.ts
+++ b/packages/installer/src/checks/prerequisites.ts
@@ -71,6 +71,19 @@ async function checkGh(): Promise<PrerequisiteResult> {
   }
 }
 
+async function checkClaudeCode(): Promise<PrerequisiteResult> {
+  try {
+    const { stdout } = await shell('claude', ['--version']);
+    return { name: 'Claude Code', installed: true, version: stdout };
+  } catch {
+    return {
+      name: 'Claude Code',
+      installed: false,
+      installCommand: 'npm install -g @anthropic-ai/claude-code',
+    };
+  }
+}
+
 async function checkWireGuard(): Promise<PrerequisiteResult> {
   try {
     const { stdout } = await shell('wg', ['--version']);
@@ -89,6 +102,7 @@ export async function checkAllPrerequisites(): Promise<PrerequisiteResult[]> {
     checkGit(),
     checkGcloud(),
     checkGh(),
+    checkClaudeCode(),
     checkWireGuard(),
   ]);
 }

--- a/packages/installer/tests/checks/prerequisites.test.ts
+++ b/packages/installer/tests/checks/prerequisites.test.ts
@@ -16,7 +16,7 @@ describe('PrerequisiteResult interface', () => {
 
     // Should return array of results
     expect(Array.isArray(results)).toBe(true);
-    expect(results.length).toBe(5); // Node, git, gcloud, gh, WireGuard
+    expect(results.length).toBe(6); // Node, git, gcloud, gh, Claude Code, WireGuard
 
     // Each result should have required fields
     for (const r of results) {
@@ -42,6 +42,18 @@ describe('PrerequisiteResult interface', () => {
     const gitResult = results.find(r => r.name === 'git');
     expect(gitResult).toBeDefined();
     expect(gitResult!.installed).toBe(true);
+  });
+
+  it('includes Claude Code in the results', async () => {
+    const { checkAllPrerequisites } = await import('../../src/checks/prerequisites.js');
+    const results = await checkAllPrerequisites();
+    const claudeResult = results.find(r => r.name === 'Claude Code');
+    expect(claudeResult).toBeDefined();
+    expect(typeof claudeResult!.installed).toBe('boolean');
+    // When not installed, it must expose the npm install command
+    if (!claudeResult!.installed) {
+      expect(claudeResult!.installCommand).toBe('npm install -g @anthropic-ai/claude-code');
+    }
   });
 
   it('provides install commands for missing prerequisites', async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- **Bug:** The installer calls `claude mcp add` at the final sub-step of step 12 (MCP registration) without ever verifying that the `claude` CLI is on `PATH`. Users who have not installed `@anthropic-ai/claude-code` hit a cryptic `'claude' is not recognized` error after 20+ minutes of VM provisioning.
- **Fix:** Added `checkClaudeCode()` to `packages/installer/src/checks/prerequisites.ts`, following the exact pattern of `checkGit()` / `checkGh()`. On failure it returns `installCommand: 'npm install -g @anthropic-ai/claude-code'` (same on all platforms — Claude Code is npm-only). The function is inserted after `checkGh()` and before `checkWireGuard()` in the `Promise.all` of `checkAllPrerequisites()`, so the installer fails fast at step 1 with a clear remediation message.
- **Tests:** Added a new `includes Claude Code in the results` test case and updated the existing `results.length` assertion from `5` to `6`. All 380 tests pass.

## Test plan

- [x] `npm run test --workspace=packages/installer` — 380 tests, 25 files, all green
- [x] `npm run build --workspaces` — TypeScript compiles cleanly for all packages
- [x] New test verifies `installCommand === 'npm install -g @anthropic-ai/claude-code'` when Claude Code is absent
- [x] Existing length assertion updated to reflect the new 6-item array

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)