### PR TITLE
fix: replace broken 'lox status' hint with actionable steps (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.18] — 2026-04-05
+## [0.6.19] — 2026-04-05
+
+### Fixed
+- **Success screen told users to run `lox status` but the command was a stub and the binary wasn't on PATH (#121).** Replaced the `lox status` hints with actionable instructions that work today: verify the VPN tunnel via `ping 10.10.0.1`, then ask Claude Code to search notes (verifies the full stack — VPN + MCP server + vault indexing). Updated both en and pt-BR strings. The `lox status` stub now prints the same actionable steps instead of "coming soon". A proper `lox` CLI is tracked as a separate enhancement (#85).
+
+
 
 ### Added
 - **Auto-install gitleaks binary during step 9 (#119, PR-D).** The pre-commit hook was already installed in the vault but `gitleaks` binary was never shipped, making the hook a no-op. Step 9 now downloads gitleaks v8.21.2 from GitHub Releases to `~/.lox/bin/` — platform-aware (linux/darwin/windows, x64/arm64), extracts via `tar` or `Expand-Archive`, best-effort (prints manual-install instructions on failure, never blocks the step). The hook script was updated to check `~/.lox/bin/gitleaks` as a fallback when gitleaks is not on global PATH.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.18",
+      "version": "0.6.19",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -183,9 +183,9 @@ export const en: I18nStrings = {
   success_claude: 'Claude Code connected',
   success_next_steps: 'Next Steps',
   success_step_1: 'Open Obsidian and verify vault sync.',
-  success_step_2: 'Run "lox status" to check all services.',
-  success_step_3: 'Ask Claude Code to search your notes.',
-  success_status_hint: 'Run "lox status" anytime to check system health.',
+  success_step_2: 'Verify the VPN tunnel: ping 10.10.0.1',
+  success_step_3: 'Ask Claude Code to search your notes — this verifies the full stack.',
+  success_status_hint: 'VPN not connecting? Check WireGuard is active and retry the ping.',
 
   // Prompts
   press_enter: 'Press Enter to continue...',

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -45,9 +45,9 @@ export const ptBr: I18nStrings = {
   success_claude: 'Claude Code conectado',
   success_next_steps: 'Proximos Passos',
   success_step_1: 'Abra o Obsidian e verifique a sincronizacao do vault.',
-  success_step_2: 'Execute "lox status" para verificar todos os servicos.',
-  success_step_3: 'Peca ao Claude Code para buscar em suas notas.',
-  success_status_hint: 'Execute "lox status" a qualquer momento para verificar a saude do sistema.',
+  success_step_2: 'Verifique o tunel VPN: ping 10.10.0.1',
+  success_step_3: 'Peca ao Claude Code para buscar em suas notas — isso verifica a stack completa.',
+  success_status_hint: 'VPN nao conecta? Verifique se o WireGuard esta ativo e tente o ping novamente.',
 
   // Prompts
   press_enter: 'Pressione Enter para continuar...',

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -37,7 +37,9 @@ async function main(): Promise<void> {
     return;
   }
   if (args[0] === 'status') {
-    console.log('lox status: coming soon');
+    console.log('lox status is not yet implemented. Verify your setup with:');
+    console.log('  1. ping 10.10.0.1          (VPN tunnel)');
+    console.log('  2. Ask Claude Code to search your notes (full stack)');
     return;
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

The success screen told users to run `lox status` but the command was a stub ("coming soon") and the `lox` binary isn't on PATH after `npx` one-shot installs. Users following the instruction got either "command not found" (Windows) or a useless message.

## Fix

Replaced with instructions that work today:
1. Open Obsidian and verify vault sync
2. **Verify the VPN tunnel: `ping 10.10.0.1`**
3. **Ask Claude Code to search notes — this verifies the full stack**
4. Hint: VPN not connecting? Check WireGuard is active

Updated both `en.ts` and `pt-br.ts`. The `lox status` stub itself now prints the same actionable steps instead of "coming soon".

A proper `lox` CLI is tracked as a separate enhancement (#85).

## Test plan

- [x] 461 tests pass, tsc clean
- [x] No test changes needed — this is a string-only fix + stub update

Closes #121