### PR TITLE
feat: auto-install gitleaks + fix audit gate (#119, PR-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.17] — 2026-04-05
+## [0.6.18] — 2026-04-05
+
+### Added
+- **Auto-install gitleaks binary during step 9 (#119, PR-D).** The pre-commit hook was already installed in the vault but `gitleaks` binary was never shipped, making the hook a no-op. Step 9 now downloads gitleaks v8.21.2 from GitHub Releases to `~/.lox/bin/` — platform-aware (linux/darwin/windows, x64/arm64), extracts via `tar` or `Expand-Archive`, best-effort (prints manual-install instructions on failure, never blocks the step). The hook script was updated to check `~/.lox/bin/gitleaks` as a fallback when gitleaks is not on global PATH.
+
+### Fixed
+- **Audit gate "Pre-commit: gitleaks active" was broken on Windows and always failed (#119, PR-D).** Used `cat` (doesn't exist on Windows) and read from CWD instead of the vault local_path. Rewritten to use `fs.readFileSync` with `expandTilde`, verify hook content includes 'gitleaks', and confirm the binary exists (PATH or `~/.lox/bin/`). Promoted from `blocking: false` to `blocking: true` since gitleaks is now auto-installed.
+
+
 
 ### Fixed
 - **Final audit gate "SSH: no password auth, no root login" failed on Windows due to `&&` in `--command` (#119, PR-C).** The check ran `gcloud compute ssh --command "grep ... && grep ..."` which broke on Windows because `cmd.exe` interprets `&&` as its own chain operator instead of passing it to gcloud — the same class of bug already fixed in step-vm-setup.ts's `sshExecScript()`. Step 7 (`vm_phase_ssh_hardening`) already correctly hardens sshd_config via the file-upload SSH pattern; only the audit verification was broken. Split into two separate `gcloud compute ssh` calls, each with a single `grep`. No installer-step or VM-side change needed — existing installs already have the hardened sshd_config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/security/gates.ts
+++ b/packages/installer/src/security/gates.ts
@@ -426,17 +426,30 @@ export const securityGates: SecurityGate[] = [
     },
   },
 
-  // 15. Pre-commit: gitleaks active (non-blocking)
+  // 15. Pre-commit: gitleaks active
   {
     name: 'Pre-commit: gitleaks active',
-    blocking: false,
-    async check() {
+    blocking: true,
+    async check(config) {
       try {
-        const { stdout } = await shell('git', ['config', '--get', 'core.hooksPath']);
-        // If hooks path is set, check for gitleaks
-        const hooksPath = stdout.trim() || '.git/hooks';
-        const { stdout: hookContent } = await shell('cat', [`${hooksPath}/pre-commit`]);
-        return hookContent.includes('gitleaks');
+        const localPath = expandTilde(config.vault.local_path ?? '');
+        if (!localPath) return false;
+
+        // Read the hook file cross-platform via Node fs (not `cat`)
+        const hookPath = join(localPath, '.git', 'hooks', 'pre-commit');
+        if (!existsSync(hookPath)) return false;
+        const hookContent = readFileSync(hookPath, 'utf-8');
+        if (!hookContent.includes('gitleaks')) return false;
+
+        // Verify gitleaks binary is reachable (PATH or ~/.lox/bin/)
+        try {
+          await shell('gitleaks', ['version']);
+          return true;
+        } catch {
+          // Fallback: check ~/.lox/bin/gitleaks
+          const binaryName = process.platform === 'win32' ? 'gitleaks.exe' : 'gitleaks';
+          return existsSync(join(homedir(), '.lox', 'bin', binaryName));
+        }
       } catch {
         return false;
       }

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -64,18 +64,91 @@ desktop.ini
 .obsidian/cache
 `;
 
-const GITLEAKS_HOOK = `#!/usr/bin/env bash
+export const GITLEAKS_HOOK = `#!/usr/bin/env bash
 # gitleaks pre-commit hook — blocks secrets from being committed
+LOX_GITLEAKS="\${HOME}/.lox/bin/gitleaks"
 if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose
-  if [ $? -ne 0 ]; then
-    echo "ERROR: gitleaks detected secrets. Commit blocked."
-    exit 1
-  fi
+  GITLEAKS_CMD="gitleaks"
+elif [ -x "$LOX_GITLEAKS" ]; then
+  GITLEAKS_CMD="$LOX_GITLEAKS"
 else
   echo "WARNING: gitleaks not installed. Skipping secret scan."
+  exit 0
+fi
+$GITLEAKS_CMD protect --staged --verbose
+if [ $? -ne 0 ]; then
+  echo "ERROR: gitleaks detected secrets. Commit blocked."
+  exit 1
 fi
 `;
+
+/** Pinned gitleaks release version — known stable. */
+export const GITLEAKS_VERSION = '8.21.2';
+
+/**
+ * Attempt to install the gitleaks binary into `~/.lox/bin/`.
+ * Best-effort: returns true on success, false on any failure. Never throws.
+ *
+ * 1. Check if gitleaks is already on PATH.
+ * 2. If not, download the pinned release from GitHub and extract to ~/.lox/bin/.
+ * 3. chmod +x on non-Windows.
+ */
+export async function tryInstallGitleaks(): Promise<boolean> {
+  const { join } = await import('node:path');
+  const { mkdirSync, chmodSync, existsSync: fsExists } = await import('node:fs');
+  const { homedir: osHomedir, tmpdir } = await import('node:os');
+
+  try {
+    // Already available on PATH — nothing to do.
+    await shell('gitleaks', ['version']);
+    return true;
+  } catch {
+    // Not on PATH — proceed to download.
+  }
+
+  try {
+    const home = osHomedir();
+    const binDir = join(home, '.lox', 'bin');
+    mkdirSync(binDir, { recursive: true });
+
+    // Map Node.js values to gitleaks release naming conventions.
+    const osMap: Record<string, string> = { darwin: 'darwin', linux: 'linux', win32: 'windows' };
+    const archMap: Record<string, string> = { x64: 'x64', arm64: 'arm64' };
+    const os = osMap[process.platform];
+    const arch = archMap[process.arch];
+    if (!os || !arch) return false;
+
+    const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
+    const url = `https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${os}_${arch}.${ext}`;
+    const tmpFile = join(tmpdir(), `gitleaks-${Date.now()}.${ext}`);
+
+    await shell('curl', ['-fsSL', '-o', tmpFile, url], { timeout: 120_000 });
+
+    if (process.platform === 'win32') {
+      await shell('powershell', [
+        '-Command',
+        `Expand-Archive -Path '${tmpFile}' -DestinationPath '${binDir}' -Force`,
+      ]);
+    } else {
+      await shell('tar', ['-xzf', tmpFile, '-C', binDir, 'gitleaks']);
+    }
+
+    // chmod +x on POSIX
+    if (process.platform !== 'win32') {
+      const binaryPath = join(binDir, 'gitleaks');
+      if (fsExists(binaryPath)) {
+        chmodSync(binaryPath, 0o755);
+      }
+    }
+
+    // Cleanup temp file (best-effort)
+    try { (await import('node:fs')).rmSync(tmpFile, { force: true }); } catch { /* ignore */ }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Get the GitHub username from the authenticated gh CLI.
@@ -638,6 +711,23 @@ export async function stepVault(ctx: InstallerContext): Promise<StepResult> {
   const hookPath = join(hooksDir, 'pre-commit');
   writeFileSync(hookPath, GITLEAKS_HOOK, { mode: 0o755 });
   console.log(chalk.green('  ✓ gitleaks pre-commit hook installed'));
+
+  // 8b. Install gitleaks binary (best-effort — never fails the step)
+  const gitleaksInstalled = await withSpinner(
+    'Installing gitleaks binary...',
+    () => tryInstallGitleaks(),
+  );
+  if (gitleaksInstalled) {
+    console.log(chalk.green('  ✓ gitleaks binary available'));
+  } else {
+    console.log(chalk.yellow(
+      '  ⚠ Could not auto-install gitleaks. Install manually:\n'
+      + '    brew install gitleaks          # macOS\n'
+      + '    sudo apt install gitleaks      # Debian/Ubuntu\n'
+      + '    choco install gitleaks         # Windows\n'
+      + '    https://github.com/gitleaks/gitleaks/releases',
+    ));
+  }
 
   // 9. Initial commit + push (#122). Without this, templates + .gitignore +
   // hook land locally but the GitHub remote stays empty — the VM cron pulls

--- a/packages/installer/tests/security/gates.test.ts
+++ b/packages/installer/tests/security/gates.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { securityGates } from '../../src/security/gates.js';
 import { shell } from '../../src/utils/shell.js';
-import { mkdirSync, writeFileSync, rmSync, existsSync as existsSyncReal } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync as existsSyncReal, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import type { LoxConfig } from '@lox-brain/shared';
@@ -416,5 +416,102 @@ describe('SSH hardening gate (#119 PR-C)', () => {
       const commandArg = args[args.indexOf('--command') + 1] ?? '';
       expect(commandArg).not.toContain('&&');
     }
+  });
+});
+
+describe('Pre-commit gitleaks gate (#119 item 6)', () => {
+  const gate = findGate('Pre-commit: gitleaks active');
+  let workDir: string;
+
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+    workDir = join(tmpdir(), `lox-gitleaks-gate-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(join(workDir, '.git', 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('is a blocking gate', () => {
+    expect(gate.blocking).toBe(true);
+  });
+
+  it('passes when hook exists with gitleaks content AND binary is on PATH', async () => {
+    writeFileSync(join(workDir, '.git', 'hooks', 'pre-commit'), '#!/bin/bash\ngitleaks protect --staged\n');
+    // shell('gitleaks', ['version']) succeeds
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'v8.21.2', stderr: '' });
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as any,
+    }))).toBe(true);
+  });
+
+  it('passes when hook exists AND binary is in ~/.lox/bin/ (PATH check fails)', async () => {
+    writeFileSync(join(workDir, '.git', 'hooks', 'pre-commit'), '#!/bin/bash\ngitleaks protect --staged\n');
+    // shell('gitleaks', ['version']) fails — not on PATH
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gitleaks'));
+
+    // Create the binary in ~/.lox/bin/ so existsSync finds it
+    const binaryName = process.platform === 'win32' ? 'gitleaks.exe' : 'gitleaks';
+    const loxBinDir = join(homedir(), '.lox', 'bin');
+    const binaryPath = join(loxBinDir, binaryName);
+    const binaryExisted = existsSyncReal(binaryPath);
+    if (!binaryExisted) {
+      mkdirSync(loxBinDir, { recursive: true });
+      writeFileSync(binaryPath, 'placeholder');
+    }
+    try {
+      expect(await gate.check(buildConfig({
+        vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as any,
+      }))).toBe(true);
+    } finally {
+      if (!binaryExisted) {
+        try { rmSync(binaryPath, { force: true }); } catch { /* best-effort */ }
+      }
+    }
+  });
+
+  it('fails when hook exists but gitleaks binary not found anywhere', async () => {
+    writeFileSync(join(workDir, '.git', 'hooks', 'pre-commit'), '#!/bin/bash\ngitleaks protect --staged\n');
+    // shell('gitleaks', ['version']) fails
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gitleaks'));
+
+    // Ensure ~/.lox/bin/gitleaks does NOT exist
+    const binaryName = process.platform === 'win32' ? 'gitleaks.exe' : 'gitleaks';
+    const binaryPath = join(homedir(), '.lox', 'bin', binaryName);
+    const binaryExisted = existsSyncReal(binaryPath);
+    if (binaryExisted) {
+      // Cannot safely remove user's real binary — skip test
+      return;
+    }
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as any,
+    }))).toBe(false);
+  });
+
+  it('fails when hook file does not exist', async () => {
+    // workDir exists but no pre-commit hook file
+    rmSync(join(workDir, '.git', 'hooks', 'pre-commit'), { force: true });
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as any,
+    }))).toBe(false);
+  });
+
+  it('fails when hook exists but does not contain gitleaks', async () => {
+    writeFileSync(join(workDir, '.git', 'hooks', 'pre-commit'), '#!/bin/bash\necho "no secret scan"\n');
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: workDir, preset: 'para' } as any,
+    }))).toBe(false);
+  });
+
+  it('expands ~ in local_path before reading the hook', async () => {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+    if (!home || !workDir.startsWith(home)) return; // skip if can't simulate tilde
+    writeFileSync(join(workDir, '.git', 'hooks', 'pre-commit'), '#!/bin/bash\ngitleaks protect\n');
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'v8.21.2', stderr: '' });
+    const tildePath = '~' + workDir.slice(home.length);
+    expect(await gate.check(buildConfig({
+      vault: { repo: 'a/b', local_path: tildePath, preset: 'para' } as any,
+    }))).toBe(true);
   });
 });

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH, resolveTemplatesDir, verifyTemplatesCopied, commitInitialVaultTemplate, EXPECTED_TEMPLATE_ENTRIES } from '../../src/steps/step-vault.js';
+import { isProPlanGate, isRepoNotFoundError, repoExists, buildVmSetupScript, isValidPatFormat, gcpSecretExists, VM_SETUP_SCRIPT_REMOTE_PATH, resolveTemplatesDir, verifyTemplatesCopied, commitInitialVaultTemplate, EXPECTED_TEMPLATE_ENTRIES, tryInstallGitleaks, GITLEAKS_VERSION, GITLEAKS_HOOK } from '../../src/steps/step-vault.js';
 import { shell } from '../../src/utils/shell.js';
 import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -519,5 +519,65 @@ describe('commitInitialVaultTemplate (#122)', () => {
       .mockRejectedValueOnce(Object.assign(new Error('Command failed'), { stderr: 'remote: Permission denied' }));
 
     await expect(commitInitialVaultTemplate('lox-vault', 'para')).rejects.toThrow('Command failed');
+  });
+});
+
+describe('GITLEAKS_HOOK constant (#119 item 6)', () => {
+  it('includes the ~/.lox/bin/gitleaks fallback path', () => {
+    expect(GITLEAKS_HOOK).toContain('${HOME}/.lox/bin/gitleaks');
+  });
+
+  it('checks PATH first, then falls back to ~/.lox/bin/', () => {
+    // The hook should check `command -v gitleaks` first, then the LOX path
+    const pathCheckIdx = GITLEAKS_HOOK.indexOf('command -v gitleaks');
+    const loxCheckIdx = GITLEAKS_HOOK.indexOf('LOX_GITLEAKS');
+    expect(pathCheckIdx).toBeGreaterThan(-1);
+    expect(loxCheckIdx).toBeGreaterThan(-1);
+  });
+
+  it('exits 0 (not 1) when gitleaks is not installed at all', () => {
+    // Graceful degradation: missing binary should not block commits
+    expect(GITLEAKS_HOOK).toContain('exit 0');
+  });
+
+  it('exits 1 when gitleaks detects secrets', () => {
+    expect(GITLEAKS_HOOK).toContain('exit 1');
+  });
+});
+
+describe('GITLEAKS_VERSION constant', () => {
+  it('is pinned to a specific version', () => {
+    expect(GITLEAKS_VERSION).toBe('8.21.2');
+  });
+});
+
+describe('tryInstallGitleaks (#119 item 6)', () => {
+  beforeEach(() => {
+    vi.mocked(shell).mockReset();
+  });
+
+  it('returns true immediately when gitleaks is already on PATH', async () => {
+    vi.mocked(shell).mockResolvedValueOnce({ stdout: 'v8.21.2', stderr: '' });
+    const result = await tryInstallGitleaks();
+    expect(result).toBe(true);
+    // Only the version check should have been called — no download
+    expect(vi.mocked(shell)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(shell)).toHaveBeenCalledWith('gitleaks', ['version']);
+  });
+
+  it('returns false gracefully when download fails (no throw)', async () => {
+    // gitleaks not on PATH
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gitleaks'));
+    // curl download fails
+    vi.mocked(shell).mockRejectedValueOnce(new Error('curl: (22) 404 Not Found'));
+    const result = await tryInstallGitleaks();
+    expect(result).toBe(false);
+  });
+
+  it('never throws even on unexpected errors', async () => {
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Command not found: gitleaks'));
+    vi.mocked(shell).mockRejectedValueOnce(new Error('Unexpected error'));
+    // Must resolve (not reject), returning false
+    await expect(tryInstallGitleaks()).resolves.toBe(false);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Final PR for #119. The pre-commit hook for secret scanning was installed in the vault but gitleaks binary was never shipped — the hook was a no-op on every install. The audit gate was also broken (used `cat`, no tilde expansion, checked CWD instead of vault path).

## Changes

### Installer (step-vault.ts)
- **`tryInstallGitleaks()`**: downloads gitleaks v8.21.2 from GitHub Releases to `~/.lox/bin/`. Platform-aware (linux/darwin/windows, x64/arm64). Extracts via `tar` (POSIX) or `Expand-Archive` (Windows). Best-effort: prints yellow warning with manual-install instructions on failure, never blocks step 9.
- **`GITLEAKS_HOOK`**: updated to check `~/.lox/bin/gitleaks` as fallback when not on global PATH.

### Audit (gates.ts)
- Gate #15 rewritten: reads hook via `fs.readFileSync` + `expandTilde(config.vault.local_path)`, verifies content includes 'gitleaks', confirms binary on PATH or in `~/.lox/bin/`.
- Promoted from `blocking: false` to `blocking: true`.

## Test plan

- [x] 461 tests pass (+14 new for hook content, binary install, audit check)
- [x] `tsc --noEmit` clean
- [ ] After v0.6.18, `#119` audit: **0 failures** on clean install (all 7 items resolved)

Closes #119