### PR TITLE
fix: remove PAT from VM git config, use GIT_ASKPASS (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.19] — 2026-04-05
+## [0.6.20] — 2026-04-05
+
+### Fixed
+- **VM: GitHub PAT no longer persisted in `~/lox-vault/.git/config` (#107).** The VM clone used `https://${GH_PAT}@github.com/...` which embedded the token in the git remote URL on disk indefinitely. Switched to `GIT_ASKPASS`: a helper script (`~/.lox-git-askpass.sh`) fetches the PAT fresh from GCP Secret Manager on every `git fetch`/`git push`. The clone URL is now `https://x-access-token@github.com/...` (standard GitHub convention, no secret). `sync-vault.sh` exports `GIT_ASKPASS` and `GIT_TERMINAL_PROMPT=0` before git operations. Benefits: `.git/config` contains no token; rotating `lox-github-pat` in Secret Manager takes effect on the next cron tick (every 2 min) without any VM-side action. Existing installs are auto-migrated: the setup script detects PAT-in-URL (prefixes `ghp_` or `github_pat_`) and rewrites the remote to the clean URL on re-run.
+
+
 
 ### Fixed
 - **Success screen told users to run `lox status` but the command was a stub and the binary wasn't on PATH (#121).** Replaced the `lox status` hints with actionable instructions that work today: verify the VPN tunnel via `ping 10.10.0.1`, then ask Claude Code to search notes (verifies the full stack — VPN + MCP server + vault indexing). Updated both en and pt-BR strings. The `lox status` stub now prints the same actionable steps instead of "coming soon". A proper `lox` CLI is tracked as a separate enhancement (#85).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.19",
+      "version": "0.6.20",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vault.ts
+++ b/packages/installer/src/steps/step-vault.ts
@@ -224,6 +224,17 @@ export function buildVmSetupScript(input: VmSetupScriptInput): string {
     '#!/bin/bash',
     'set -euo pipefail',
     '',
+    // GIT_ASKPASS helper: fetches the PAT from Secret Manager on every
+    // git operation that needs auth. The token never persists in
+    // .git/config — git calls this script as a password provider (#107).
+    // Single-quoted heredoc tag prevents bash expansion; the secret name
+    // is embedded as a JS template literal at script-generation time.
+    `cat > ~/.lox-git-askpass.sh <<'ASKPASS_EOF'`,
+    '#!/bin/bash',
+    `gcloud secrets versions access latest --secret=${safeSecret}`,
+    'ASKPASS_EOF',
+    'chmod 700 ~/.lox-git-askpass.sh',
+    '',
     // #104-B: initial clone of the vault repo on the VM. sync-vault.sh
     // (written below) does `cd ~/lox-vault` and assumes it exists — but
     // step 9 only ever clones the repo on the user's local machine, never
@@ -233,17 +244,27 @@ export function buildVmSetupScript(input: VmSetupScriptInput): string {
     // skipped if ~/lox-vault/.git already exists.
     'if [ ! -d "$HOME/lox-vault/.git" ]; then',
     '  echo "[lox] Cloning vault repo to ~/lox-vault (one-time)..."',
-    `  GH_PAT=$(gcloud secrets versions access latest --secret=${safeSecret})`,
-    // PAT embedded in the clone URL so subsequent `git fetch` / `git push`
-    // in sync-vault.sh work without a credential helper. The token stays
-    // in ~/lox-vault/.git/config, which is 0600 on the VM (single-user).
-    `  git clone "https://\${GH_PAT}@github.com/${safeUser}/${safeRepo}.git" "$HOME/lox-vault"`,
-    '  unset GH_PAT',
+    '  GIT_ASKPASS="$HOME/.lox-git-askpass.sh" GIT_TERMINAL_PROMPT=0 \\',
+    `    git clone "https://x-access-token@github.com/${safeUser}/${safeRepo}.git" "$HOME/lox-vault"`,
+    'fi',
+    '',
+    // Migration: remove embedded PAT from existing installs (#107).
+    // Only triggers when the remote URL contains a PAT prefix (ghp_ or
+    // github_pat_), replacing it with the clean x-access-token@ URL that
+    // delegates auth to GIT_ASKPASS.
+    'if git -C "$HOME/lox-vault" remote get-url origin 2>/dev/null | grep -q \'@github.com\'; then',
+    '  CURRENT_URL=$(git -C "$HOME/lox-vault" remote get-url origin)',
+    '  if echo "$CURRENT_URL" | grep -qE \'https://(ghp_|github_pat_)\'; then',
+    '    echo "[lox] Migrating vault remote URL (removing embedded PAT)..."',
+    `    git -C "$HOME/lox-vault" remote set-url origin "https://x-access-token@github.com/${safeUser}/${safeRepo}.git"`,
+    '  fi',
     'fi',
     '',
     "cat > ~/sync-vault.sh <<'LOX_SYNC_EOF'",
     '#!/bin/bash',
     'set -euo pipefail',
+    'export GIT_ASKPASS="$HOME/.lox-git-askpass.sh"',
+    'export GIT_TERMINAL_PROMPT=0',
     'cd ~/lox-vault',
     'git fetch origin main',
     'git merge --ff-only origin/main || true',

--- a/packages/installer/tests/steps/step-vault.test.ts
+++ b/packages/installer/tests/steps/step-vault.test.ts
@@ -181,22 +181,44 @@ describe('buildVmSetupScript', () => {
     expect(script).toContain('rm -- "$0"');
   });
 
-  it('clones the vault repo to ~/lox-vault if missing (#104-B)', () => {
-    // Before #104-B, sync-vault.sh did `cd ~/lox-vault` against a
-    // directory that the installer never created on the VM — cron
-    // failed silently forever. Now the setup script clones the repo
-    // as a one-time bootstrap.
-    expect(script).toContain('if [ ! -d "$HOME/lox-vault/.git" ]; then');
-    expect(script).toContain('git clone');
-    expect(script).toContain('github.com/alice/lox-vault.git');
-    expect(script).toContain('$HOME/lox-vault');
+  it('writes GIT_ASKPASS helper script (~/.lox-git-askpass.sh)', () => {
+    // The askpass helper fetches the PAT from Secret Manager on demand,
+    // so the token never persists in .git/config (#107).
+    expect(script).toContain('cat > ~/.lox-git-askpass.sh');
+    expect(script).toContain('gcloud secrets versions access latest --secret=lox-github-pat');
+    expect(script).toContain('chmod 700 ~/.lox-git-askpass.sh');
   });
 
-  it('fetches the PAT from Secret Manager and unsets it after clone', () => {
-    // The token must be scrubbed from the shell env after the clone so
-    // it doesn't linger for subsequent lines in the setup script.
-    expect(script).toContain('gcloud secrets versions access latest --secret=lox-github-pat');
-    expect(script).toContain('unset GH_PAT');
+  it('clones with clean URL using GIT_ASKPASS (no PAT in URL)', () => {
+    // The clone URL uses x-access-token@ as the username — git prompts
+    // for password only, which GIT_ASKPASS answers from Secret Manager.
+    // No token lands in .git/config (#107).
+    expect(script).toContain('if [ ! -d "$HOME/lox-vault/.git" ]; then');
+    expect(script).toContain('git clone "https://x-access-token@github.com/alice/lox-vault.git"');
+    expect(script).toContain('GIT_ASKPASS="$HOME/.lox-git-askpass.sh"');
+    expect(script).toContain('GIT_TERMINAL_PROMPT=0');
+  });
+
+  it('sync-vault.sh exports GIT_ASKPASS before git operations', () => {
+    // sync-vault.sh needs GIT_ASKPASS so every git fetch/push re-fetches
+    // the PAT from Secret Manager rather than relying on a cached URL.
+    expect(script).toContain('export GIT_ASKPASS="$HOME/.lox-git-askpass.sh"');
+    expect(script).toContain('export GIT_TERMINAL_PROMPT=0');
+  });
+
+  it('migrates existing PAT-in-URL installs (#107)', () => {
+    // Existing installs may have PATs embedded in the remote URL.
+    // The migration block detects and replaces them.
+    expect(script).toContain('remote set-url origin');
+    expect(script).toContain("grep -qE 'https://(ghp_|github_pat_)'");
+    expect(script).toContain('https://x-access-token@github.com/alice/lox-vault.git');
+  });
+
+  it('clone URL never contains the PAT token', () => {
+    // The script must NOT embed the PAT directly in any URL or use
+    // the old GH_PAT variable pattern.
+    expect(script).not.toContain('${GH_PAT}@github.com');
+    expect(script).not.toContain('unset GH_PAT');
   });
 
   it('sanitizes repoName / githubUser / patSecretName against shell injection', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

The VM cloned the vault with `https://${GH_PAT}@github.com/...` which persisted the GitHub PAT in `~/lox-vault/.git/config` on disk indefinitely. Switched to `GIT_ASKPASS`: a helper script (`~/.lox-git-askpass.sh`) fetches the PAT fresh from GCP Secret Manager on every `git fetch`/`git push`.

## Changes

- **Clone URL**: `https://x-access-token@github.com/<user>/<repo>.git` (no token, standard GitHub convention)
- **GIT_ASKPASS helper**: `~/.lox-git-askpass.sh` — reads PAT from Secret Manager, chmod 700
- **sync-vault.sh**: exports `GIT_ASKPASS` + `GIT_TERMINAL_PROMPT=0` before git operations
- **Migration**: detects `ghp_`/`github_pat_` in existing remote URL and rewrites to clean URL on re-run

## Benefits

- `.git/config` never contains the token
- Rotating `lox-github-pat` in Secret Manager takes effect on the next cron tick (every 2 min)
- `git remote -v` no longer leaks the PAT to terminal/logs

## Test plan

- [x] 464 tests pass (+5 new, -2 removed for old PAT-in-URL pattern)
- [x] `tsc --noEmit` clean
- [x] Existing tests for sanitization, cron, self-cleanup still pass

Closes #107