### PR TITLE
fix: VM public IP gate contradicted architecture (#119, PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.15] — 2026-04-05
+## [0.6.16] — 2026-04-05
+
+### Fixed
+- **Final audit gate "VM has no public IP" contradicted the actual architecture and always failed on working installs (#119, PR-B).** The check asserted the VM must have zero public IPs, but step 8 (`step-vpn.ts`) intentionally attaches a static IP to the VM via `gcloud compute instances add-access-config --access-config-name=vpn-only` because WireGuard needs a reachable UDP endpoint on the internet. The check has been rewritten and renamed to **"VM public IP restricted to VPN endpoint"**: passes when the VM has zero access configs OR exactly one access config named `vpn-only` (the name the installer sets). Fails if any access config has a different name (e.g. the GCP default `external-nat`) or if more than one access config is attached. Combined with gate #4 (firewall deny-all except UDP 51820 to 0.0.0.0/0), this matches the real security posture: public IP exists, but only WireGuard responds on it. Existing installs don't need any VM-side change — their `vpn-only` access config already matches.
+
+
 
 ### Fixed
 - **Final security audit reported 4 false-negative check bugs on clean installs (#119, partial — PR-A).** Four gates in `packages/installer/src/security/gates.ts` were reporting failure even when the installer had delivered the promised security posture:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.15",
+      "version": "0.6.16",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/security/gates.ts
+++ b/packages/installer/src/security/gates.ts
@@ -1,5 +1,6 @@
 import { shell } from '../utils/shell.js';
 import { isProPlanGate } from '../steps/step-vault.js';
+import { VPN_ACCESS_CONFIG_NAME } from '../steps/step-vpn.js';
 import type { LoxConfig } from '@lox-brain/shared';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -76,9 +77,20 @@ export const securityGates: SecurityGate[] = [
     },
   },
 
-  // 3. VM has no public IP
+  // 3. VM public IP is restricted to the VPN endpoint (#119 item 2)
+  //
+  // The VM intentionally HAS a public IP: step 8 (step-vpn.ts) attaches
+  // a static IP via `gcloud compute instances add-access-config
+  // --access-config-name=vpn-only` because WireGuard needs a reachable
+  // UDP endpoint on the internet. The previous "VM has no public IP"
+  // check contradicted the architecture and always failed on working
+  // installs. What we actually verify here is that the public IP exists
+  // ONLY as the VPN endpoint — any additional or differently-named
+  // access config means an unintended IP got attached. The firewall
+  // gate (#4) is the companion check that guarantees only UDP 51820 is
+  // reachable on that IP.
   {
-    name: 'VM has no public IP',
+    name: 'VM public IP restricted to VPN endpoint',
     blocking: true,
     async check(config) {
       try {
@@ -86,16 +98,22 @@ export const securityGates: SecurityGate[] = [
           'compute', 'instances', 'describe', config.gcp.vm_name,
           '--zone', config.gcp.zone,
           '--project', config.gcp.project,
-          '--format', 'json(networkInterfaces[].accessConfigs[].natIP)',
+          '--format', 'json(networkInterfaces[].accessConfigs[])',
         ]);
         const parsed = JSON.parse(stdout);
         const interfaces = parsed.networkInterfaces ?? [];
-        for (const iface of interfaces) {
-          for (const ac of iface.accessConfigs ?? []) {
-            if (ac.natIP) return false;
-          }
-        }
-        return true;
+        const allConfigs = interfaces.flatMap(
+          (iface: { accessConfigs?: Array<{ name?: string }> }) => iface.accessConfigs ?? [],
+        );
+        // Zero access configs = no public IP at all. Strictly safer
+        // than the "one vpn-only config" state from a public-exposure
+        // standpoint. If step 8 silently failed to attach the static
+        // IP, the VPN tunnel probe in step 12 catches that failure —
+        // this gate is about "is the public IP restricted?", and the
+        // answer is trivially yes when there is no public IP.
+        if (allConfigs.length === 0) return true;
+        if (allConfigs.length === 1 && allConfigs[0].name === VPN_ACCESS_CONFIG_NAME) return true;
+        return false;
       } catch {
         return false;
       }

--- a/packages/installer/src/steps/step-vpn.ts
+++ b/packages/installer/src/steps/step-vpn.ts
@@ -26,6 +26,14 @@ const TOTAL_STEPS = 12;
 const VM_NAME = 'lox-vm';
 const VPN_LISTEN_PORT = 51820;
 const VPN_SERVER_IP = '10.10.0.1';
+/**
+ * Name for the VM's single public-IP access config. The audit gate
+ * `VM public IP restricted to VPN endpoint` imports this constant to
+ * verify the attached public IP is the one we created intentionally
+ * (and not, e.g., the GCP default `external-nat`). Keep the two
+ * call sites in sync via this constant.
+ */
+export const VPN_ACCESS_CONFIG_NAME = 'vpn-only';
 const VPN_CLIENT_IP = '10.10.0.3'; // Mac client (0.2 reserved for Arch)
 const VPN_SUBNET = '10.10.0.0/24';
 const HOST_INTERFACE = 'ens4'; // GCP default NIC
@@ -152,7 +160,7 @@ export async function stepVpn(ctx: InstallerContext): Promise<StepResult> {
         await shell('gcloud', [
           'compute', 'instances', 'add-access-config', VM_NAME,
           '--zone', zone,
-          '--access-config-name=vpn-only',
+          `--access-config-name=${VPN_ACCESS_CONFIG_NAME}`,
           `--address=${staticIp}`,
           '--project', project,
         ]);
@@ -162,13 +170,13 @@ export async function stepVpn(ctx: InstallerContext): Promise<StepResult> {
           await shell('gcloud', [
             'compute', 'instances', 'delete-access-config', VM_NAME,
             '--zone', zone,
-            '--access-config-name=vpn-only',
+            `--access-config-name=${VPN_ACCESS_CONFIG_NAME}`,
             '--project', project,
           ]);
           await shell('gcloud', [
             'compute', 'instances', 'add-access-config', VM_NAME,
             '--zone', zone,
-            '--access-config-name=vpn-only',
+            `--access-config-name=${VPN_ACCESS_CONFIG_NAME}`,
             `--address=${staticIp}`,
             '--project', project,
           ]);

--- a/packages/installer/tests/security/audit.test.ts
+++ b/packages/installer/tests/security/audit.test.ts
@@ -5,29 +5,29 @@ import type { AuditResult } from '../../src/security/audit.js';
 describe('renderAuditResults', () => {
   it('renders all-passed audit', () => {
     const results: AuditResult[] = [
-      { name: 'VM has no public IP', passed: true, blocking: true },
+      { name: 'VM public IP restricted to VPN endpoint', passed: true, blocking: true },
       { name: 'Firewall: deny-all', passed: true, blocking: true },
     ];
     const output = renderAuditResults(results);
     expect(output).toContain('passed');
-    expect(output).toContain('VM has no public IP');
+    expect(output).toContain('VM public IP restricted to VPN endpoint');
     expect(output).toContain('Zero Trust');
   });
 
   it('renders failed blocking audit', () => {
     const results: AuditResult[] = [
-      { name: 'VM has no public IP', passed: false, blocking: true },
+      { name: 'VM public IP restricted to VPN endpoint', passed: false, blocking: true },
       { name: 'Cloud Logging', passed: true, blocking: false },
     ];
     const output = renderAuditResults(results);
     expect(output).toContain('failed');
-    expect(output).toContain('VM has no public IP');
+    expect(output).toContain('VM public IP restricted to VPN endpoint');
     expect(output).not.toContain('Zero Trust');
   });
 
   it('non-blocking failure does not fail overall audit', () => {
     const results: AuditResult[] = [
-      { name: 'VM has no public IP', passed: true, blocking: true },
+      { name: 'VM public IP restricted to VPN endpoint', passed: true, blocking: true },
       { name: 'Cloud Logging', passed: false, blocking: false },
     ];
     const output = renderAuditResults(results);

--- a/packages/installer/tests/security/gates.test.ts
+++ b/packages/installer/tests/security/gates.test.ts
@@ -259,3 +259,104 @@ describe('.gitignore sensitive patterns gate (#119)', () => {
     }))).toBe(true);
   });
 });
+
+describe('VM public IP restricted to VPN endpoint gate (#119 PR-B)', () => {
+  const gate = findGate('VM public IP restricted to VPN endpoint');
+
+  beforeEach(() => { vi.mocked(shell).mockReset(); });
+
+  it('passes when VM has zero access configs (truly no public IP)', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({ networkInterfaces: [{}] }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('passes when networkInterfaces is an empty array', async () => {
+    // gcloud's behaviour when the VM has its external IP released but
+    // the interface still listed can produce an empty interfaces array
+    // via the JSON projection. Strictly safer than vpn-only; should pass.
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({ networkInterfaces: [] }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('passes when VM has exactly one access config named "vpn-only"', async () => {
+    // This is the correct-by-design state: step 8 (step-vpn.ts) attaches
+    // a static IP via `gcloud compute instances add-access-config
+    // --access-config-name=vpn-only` because WireGuard needs a reachable
+    // UDP endpoint. The firewall (gate #4) separately guarantees only
+    // UDP 51820 is open to 0.0.0.0/0.
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        networkInterfaces: [{
+          accessConfigs: [{ name: 'vpn-only', natIP: '35.196.10.20' }],
+        }],
+      }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(true);
+  });
+
+  it('fails when VM has a single access config with the default "external-nat" name', async () => {
+    // If someone manually re-creates the VM without --no-address OR
+    // attaches an access config via `gcloud compute instances add-access-config`
+    // without `--access-config-name=vpn-only`, the default name is
+    // "external-nat" (or "External NAT"). That's NOT our VPN endpoint —
+    // it means an unintended public IP exists.
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        networkInterfaces: [{
+          accessConfigs: [{ name: 'external-nat', natIP: '35.196.10.20' }],
+        }],
+      }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when VM has two access configs (extra IP attached)', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        networkInterfaces: [{
+          accessConfigs: [
+            { name: 'vpn-only', natIP: '35.196.10.20' },
+            { name: 'debug', natIP: '34.150.0.99' },
+          ],
+        }],
+      }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when VM has access configs on multiple network interfaces', async () => {
+    // Defense in depth: a VM with two NICs each holding an access config
+    // would pass a naive "first-interface" check but shouldn't pass ours.
+    vi.mocked(shell).mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        networkInterfaces: [
+          { accessConfigs: [{ name: 'vpn-only', natIP: '35.196.10.20' }] },
+          { accessConfigs: [{ name: 'external-nat', natIP: '34.150.0.99' }] },
+        ],
+      }),
+      stderr: '',
+    });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when gcloud describe fails (VM missing, auth error)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(Object.assign(new Error('Command failed'), {
+      stderr: 'ERROR: (gcloud.compute.instances.describe) NOT_FOUND: instance not found',
+    }));
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when gcloud returns malformed JSON', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'not json', stderr: '' });
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Second PR for #119. The audit gate \"VM has no public IP\" was always failing on working installs because it **contradicted the architecture**: the VM intentionally gets a public IP attached in step 8 (`step-vpn.ts:148-180`) via \`--access-config-name=vpn-only\` because WireGuard needs a reachable UDP endpoint on the internet.

This PR rewrites gate #3 to match the real security posture: **the public IP exists, but only the VPN endpoint responds on it**. The firewall gate (#4) is the companion check that verifies only UDP 51820 is open to 0.0.0.0/0.

## Changes

- **Gate renamed**: \`VM has no public IP\` → \`VM public IP restricted to VPN endpoint\`.
- **New pass condition**: 0 access configs OR exactly 1 config named \`vpn-only\`.
- **New fail cases**: differently-named config (e.g. GCP default \`external-nat\`), multiple configs, or access configs on multiple network interfaces.
- **Extracted constant**: \`VPN_ACCESS_CONFIG_NAME\` exported from \`step-vpn.ts\` — both the installer (writer) and the audit (reader) import it, preventing silent drift.

## Existing installs

No VM-side change needed. Existing Lox installs already have the \`vpn-only\` access config attached by step 8 — the gate will start passing on the next audit run with zero manual intervention.

## Test plan

- [x] 8 new tests covering: zero configs, empty interfaces array, single vpn-only config, single external-nat config, two configs, multi-interface configs, gcloud error, malformed JSON
- [x] \`audit.test.ts\` fixtures updated to the new gate name
- [x] \`npm run test --workspace=packages/installer\` — 440 tests pass
- [x] \`tsc --noEmit\` clean
- [x] Code review via code-reviewer agent — both ISSUES addressed (shared constant + clarifying comment)

Refs #119