### PR TITLE
fix: SSH hardening audit gate broken by && on Windows (#119, PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.16] — 2026-04-05
+## [0.6.17] — 2026-04-05
+
+### Fixed
+- **Final audit gate "SSH: no password auth, no root login" failed on Windows due to `&&` in `--command` (#119, PR-C).** The check ran `gcloud compute ssh --command "grep ... && grep ..."` which broke on Windows because `cmd.exe` interprets `&&` as its own chain operator instead of passing it to gcloud — the same class of bug already fixed in step-vm-setup.ts's `sshExecScript()`. Step 7 (`vm_phase_ssh_hardening`) already correctly hardens sshd_config via the file-upload SSH pattern; only the audit verification was broken. Split into two separate `gcloud compute ssh` calls, each with a single `grep`. No installer-step or VM-side change needed — existing installs already have the hardened sshd_config.
+
+
 
 ### Fixed
 - **Final audit gate "VM has no public IP" contradicted the actual architecture and always failed on working installs (#119, PR-B).** The check asserted the VM must have zero public IPs, but step 8 (`step-vpn.ts`) intentionally attaches a static IP to the VM via `gcloud compute instances add-access-config --access-config-name=vpn-only` because WireGuard needs a reachable UDP endpoint on the internet. The check has been rewritten and renamed to **"VM public IP restricted to VPN endpoint"**: passes when the VM has zero access configs OR exactly one access config named `vpn-only` (the name the installer sets). Fails if any access config has a different name (e.g. the GCP default `external-nat`) or if more than one access config is attached. Combined with gate #4 (firewall deny-all except UDP 51820 to 0.0.0.0/0), this matches the real security posture: public IP exists, but only WireGuard responds on it. Existing installs don't need any VM-side change — their `vpn-only` access config already matches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.16",
+      "version": "0.6.17",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/security/gates.ts
+++ b/packages/installer/src/security/gates.ts
@@ -162,19 +162,36 @@ export const securityGates: SecurityGate[] = [
   },
 
   // 5. SSH: no password auth, no root login
+  //
+  // Step 7 (vm_phase_ssh_hardening) runs sed to set both
+  // PasswordAuthentication and PermitRootLogin to "no" in
+  // /etc/ssh/sshd_config. Previously this gate verified both settings
+  // in a single `--command "grep ... && grep ..."` call. On Windows,
+  // cmd.exe interprets `&&` as its own chain operator instead of passing
+  // it to gcloud — same class of bug fixed in sshExecScript() for step 7.
+  // Now uses two separate SSH calls, each with a single grep (#119 item 3).
   {
     name: 'SSH: no password auth, no root login',
     blocking: true,
     async check(config) {
+      const sshBase = [
+        'compute', 'ssh', config.gcp.vm_name,
+        '--zone', config.gcp.zone,
+        '--project', config.gcp.project,
+        '--tunnel-through-iap',
+      ];
       try {
-        const { stdout } = await shell('gcloud', [
-          'compute', 'ssh', config.gcp.vm_name,
-          '--zone', config.gcp.zone,
-          '--project', config.gcp.project,
-          '--command', 'grep -c "^PasswordAuthentication no" /etc/ssh/sshd_config && grep -c "^PermitRootLogin no" /etc/ssh/sshd_config',
+        const { stdout: pwAuth } = await shell('gcloud', [
+          ...sshBase,
+          '--command', "grep -c '^PasswordAuthentication no' /etc/ssh/sshd_config",
         ]);
-        const lines = stdout.trim().split('\n');
-        return lines.every(l => parseInt(l, 10) >= 1);
+        if (parseInt(pwAuth.trim(), 10) < 1) return false;
+
+        const { stdout: rootLogin } = await shell('gcloud', [
+          ...sshBase,
+          '--command', "grep -c '^PermitRootLogin no' /etc/ssh/sshd_config",
+        ]);
+        return parseInt(rootLogin.trim(), 10) >= 1;
       } catch {
         return false;
       }

--- a/packages/installer/tests/security/gates.test.ts
+++ b/packages/installer/tests/security/gates.test.ts
@@ -360,3 +360,61 @@ describe('VM public IP restricted to VPN endpoint gate (#119 PR-B)', () => {
     expect(await gate.check(buildConfig())).toBe(false);
   });
 });
+
+describe('SSH hardening gate (#119 PR-C)', () => {
+  const gate = findGate('SSH: no password auth, no root login');
+
+  beforeEach(() => { vi.mocked(shell).mockReset(); });
+
+  it('passes when both PasswordAuthentication and PermitRootLogin are "no"', async () => {
+    // Step 7 (vm_phase_ssh_hardening) runs sed to set both. The gate
+    // verifies each setting with a separate gcloud SSH call (#119:
+    // previously used && in --command which broke on Windows cmd.exe).
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' })   // PasswordAuthentication no
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' });   // PermitRootLogin no
+    expect(await gate.check(buildConfig())).toBe(true);
+    // MUST be two separate SSH calls, no && chain
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails when PasswordAuthentication is not hardened', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '0', stderr: '' })   // PasswordAuth grep finds 0 matches
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' });   // PermitRootLogin is fine
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when PermitRootLogin is not hardened', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' })   // PasswordAuth is fine
+      .mockResolvedValueOnce({ stdout: '0', stderr: '' });   // Root login grep finds 0 matches
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('fails when the first SSH call throws (connection error)', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(new Error('SSH connection timed out'));
+    expect(await gate.check(buildConfig())).toBe(false);
+    // Must not attempt the second SSH call
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails when the second SSH call throws', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' })
+      .mockRejectedValueOnce(new Error('SSH connection reset'));
+    expect(await gate.check(buildConfig())).toBe(false);
+  });
+
+  it('each SSH call does NOT contain && (regression test for Windows cmd.exe)', async () => {
+    vi.mocked(shell)
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '1', stderr: '' });
+    await gate.check(buildConfig());
+    for (const call of vi.mocked(shell).mock.calls) {
+      const args = call[1] as string[];
+      const commandArg = args[args.indexOf('--command') + 1] ?? '';
+      expect(commandArg).not.toContain('&&');
+    }
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Third PR for #119. Gate #5 (SSH hardening) ran `gcloud compute ssh --command "grep ... && grep ..."`. On Windows, `cmd.exe` interprets `&&` as its own chain operator instead of passing it to gcloud — same class of bug already fixed in `step-vm-setup.ts`'s `sshExecScript()`.

**Step 7 already correctly hardens sshd_config** via the file-upload SSH pattern. Only the audit verification was broken. Fix: split into two separate `gcloud compute ssh` calls, each with a single `grep`. No installer-step or VM-side change needed — existing installs already have the hardened sshd_config.

## Test plan

- [x] 6 new tests covering: both-pass, pw-auth-fail, root-login-fail, SSH-error-short-circuits, second-call-error, no-&&-in-command regression test
- [x] 446 tests pass, tsc clean
- [ ] After v0.6.17, `#119` audit drops from 7 original failures to 1 (gitleaks — needs product decision)

Refs #119