### PR TITLE
fix: verify vault template copy + push initial commit (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.13] — 2026-04-05
+## [0.6.14] — 2026-04-05
+
+### Fixed
+- **Step 9 — vault remained empty after install on Windows (#122).** The installer copied template files via `cpSync` without verifying the copy succeeded, and never ran `git add/commit/push` after the template copy. Three failure modes resulted: (a) silent `cpSync` failures produced an empty vault with no error; (b) templates landed locally but the GitHub `lox-vault` remote stayed empty because no initial commit was ever made; (c) the VM's `sync-vault.sh` cron (every 2 min) pulled from an empty remote, so the VM's vault clone also stayed empty. Fix adds post-copy verification (throws with `templatesSrc`, `vaultDir`, missing entries, and actual entries when the expected template structure is absent for the selected preset) and a git `add -A` → porcelain dirty-check → `commit` → `push origin main` sequence after `.gitignore` + gitleaks hook install. Idempotent: re-runs over an already-committed vault are a no-op. For users already on v0.6.13 or earlier with an empty vault: `cd lox-vault && git add -A && git commit -m "chore: initialize template" && git push origin main` (run from the directory where the installer was executed, after manually copying templates from `lox-brain/templates/<preset>/` if the local vault is also empty).
+
+
 
 ### Added
 - Step 8 now auto-activates the WireGuard client tunnel after writing `wg0.conf` so step 12 can scp over the VPN without the user manually importing the config into the WireGuard GUI (#98). Probes `VPN_SERVER_IP:22` first and short-circuits as "already active" if reachable; otherwise runs `sudo wg-quick up` on Unix or `wireguard.exe /installtunnelservice` on Windows (with `net session` elevation check and fallback probing of `C:\Program Files\WireGuard\wireguard.exe` when `wireguard` isn't on PATH), then verifies reachability via a paced 10s probe loop. Never blocks step 8: failures print the verbatim manual command plus a resume hint and fall through to step 12's preflight (#93), which is the real VPN gate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "1.0.0",
+  "version": "0.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "1.0.0",
+      "version": "0.6.14",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "1.0.0",
+      "version": "0.6.14",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "1.0.0",
+      "version": "0.6.14",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "1.0.0",
+      "version": "0.6.14",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -4,7 +4,7 @@ import { t } from '../i18n/index.js';
 import { renderStepHeader, renderBox } from '../ui/box.js';
 import { withSpinner } from '../ui/spinner.js';
 import type { InstallerContext, StepResult } from './types.js';
-import { cpSync, existsSync } from 'node:fs';
+import { cpSync, existsSync, readdirSync } from 'node:fs';
 import { resolve as pathResolve } from 'node:path';
 
 /**
@@ -210,6 +210,97 @@ export function isValidPatFormat(token: string): boolean {
 }
 
 /**
+ * Top-level entries each template preset MUST produce after `cpSync` (#122).
+ *
+ * Kept as a static list (not derived from `readdirSync(templatesSrc)`) because
+ * the check's job is to catch a silent cpSync failure — reading the source on
+ * every verify would paper over a bundling regression where `templates/` is
+ * missing from the shipped package entirely. The list is the contract.
+ */
+export const EXPECTED_TEMPLATE_ENTRIES: Record<string, string[]> = {
+  para: [
+    '1 - Inbox',
+    '2 - Projects',
+    '3 - Areas',
+    '4 - Resources',
+    '5 - Archive',
+    'Templates',
+    'Welcome to Lox.md',
+  ],
+  zettelkasten: [
+    '1 - Fleeting Notes',
+    '2 - Projects',
+    '2 - Source Material',
+    '3 - Tags',
+    '5 - Templates',
+    '6 - Atomic Notes',
+    '7 - Meeting Notes',
+    'attachments',
+    'Welcome to Lox.md',
+  ],
+};
+
+/**
+ * Verify that `cpSync(templatesSrc, vaultDir)` actually produced the expected
+ * top-level entries (#122). Throws with a diagnostic that includes the source
+ * path, destination path, what's missing, and what's actually on disk — this
+ * is the information a reporter needs to diagnose why the copy silently
+ * failed (typically path resolution on Windows, or packaging regression).
+ *
+ * Defensive against unknown presets even though the installer's select prompt
+ * already constrains `preset` — an untyped extension would otherwise produce
+ * a silent pass.
+ */
+export function verifyTemplatesCopied(vaultDir: string, preset: string, templatesSrc: string): void {
+  const expected = EXPECTED_TEMPLATE_ENTRIES[preset];
+  if (!expected) {
+    throw new Error(`Template copy verification: unknown preset "${preset}"`);
+  }
+  const actual = readdirSync(vaultDir);
+  const actualSet = new Set(actual);
+  const missing = expected.filter(entry => !actualSet.has(entry));
+  if (missing.length > 0) {
+    throw new Error(
+      `Template copy verification failed for preset "${preset}".\n`
+      + `  templatesSrc: ${templatesSrc}\n`
+      + `  vaultDir: ${vaultDir}\n`
+      + `  missing: ${missing.join(', ')}\n`
+      + `  actual entries: ${actual.length > 0 ? actual.join(', ') : '(empty)'}`,
+    );
+  }
+}
+
+/**
+ * Make the initial commit on a freshly-created vault and push to origin/main
+ * (#122). Without this step, templates land locally but the GitHub remote and
+ * VM clone stay empty — the VM's sync-vault.sh cron has nothing to pull, and
+ * Obsidian opens a vault that is never committed anywhere.
+ *
+ * Idempotent: when nothing is staged (re-run over an already-initialized
+ * vault), returns `'nothing-to-commit'` without calling `git commit` or
+ * `git push`. Callers should treat both return values as success.
+ */
+export async function commitInitialVaultTemplate(
+  vaultDir: string,
+  preset: string,
+): Promise<'pushed' | 'nothing-to-commit'> {
+  await shell('git', ['-C', vaultDir, 'add', '-A']);
+  const { stdout } = await shell('git', ['-C', vaultDir, 'status', '--porcelain']);
+  if (stdout.trim() === '') {
+    return 'nothing-to-commit';
+  }
+  // Set a local git identity so `git commit` doesn't fail with
+  // "Author identity unknown" on hosts where the user has never set a
+  // global git config (fresh Windows installs, CI runners). Scoped to the
+  // vault repo — doesn't touch the user's global config.
+  await shell('git', ['-C', vaultDir, 'config', 'user.email', 'installer@lox.local']);
+  await shell('git', ['-C', vaultDir, 'config', 'user.name', 'Lox Installer']);
+  await shell('git', ['-C', vaultDir, 'commit', '-m', `chore: initialize ${preset} template`]);
+  await shell('git', ['-C', vaultDir, 'push', 'origin', 'main']);
+  return 'pushed';
+}
+
+/**
  * Check whether a GCP Secret Manager secret already exists in the given project.
  * Returns true on success, false when the secret is not found, and rethrows on
  * other failures (auth, billing, API disabled) so real problems surface.
@@ -317,24 +408,28 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   }
 
   const fullRepo = `${ghUser}/${repoName}`;
-  const vaultDir = repoName;
+  // Resolve to an absolute path at creation (#122 review): makes subsequent
+  // readdirSync / `git -C` calls CWD-independent and ensures diagnostic
+  // error messages from verifyTemplatesCopied show an actionable path
+  // instead of a bare relative name.
+  const vaultDir = pathResolve(process.cwd(), repoName);
 
   // Handle a stale local clone directory from a prior run.
   if (fsExistsSync(vaultDir)) {
-    console.log(chalk.yellow(`  ⚠ Local directory ./${vaultDir} already exists.`));
+    console.log(chalk.yellow(`  ⚠ Local directory ./${repoName} already exists.`));
     const removeIt = await confirm({
-      message: `Remove ./${vaultDir} and continue? (choose No to abort)`,
+      message: `Remove ./${repoName} and continue? (choose No to abort)`,
       default: false,
     });
     if (!removeIt) {
-      return { success: false, message: `Aborted: ./${vaultDir} already exists.` };
+      return { success: false, message: `Aborted: ./${repoName} already exists.` };
     }
     try {
       rmSync(vaultDir, { recursive: true, force: true });
     } catch (err) {
       return {
         success: false,
-        message: `Failed to remove ./${vaultDir}: ${(err as Error).message}`,
+        message: `Failed to remove ./${repoName}: ${(err as Error).message}`,
       };
     }
   }
@@ -374,6 +469,10 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
         );
       }
       cpSync(templatesSrc, vaultDir, { recursive: true, force: true });
+      // #122: verify the copy landed — previously a silent cpSync failure
+      // (path resolution, permissions, packaging regression) produced an
+      // empty vault with no error signal anywhere.
+      verifyTemplatesCopied(vaultDir, preset, templatesSrc);
     },
   );
 
@@ -539,6 +638,21 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   const hookPath = join(hooksDir, 'pre-commit');
   writeFileSync(hookPath, GITLEAKS_HOOK, { mode: 0o755 });
   console.log(chalk.green('  ✓ gitleaks pre-commit hook installed'));
+
+  // 9. Initial commit + push (#122). Without this, templates + .gitignore +
+  // hook land locally but the GitHub remote stays empty — the VM cron pulls
+  // nothing, Obsidian opens a vault that is never committed anywhere, and
+  // the user ends up with three disconnected copies. Idempotent: a re-run
+  // over an already-committed vault is a no-op.
+  const commitResult = await withSpinner(
+    'Committing initial vault template and pushing to origin/main...',
+    () => commitInitialVaultTemplate(vaultDir, preset),
+  );
+  if (commitResult === 'pushed') {
+    console.log(chalk.green('  ✓ Initial vault template committed and pushed'));
+  } else {
+    console.log(chalk.green('  ✓ Vault already in sync with origin/main'));
+  }
 
   // Security gate: validate repo is private
   const isPrivate = await isRepoPrivate(fullRepo);

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH, resolveTemplatesDir } from '../../src/steps/step-vault.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH, resolveTemplatesDir, verifyTemplatesCopied, commitInitialVaultTemplate, EXPECTED_TEMPLATE_ENTRIES } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 vi.mock('../../src/utils/shell.js', () => ({
   shell: vi.fn(),
@@ -359,5 +361,163 @@ describe('gcpSecretExists', () => {
   it('rethrows "Command not found" for missing gcloud', async () => {
     vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gcloud'));
     await expect(gcpSecretExists('x', 'y')).rejects.toThrow('Command not found: gcloud');
+  });
+});
+
+describe('verifyTemplatesCopied (#122)', () => {
+  // Use a fresh tmpdir per test so we can exercise real filesystem reads —
+  // this is the check that would have caught #122 (empty vault after install).
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = join(tmpdir(), `lox-test-verify-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(workDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('exposes the expected entries per preset', () => {
+    expect(EXPECTED_TEMPLATE_ENTRIES.para).toContain('1 - Inbox');
+    expect(EXPECTED_TEMPLATE_ENTRIES.para).toContain('Welcome to Lox.md');
+    expect(EXPECTED_TEMPLATE_ENTRIES.zettelkasten).toContain('Welcome to Lox.md');
+  });
+
+  it('returns silently when all expected PARA entries exist', () => {
+    for (const entry of EXPECTED_TEMPLATE_ENTRIES.para) {
+      if (entry.endsWith('.md')) {
+        writeFileSync(join(workDir, entry), '# test');
+      } else {
+        mkdirSync(join(workDir, entry));
+      }
+    }
+    expect(() => verifyTemplatesCopied(workDir, 'para', '/fake/src')).not.toThrow();
+  });
+
+  it('throws when the vault is empty (regression test for #122)', () => {
+    // This is the exact symptom from #122: cpSync silently produced an
+    // empty vault because the source path didn't resolve on Windows
+    // (or some other silent failure). Verification catches it.
+    expect(() => verifyTemplatesCopied(workDir, 'para', '/fake/src')).toThrow(/Template copy verification failed/);
+  });
+
+  it('includes templatesSrc, vaultDir, missing entries, and actual entries in the error message', () => {
+    writeFileSync(join(workDir, '1 - Inbox'), 'oops-this-is-a-file-not-a-dir'); // present but only one
+    try {
+      verifyTemplatesCopied(workDir, 'para', '/my/templates/src');
+      throw new Error('should have thrown');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('templatesSrc: /my/templates/src');
+      expect(msg).toContain(`vaultDir: ${workDir}`);
+      expect(msg).toContain('missing:');
+      // Present entry must NOT be reported as missing
+      expect(msg).not.toMatch(/missing:.*1 - Inbox/);
+      // A missing entry MUST be reported
+      expect(msg).toMatch(/missing:.*Welcome to Lox\.md/);
+      expect(msg).toContain('actual entries:');
+      // The one file we did create shows up under "actual entries"
+      expect(msg).toMatch(/actual entries:.*1 - Inbox/);
+    }
+  });
+
+  it('reports "(empty)" when the vaultDir has no entries', () => {
+    try {
+      verifyTemplatesCopied(workDir, 'para', '/s');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as Error).message).toContain('actual entries: (empty)');
+    }
+  });
+
+  it('throws for unknown presets (defensive — caller validates, but still)', () => {
+    expect(() => verifyTemplatesCopied(workDir, 'unknown-preset', '/s')).toThrow(/unknown preset/i);
+  });
+
+  it('validates zettelkasten preset as well', () => {
+    for (const entry of EXPECTED_TEMPLATE_ENTRIES.zettelkasten) {
+      if (entry.endsWith('.md')) {
+        writeFileSync(join(workDir, entry), '# test');
+      } else {
+        mkdirSync(join(workDir, entry));
+      }
+    }
+    expect(() => verifyTemplatesCopied(workDir, 'zettelkasten', '/s')).not.toThrow();
+  });
+});
+
+describe('commitInitialVaultTemplate (#122)', () => {
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  it('adds, commits, and pushes when the working tree is dirty', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                     // git add -A
+      .mockResolvedValueOnce({ stdout: 'A  1 - Inbox/README.md\n', stderr: '' }) // git status --porcelain (dirty)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                     // git config user.email
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                     // git config user.name
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                     // git commit
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });                    // git push
+
+    const result = await commitInitialVaultTemplate('lox-vault', 'para');
+
+    expect(result).toBe('pushed');
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(6);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(1, 'git', ['-C', 'lox-vault', 'add', '-A']);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(2, 'git', ['-C', 'lox-vault', 'status', '--porcelain']);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(3, 'git', ['-C', 'lox-vault', 'config', 'user.email', 'installer@lox.local']);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(4, 'git', ['-C', 'lox-vault', 'config', 'user.name', 'Lox Installer']);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(5, 'git', ['-C', 'lox-vault', 'commit', '-m', 'chore: initialize para template']);
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(6, 'git', ['-C', 'lox-vault', 'push', 'origin', 'main']);
+  });
+
+  it('propagates git add failures immediately (no status/commit/push attempted)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(
+      Object.assign(new Error('Command failed'), { stderr: 'fatal: unable to index file' }),
+    );
+    await expect(commitInitialVaultTemplate('lox-vault', 'para')).rejects.toThrow('Command failed');
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips commit and push when there is nothing to commit (idempotent re-run)', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add -A
+      .mockResolvedValueOnce({ stdout: '   \n', stderr: '' }); // porcelain output is whitespace only
+
+    const result = await commitInitialVaultTemplate('lox-vault', 'para');
+
+    expect(result).toBe('nothing-to-commit');
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(2);
+    // No commit or push should have fired
+    expect(vi.mocked(shell)).not.toHaveBeenCalledWith('git', expect.arrayContaining(['commit', '-m', expect.any(String)]));
+    expect(vi.mocked(shell)).not.toHaveBeenCalledWith('git', expect.arrayContaining(['push', 'origin', 'main']));
+  });
+
+  it('uses the correct preset name in the commit message', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'A  file\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await commitInitialVaultTemplate('lox-vault', 'zettelkasten');
+
+    expect(vi.mocked(shell)).toHaveBeenNthCalledWith(5, 'git', ['-C', 'lox-vault', 'commit', '-m', 'chore: initialize zettelkasten template']);
+  });
+
+  it('propagates git push failures (e.g. network, auth)', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'A  file\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(Object.assign(new Error('Command failed'), { stderr: 'remote: Permission denied' }));
+
+    await expect(commitInitialVaultTemplate('lox-vault', 'para')).rejects.toThrow('Command failed');
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Step 9 (stepVault) now verifies `cpSync` produced the expected top-level entries per preset, throwing a diagnostic with `templatesSrc` / `vaultDir` / missing / actual entries if the copy silently failed.
- After `.gitignore` + gitleaks hook install, the installer now runs `git add -A` → porcelain dirty-check → `commit` → `push origin main`, so the GitHub remote gets the template scaffold instead of staying empty. Idempotent on re-runs.
- Sets local `user.email` / `user.name` inline so `git commit` doesn't fail on Windows hosts without a global git config.
- `vaultDir` is now resolved to an absolute path at creation — diagnostic errors and `git -C` calls are CWD-independent.

## Why this was broken

The old step 9 copied templates, wrote `.gitignore`, installed the gitleaks hook — and then just moved on. No commit, no push. Result: three disconnected copies (local vault, empty GitHub remote, VM's vault clone that pulled from the empty remote via cron), converging only if the user happened to manually push. Users didn't know they needed to. Obsidian opened an empty vault.

The `cpSync` also had no post-copy verification, so a silent path-resolution failure (or a future packaging regression where `templates/` doesn't ship with the installer) produced the same empty-vault symptom with no error signal.

## Test plan

- [x] `npm run test --workspace=packages/installer` — 414 tests pass (+13 new for `verifyTemplatesCopied` + `commitInitialVaultTemplate`)
- [x] `npm run test --workspaces` — 532 total pass
- [x] `tsc --noEmit` clean on shared/core/installer
- [x] Code review via code-reviewer agent (MUST-FIX absolute path + git identity applied; additional add-failure test added)
- [ ] Windows CI: installer-tests workflow validates `cpSync` verification path
- [ ] Manual recovery path documented in CHANGELOG for users already on v0.6.13

Closes #122