### PR TITLE
docs: fix CLAUDE.md monorepo structure (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,28 @@ To reconfigure after installation, edit `~/.lox/config.json` directly or re-run 
 ```
 lox-brain/
   packages/
-    core/
+    shared/                # Constants, types, config (consumed by core + installer)
+      src/
+        config.ts
+        constants.ts       # LOX_VERSION (read dynamically from package.json)
+        types.ts
+    core/                  # Runs on the GCP VM
       src/
         lib/               # Embedding service, DB client
         mcp/               # MCP server (stdio transport)
         watcher/           # Vault watcher (chokidar)
+        scripts/           # index-vault, migrations
       tests/
-    cli/                   # CLI tool (lox status, lox migrate)
-    installer/             # Cross-platform installer
+    installer/             # Cross-platform setup wizard (Win/macOS/Linux)
+      src/
+        steps/             # step-*.ts — ordered install steps
+        utils/             # shell(), windows-acl, etc.
   docs/
-    plans/
+    plans/                 # Historical planning docs (pre-monorepo)
+    internal/              # Gitignored (strategy, pricing — not public)
+    zettelkasten/
+    superpowers/
+  ROADMAP.md               # Public roadmap (Phase 0-4)
 ```
 
 ## Security (Zero Trust)


### PR DESCRIPTION
## Summary

Fix factual drift in \`CLAUDE.md\` discovered by 2026-04-05 documentation audit:

- **Remove** \`packages/cli\` — does not exist in the repo
- **Add** \`packages/shared\` — the actual third package (constants, types, config)
- Expand subdirectory listings for \`core\`, \`installer\`, \`shared\` to match reality
- Add \`docs/\` subdirectories (\`plans/\`, \`internal/\`, \`zettelkasten/\`, \`superpowers/\`) and \`ROADMAP.md\` to the tree

The previous listing contradicted \`ls packages/\` output, which any AI agent or contributor would immediately notice.

## Test plan

- [x] \`ls packages/\` shows \`core\`, \`installer\`, \`shared\` — now matches CLAUDE.md
- [x] Pre-commit hooks pass
- [ ] CI passes

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)