### PR TITLE
fix: audit gate false-negatives on clean install (#119, PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.14] — 2026-04-05
+## [0.6.15] — 2026-04-05
+
+### Fixed
+- **Final security audit reported 4 false-negative check bugs on clean installs (#119, partial — PR-A).** Four gates in `packages/installer/src/security/gates.ts` were reporting failure even when the installer had delivered the promised security posture:
+  - **Branch protection (gate #2)**: threw on GitHub Free's "Upgrade to Pro" HTTP 403 for private repos. Step 9 already skips branch protection gracefully on Free accounts with a visible warning; the audit now recognises the Pro-gate 403 (via `isProPlanGate`) and counts it as N/A → pass, matching the installer's behaviour.
+  - **SSH key permissions (gate #6)**: had no Windows code path, always returned false on Windows because `stat -f %Lp` / `stat -c %a` don't exist there. Added a Windows branch using `icacls /findsid` against the four well-known loose-group SIDs (Everyone, Authenticated Users, BUILTIN\Users, CREATOR OWNER) — locale-independent, mirrors the four principals `utils/windows-acl.ts` removes in step 7.
+  - **Remote URL HTTPS (gate #14)**: checked `config.vault.repo.startsWith('https://')`, but `vault.repo` is stored as the GitHub short format `owner/repo` which never starts with `https://`, so the check always failed. Now queries the actual git remote via `git -C <local_path> remote get-url origin`.
+  - **.gitignore sensitive patterns (gate #16)**: invoked `cat ${repoPath}/.gitignore`, which (a) doesn't exist on Windows and (b) never shell-expanded the `~` in `vault.local_path='~/Obsidian/Lox'`, so the path resolved to a literal `~/Obsidian/Lox/.gitignore`. Now reads via Node `fs.readFileSync` with explicit tilde expansion.
+
+  Remaining #119 items (VM public IP, sshd hardening, gitleaks hook propagation) are installer-side gaps and will ship as separate PRs.
+
+
 
 ### Fixed
 - **Step 9 — vault remained empty after install on Windows (#122).** The installer copied template files via `cpSync` without verifying the copy succeeded, and never ran `git add/commit/push` after the template copy. Three failure modes resulted: (a) silent `cpSync` failures produced an empty vault with no error; (b) templates landed locally but the GitHub `lox-vault` remote stayed empty because no initial commit was ever made; (c) the VM's `sync-vault.sh` cron (every 2 min) pulled from an empty remote, so the VM's vault clone also stayed empty. Fix adds post-copy verification (throws with `templatesSrc`, `vaultDir`, missing entries, and actual entries when the expected template structure is absent for the selected preset) and a git `add -A` → porcelain dirty-check → `commit` → `push origin main` sequence after `.gitignore` + gitleaks hook install. Idempotent: re-runs over an already-committed vault are a no-op. For users already on v0.6.13 or earlier with an empty vault: `cd lox-vault && git add -A && git commit -m "chore: initialize template" && git push origin main` (run from the directory where the installer was executed, after manually copying templates from `lox-brain/templates/<preset>/` if the local vault is also empty).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/security/gates.ts
+++ b/packages/installer/src/security/gates.ts
@@ -1,5 +1,28 @@
 import { shell } from '../utils/shell.js';
+import { isProPlanGate } from '../steps/step-vault.js';
 import type { LoxConfig } from '@lox-brain/shared';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * Expand a leading `~` in a path to the user's home directory. Only the
+ * bare `~`, `~/...`, or `~\...` forms are expanded — the POSIX `~user/...`
+ * named-user form is intentionally NOT supported (Lox never generates
+ * those paths, and expanding them naively would corrupt them silently).
+ * Any other leading token is passed through unchanged.
+ *
+ * Why we need this at all: `shell()` routes through `execFile`, which
+ * does NOT invoke a shell and therefore does not perform tilde
+ * expansion on arguments. Before this helper, `config.vault.local_path
+ * = '~/Obsidian/Lox'` was passed verbatim to fs calls and never
+ * resolved — part of the #119 item 7 regression.
+ */
+function expandTilde(p: string): string {
+  if (p !== '~' && !p.startsWith('~/') && !p.startsWith('~\\')) return p;
+  const home = homedir() || process.env.HOME || process.env.USERPROFILE || '';
+  return home + p.slice(1);
+}
 
 export interface SecurityGate {
   name: string;
@@ -40,8 +63,14 @@ export const securityGates: SecurityGate[] = [
         ]);
         // If the API call succeeds, protection exists
         return stdout.length > 0 || true;
-      } catch {
-        // 404 means no protection — fail
+      } catch (err) {
+        // GitHub Free rejects branch protection on private repos with
+        // HTTP 403 "Upgrade to GitHub Pro" (#119 item 1). Step 9 already
+        // skipped the setup with a visible warning — counting it as a
+        // failure here would produce a false negative on every Free
+        // install. Treat as N/A, pass. Any other error (404, auth, etc.)
+        // is a real failure.
+        if (isProPlanGate(err)) return true;
         return false;
       }
     },
@@ -139,14 +168,56 @@ export const securityGates: SecurityGate[] = [
     name: 'SSH key permissions validated',
     blocking: true,
     async check() {
+      const keyPath = join(homedir(), '.ssh', 'google_compute_engine');
+      if (process.platform === 'win32') {
+        // Windows has no stat -c/%a equivalent (#119 item 4). Use
+        // `icacls /findsid <SID>` with well-known loose-group SIDs.
+        // Both presence and absence of the SID produce exit code 0, so
+        // we have to parse stdout. But the "not found" message itself
+        // IS localized on pt-BR/Windows ("Nenhum arquivo correspondente..."),
+        // so we can't match that text. What IS stable across locales
+        // is the SID string itself — icacls prints the SID in its
+        // output ONLY when the SID matches the ACL. Check for the
+        // SID substring instead.
+        //
+        // The four SIDs match the four loose principals that
+        // utils/windows-acl.ts removes: Everyone, Authenticated Users,
+        // BUILTIN\Users, CREATOR OWNER.
+        if (!existsSync(keyPath)) return false;
+        const looseSids = [
+          'S-1-1-0',       // Everyone
+          'S-1-5-11',      // Authenticated Users
+          'S-1-5-32-545',  // BUILTIN\Users
+          'S-1-3-0',       // CREATOR OWNER
+        ];
+        try {
+          for (const sid of looseSids) {
+            const { stdout } = await shell('icacls', [keyPath, '/findsid', sid]);
+            // icacls prints the SID string ONLY when it is present in
+            // the ACL (along with the file path and the principal's
+            // localized name). Absence of the SID in stdout = SID not
+            // in the ACL. This works across Windows locales.
+            if (stdout.includes(sid)) {
+              return false;
+            }
+          }
+          return true;
+        } catch {
+          // icacls failing on a file that exists and whose owner is the
+          // current user would be unusual — fixWindowsAcl grants user:F.
+          // Fail-closed: an audit that can't verify should report
+          // failure, not silently trust.
+          return false;
+        }
+      }
+      // POSIX (Linux/macOS): BSD stat first, Linux stat as fallback.
       try {
-        const { stdout } = await shell('stat', ['-f', '%Lp', `${process.env.HOME}/.ssh/google_compute_engine`]);
+        const { stdout } = await shell('stat', ['-f', '%Lp', keyPath]);
         const perm = stdout.trim();
         return perm === '600' || perm === '400';
       } catch {
-        // Try Linux stat format
         try {
-          const { stdout } = await shell('stat', ['-c', '%a', `${process.env.HOME}/.ssh/google_compute_engine`]);
+          const { stdout } = await shell('stat', ['-c', '%a', keyPath]);
           const perm = stdout.trim();
           return perm === '600' || perm === '400';
         } catch {
@@ -302,7 +373,21 @@ export const securityGates: SecurityGate[] = [
     name: 'Remote URL uses HTTPS',
     blocking: true,
     async check(config) {
-      return config.vault.repo.startsWith('https://');
+      // Previously: checked config.vault.repo.startsWith('https://').
+      // But step-vault stores vault.repo as "owner/repo" (the GitHub
+      // short format) — NEVER starting with https:// — so the check
+      // always failed (#119 item 5). Now query the ACTUAL git remote
+      // URL that the local clone uses for fetch/push, which is what
+      // this check's name implies. `git -C <path> remote get-url origin`
+      // is cross-platform and goes through execFile via shell().
+      try {
+        const localPath = expandTilde(config.vault.local_path ?? '');
+        if (!localPath) return false;
+        const { stdout } = await shell('git', ['-C', localPath, 'remote', 'get-url', 'origin']);
+        return stdout.trim().startsWith('https://');
+      } catch {
+        return false;
+      }
     },
   },
 
@@ -328,10 +413,15 @@ export const securityGates: SecurityGate[] = [
     name: '.gitignore covers sensitive patterns',
     blocking: true,
     async check(config) {
+      // Previously: `cat ${repoPath}/.gitignore` (#119 item 7). Two bugs:
+      // (a) `cat` doesn't exist on Windows, (b) `execFile`-based shell()
+      // doesn't expand `~` in path args, so local_path='~/Obsidian/Lox'
+      // was read as a literal path that never resolved. Now read via
+      // Node fs with explicit tilde expansion.
       try {
-        const repoPath = config.vault.local_path;
-        const { stdout } = await shell('cat', [`${repoPath}/.gitignore`]);
-        const content = stdout.toLowerCase();
+        const repoPath = expandTilde(config.vault.local_path ?? '');
+        if (!repoPath) return false;
+        const content = readFileSync(join(repoPath, '.gitignore'), 'utf-8').toLowerCase();
         const requiredPatterns = ['.env', '*.pem', '*.key', 'credentials.json'];
         return requiredPatterns.every(p => content.includes(p.toLowerCase()));
       } catch {

--- a/packages/installer/tests/security/gates.test.ts
+++ b/packages/installer/tests/security/gates.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { securityGates } from '../../src/security/gates.js';
+import { shell } from '../../src/utils/shell.js';
+import { mkdirSync, writeFileSync, rmSync, existsSync as existsSyncReal } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import type { LoxConfig } from '@lox-brain/shared';
+
+vi.mock('../../src/utils/shell.js', () => ({
+  shell: vi.fn(),
+}));
+
+// Minimal config stub. Each test overrides only the fields its gate inspects.
+function buildConfig(overrides: Partial<LoxConfig> = {}): LoxConfig {
+  return {
+    version: '0.6.14',
+    mode: 'personal',
+    gcp: {
+      project: 'test-project',
+      region: 'us-east1',
+      zone: 'us-east1-b',
+      vm_name: 'lox-vm',
+      service_account: 'lox-sa@test-project.iam.gserviceaccount.com',
+    },
+    database: { host: '127.0.0.1', port: 5432, name: 'lox_brain', user: 'lox' },
+    vpn: { server_ip: '10.10.0.1', subnet: '10.10.0.0/24', listen_port: 51820, peers: [] },
+    vault: { repo: 'alice/lox-vault', local_path: '~/Obsidian/Lox', preset: 'para' },
+    install_dir: '/tmp/lox',
+    installed_at: '2026-04-05T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function findGate(name: string) {
+  const gate = securityGates.find(g => g.name === name);
+  if (!gate) throw new Error(`Gate not found: ${name}`);
+  return gate;
+}
+
+describe('Branch protection gate (#119)', () => {
+  const gate = findGate('Branch protection enabled on main');
+
+  beforeEach(() => { vi.mocked(shell).mockReset(); });
+
+  it('passes when gh api returns protection details', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: '{}', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('passes (N/A) when GitHub Free rejects with Pro-upgrade 403', async () => {
+    // Private repos on GitHub Free can't enable branch protection — the
+    // installer already skipped it in step 9 with a warning. Counting it
+    // as a failure here would produce a false negative in the audit.
+    vi.mocked(shell).mockRejectedValueOnce(Object.assign(new Error('Command failed'), {
+      stderr: 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)',
+    }));
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('fails when gh api returns a different error (real missing protection)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(Object.assign(new Error('Command failed'), {
+      stderr: 'gh: Not Found (HTTP 404)',
+    }));
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails on generic errors (auth, network)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(Object.assign(new Error('Command failed'), {
+      stderr: 'HTTP 403 Forbidden — token expired',
+    }));
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+});
+
+describe('SSH key permissions gate (#119)', () => {
+  const gate = findGate('SSH key permissions validated');
+  const originalPlatform = process.platform;
+
+  beforeEach(() => { vi.mocked(shell).mockReset(); });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('POSIX: passes when stat returns 600', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.mocked(shell).mockRejectedValueOnce(new Error('stat -f unsupported'));
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: '600\n', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('POSIX: fails when stat returns 644', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.mocked(shell).mockRejectedValueOnce(new Error('stat -f unsupported'));
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: '644\n', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('Windows: passes when icacls output contains none of the loose SIDs', async () => {
+    // icacls prints the SID string ONLY when the SID is in the ACL. An
+    // output with NO SID substring means the key was hardened (step 7's
+    // fixWindowsAcl removes all four loose principals). Locale-independent:
+    // works on en-US ("Successfully processed 0 files") AND pt-BR
+    // ("Nenhum arquivo correspondente...") because neither phrase is
+    // what we match on.
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    // The key file must exist for the Windows branch to probe — the
+    // check calls existsSync upfront and fails if absent. Point the
+    // test at a file we know exists (the test file itself).
+    const keyPath = join(homedir(), '.ssh', 'google_compute_engine');
+    vi.mocked(shell).mockResolvedValue({
+      stdout: 'Successfully processed 0 files; Failed processing 0 files',
+      stderr: '',
+    });
+    // Skip this test if the SSH key doesn't exist on the CI runner —
+    // existsSync guard would return false before reaching icacls mock.
+    if (!existsSyncReal(keyPath)) return;
+    expect(await gate.check(buildConfig())).toBe(true);
+    // Called once per loose SID (4 total) — iteration stops early on
+    // the first match, but no-match path visits all four.
+    expect(vi.mocked(shell).mock.calls.length).toBe(4);
+  });
+
+  it('Windows: fails when icacls stdout contains a loose SID (e.g. S-1-1-0 Everyone)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const keyPath = join(homedir(), '.ssh', 'google_compute_engine');
+    if (!existsSyncReal(keyPath)) return;
+    // icacls prints the SID in its output when the SID is present in
+    // the ACL. The first call hits S-1-1-0 (Everyone).
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: `${keyPath} Everyone:(R,W)\n  S-1-1-0\nSuccessfully processed 1 files`,
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('Windows: fails when the key file does not exist (fail-closed)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    // Override HOME to a tmpdir that definitely has no ~/.ssh/google_compute_engine
+    const originalHome = process.env.HOME;
+    const originalUserprofile = process.env.USERPROFILE;
+    const emptyHome = join(tmpdir(), `lox-no-ssh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(emptyHome, { recursive: true });
+    process.env.HOME = emptyHome;
+    process.env.USERPROFILE = emptyHome;
+    try {
+      expect(await gate.check(buildConfig())).toBe(false);
+      // icacls must NOT be called when the file doesn't exist
+      expect(vi.mocked(shell)).not.toHaveBeenCalled();
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+      if (originalUserprofile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserprofile;
+      rmSync(emptyHome, { recursive: true, force: true });
+    }
+  });
+
+  it('Windows: fails when icacls itself throws (fail-closed, does not trust silently)', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const keyPath = join(homedir(), '.ssh', 'google_compute_engine');
+    if (!existsSyncReal(keyPath)) return;
+    vi.mocked(shell).mockRejectedValue(Object.assign(new Error('Command failed'), {
+      stderr: 'Access is denied',
+    }));
+    // Audit that can't verify should report failure, not pass silently.
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+});
+
+describe('Remote URL HTTPS gate (#119)', () => {
+  const gate = findGate('Remote URL uses HTTPS');
+
+  beforeEach(() => { vi.mocked(shell).mockReset(); });
+
+  it('passes when the actual git remote URL starts with https://', async () => {
+    // Previously the check looked at config.vault.repo ("alice/lox-vault")
+    // which NEVER starts with https:// — always failed. Now it queries
+    // `git -C <local_path> remote get-url origin` to verify the real URL.
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'https://github.com/alice/lox-vault.git\n', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('fails when the remote URL is SSH (git@github.com:...)', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'git@github.com:alice/lox-vault.git\n', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when git remote get-url fails (not a git repo, missing remote)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(new Error('fatal: No such remote'));
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('expands ~ in local_path before invoking git -C', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'https://github.com/a/b.git\n', stderr: '' });
+    await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: '~/Obsidian/Lox', preset: 'para' } as LoxConfig['vault'],
+    }));
+    const args = vi.mocked(shell).mock.calls[0][1] as string[];
+    // -C <path> ... — path must NOT start with '~' (unexpanded)
+    const dashC = args.indexOf('-C');
+    expect(dashC).toBeGreaterThanOrEqual(0);
+    expect(args[dashC + 1]).not.toMatch(/^~/);
+  });
+});
+
+describe('.gitignore sensitive patterns gate (#119)', () => {
+  const gate = findGate('.gitignore covers sensitive patterns');
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = join(tmpdir(), `lox-gitignore-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(workDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('passes when .gitignore contains all required patterns', async () => {
+    writeFileSync(join(workDir, '.gitignore'), [
+      '.env',
+      '.env.*',
+      '*.pem',
+      '*.key',
+      'credentials.json',
+      'service-account*.json',
+    ].join('\n'));
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as LoxConfig['vault'],
+    }))).toBe(true);
+  });
+
+  it('fails when .gitignore is missing a required pattern', async () => {
+    writeFileSync(join(workDir, '.gitignore'), '.env\n*.pem\n'); // missing *.key, credentials.json
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as LoxConfig['vault'],
+    }))).toBe(false);
+  });
+
+  it('fails when .gitignore does not exist at the vault path', async () => {
+    // No writeFileSync — directory is empty
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as LoxConfig['vault'],
+    }))).toBe(false);
+  });
+
+  it('expands ~ in local_path (regression for #119 item 7)', async () => {
+    // Previously the check `cat`ed `~/Obsidian/Lox/.gitignore` as a literal
+    // path. `cat` does NOT shell-expand `~`, so the check always failed
+    // when local_path used tilde notation. Simulate by passing a tilde
+    // path that resolves to a real dir on this machine.
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    if (!home || !workDir.startsWith(home)) {
+      // Cannot simulate tilde path on this CI — skip without failing
+      return;
+    }
+    writeFileSync(join(workDir, '.gitignore'), '.env\n*.pem\n*.key\ncredentials.json\n');
+    const tildePath = '~' + workDir.slice(home.length);
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: tildePath, preset: 'para' } as LoxConfig['vault'],
+    }))).toBe(true);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

First of several PRs for #119. The final security audit reported 7 failures on clean v0.6.12 installs. Four of them are check bugs in `packages/installer/src/security/gates.ts` — fixed here. The other three (VM public IP, sshd hardening, gitleaks hook propagation) are real installer gaps and will ship as separate PRs.

## Fixes

- **Gate #2 (Branch protection)**: recognises GitHub Free's \"Upgrade to Pro\" HTTP 403 via `isProPlanGate` and treats it as N/A → pass. Step 9 already skipped the setup with a visible warning, so counting it as a failure was producing false negatives on every Free install.
- **Gate #6 (SSH key perms)**: adds a Windows branch using `icacls /findsid <SID>` against the four loose-group SIDs. Locale-independent (matches on SID substring in stdout, not on localized phrases like \"No matching files were found\" / \"Nenhum arquivo correspondente...\"). Fail-closed on missing file or icacls error.
- **Gate #14 (HTTPS remote URL)**: queries the actual git remote via `git -C <path> remote get-url origin` instead of inspecting `config.vault.repo` (which is the short `owner/repo` format and never starts with `https://`).
- **Gate #16 (.gitignore patterns)**: replaces `cat $path/.gitignore` with `fs.readFileSync` + tilde expansion. Works on Windows; handles `~/Obsidian/Lox` properly.

## Test plan

- [x] 18 new tests in `tests/security/gates.test.ts` covering all four gates
- [x] Windows branch tests use `Object.defineProperty(process, 'platform', ...)` with restore in afterEach
- [x] `.gitignore` gate tested against real tmpdir filesystem
- [x] `npm run test --workspace=packages/installer` — 432 tests pass
- [x] `tsc --noEmit` clean
- [x] Code review via code-reviewer agent — BLOCKER (icacls locale) + 2 ISSUES fixed before push
- [ ] Fresh-install Windows audit should drop from 7 failures to 3 (remaining = installer gaps)

Refs #119