### PR TITLE
feat: ship /zettelkasten skill + Claude Skills infra (#85, PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.20] — 2026-04-05
+## [0.7.0] — 2026-04-05
+
+### Added
+- **Claude Skills are now a first-class feature (#85, PR 1/3).** Lox ships with the `/zettelkasten` skill — generates atomic smart notes from project codebases in three modes (full scan, topic-focused, review). Skills are installed automatically to `~/.claude/skills/` during post-install. The splash screen tagline now includes "Claude Skills" in the stack listing. More skills coming: `/obsidian-ingest`, `/sync-calendar`, `/para`.
+
+### Changed
+- **README.md updated** to reflect shipped skills, corrected monorepo structure (removed phantom `cli/` package, added `skills/` and `templates/` directories), and fixed security section to say "VM public IP restricted to VPN endpoint" instead of the outdated "no public IP" claim (per #119/v0.6.16).
+
+
 
 ### Fixed
 - **VM: GitHub PAT no longer persisted in `~/lox-vault/.git/config` (#107).** The VM clone used `https://${GH_PAT}@github.com/...` which embedded the token in the git remote URL on disk indefinitely. Switched to `GIT_ASKPASS`: a helper script (`~/.lox-git-askpass.sh`) fetches the PAT fresh from GCP Secret Manager on every `git fetch`/`git push`. The clone URL is now `https://x-access-token@github.com/...` (standard GitHub convention, no secret). `sync-vault.sh` exports `GIT_ASKPASS` and `GIT_TERMINAL_PROMPT=0` before git operations. Benefits: `.git/config` contains no token; rotating `lox-github-pat` in Secret Manager takes effect on the next cron tick (every 2 min) without any VM-side action. Existing installs are auto-migrated: the setup script detects PAT-in-URL (prefixes `ghp_` or `github_pat_`) and rewrites the remote to the clean URL on re-run.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Claude Code --VPN--> MCP Server --> tools
 - **Text chunking** for large notes (4000 tokens, 200 overlap)
 - **Zero Trust security** -- no public IPs, VPN-only access, secrets in GCP Secret Manager
 - **Git sync** between local vault and VM (bidirectional, 2-min cron)
+- **Claude Skills** shipped out of the box (`/zettelkasten`, more coming) for day-one workflows
 - **CI/CD** via GitHub Actions (build, test, deploy over IAP tunnel)
 
 ## Quick Start
@@ -88,35 +89,38 @@ bash scripts/install.sh
 
 All search tools return metadata only by default. Use `read_note` to fetch full content after finding notes. Pagination parameters: `limit`, `offset`, `include_content`, `content_preview_length`.
 
-## CLI Commands
+## Claude Skills
 
-```bash
-lox status     # Check VM, database, and watcher health
-lox migrate    # Run pending database migrations
-```
+Lox ships with Claude Skills that provide opinionated workflows on top of the MCP tools. Installed automatically to `~/.claude/skills/` during setup.
+
+| Skill | Description |
+|-------|-------------|
+| `/zettelkasten` | Generate atomic smart notes from project codebases (3 modes: full scan, topic-focused, review) |
+
+More skills coming: `/obsidian-ingest` (content ingestion), `/sync-calendar` (Google Calendar → vault), `/para` (PARA method notes).
 
 ## Monorepo Structure
 
 ```
 lox-brain/
   packages/
-    core/                  # Main application
-      src/
-        lib/               # Embedding service, DB client
-        mcp/               # MCP server (stdio transport)
-        watcher/           # Vault watcher (chokidar)
-      tests/
-    cli/                   # CLI tool (lox status, lox migrate)
-    installer/             # Cross-platform installer (install.sh, install.ps1)
+    shared/                # Constants, types, config
+    core/                  # MCP server, vault watcher, embedding service (runs on VM)
+    installer/             # Cross-platform setup wizard (runs locally)
+  skills/
+    zettelkasten/          # /zettelkasten Claude Skill
   docs/
     plans/                 # Design docs and implementation plan
+  templates/
+    para/                  # PARA vault template
+    zettelkasten/          # Zettelkasten vault template
   .github/
     workflows/             # CI/CD (build, test, deploy)
 ```
 
 ## Security (Zero Trust)
 
-- VM has **no public IP** -- all access via WireGuard VPN
+- VM public IP **restricted to VPN endpoint** (WireGuard UDP 51820 only)
 - PostgreSQL listens on **localhost only** (127.0.0.1)
 - Firewall: **deny-all** default, only UDP 51820 (WireGuard) open
 - SSH via **IAP tunnel only** (Google range 35.235.240.0/20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.6.20",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.6.20",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.6.20",
+      "version": "0.7.0",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.6.20",
+      "version": "0.7.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.6.20",
+      "version": "0.7.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.6.20",
+  "version": "0.7.0",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.6.20",
+  "version": "0.7.0",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.6.20",
+  "version": "0.7.0",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/i18n/en.ts
+++ b/packages/installer/src/i18n/en.ts
@@ -146,7 +146,7 @@ export const en: I18nStrings = {
 
   // Splash
   splash_description: 'Personal AI-powered Second Brain with semantic search.',
-  splash_features: 'Obsidian + pgvector + MCP Server + WireGuard VPN',
+  splash_features: 'Obsidian + pgvector + MCP Server + Claude Skills + WireGuard VPN',
 
   // Steps
   step_prefix: 'Step',

--- a/packages/installer/src/i18n/pt-br.ts
+++ b/packages/installer/src/i18n/pt-br.ts
@@ -8,7 +8,7 @@ export const ptBr: I18nStrings = {
 
   // Splash
   splash_description: 'Segundo Cerebro pessoal com IA e busca semantica.',
-  splash_features: 'Obsidian + pgvector + MCP Server + WireGuard VPN',
+  splash_features: 'Obsidian + pgvector + MCP Server + Claude Skills + WireGuard VPN',
 
   // Steps
   step_prefix: 'Passo',

--- a/packages/installer/src/steps/step-post-install.ts
+++ b/packages/installer/src/steps/step-post-install.ts
@@ -5,6 +5,24 @@ import { getConfigPath } from '@lox-brain/shared';
 import type { InstallerContext } from './types.js';
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
+import chalk from 'chalk';
+
+async function installSkills(): Promise<void> {
+  const { cpSync, existsSync: fsExistsSync, mkdirSync: fsMkdirSync } = await import('node:fs');
+  const { resolve: pathResolve, join } = await import('node:path');
+  const { homedir } = await import('node:os');
+
+  // Skills source: skills/ at repo root, relative to this compiled file.
+  // Compiled layout: packages/installer/dist/steps/step-post-install.js
+  // → go up 4 dirs to repo root, then into skills/
+  const skillsSrc = pathResolve(__dirname, '..', '..', '..', '..', 'skills');
+  if (!fsExistsSync(skillsSrc)) return; // No skills directory — skip silently
+
+  const targetDir = join(homedir(), '.claude', 'skills');
+  fsMkdirSync(targetDir, { recursive: true });
+
+  cpSync(skillsSrc, targetDir, { recursive: true, force: true });
+}
 
 /**
  * Post-install sequence: security audit, hygiene reminders,
@@ -32,6 +50,14 @@ export async function runPostInstall(ctx: InstallerContext): Promise<void> {
     mkdirSync(configDir, { recursive: true });
   }
   writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+  // Install shipped Claude Skills
+  try {
+    await installSkills();
+    console.log(chalk.green('  ✓ Claude Skills installed to ~/.claude/skills/'));
+  } catch {
+    console.log(chalk.yellow('  ⚠ Could not install Claude Skills — copy them manually from skills/'));
+  }
 
   // Success screen
   const strings = t();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.6.20",
+  "version": "0.7.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skills/zettelkasten/SKILL.md
+++ b/skills/zettelkasten/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: zettelkasten
+description: Generate atomic smart notes in Zettelkasten format from project codebases, compatible with Obsidian and the Lox MCP Server
+---
+
+# Zettelkasten — Smart Notes from Code
+
+## Configuration
+
+This skill reads your Lox configuration from `~/.lox/config.json`:
+- `vault.preset`: determines folder structure (`zettelkasten` or `para`)
+- `vault.local_path`: path to your Obsidian vault (default: `~/Obsidian/Lox`)
+
+Folder mapping by preset:
+| Preset | Atomic notes folder | Tags folder |
+|--------|-------------------|-------------|
+| zettelkasten | `6 - Atomic Notes/` | `3 - Tags/` |
+| para | `4 - Resources/Zettelkasten/` | `4 - Resources/Tags/` |
+
+When the skill refers to "the atomic notes folder" or "the tags folder" below, it means the folder corresponding to the user's configured preset.
+
+Content language defaults to pt-BR. Technical terms and code identifiers stay in English. If the project's primary language is different (detected from README, CLAUDE.md, or user preference), adapt accordingly.
+
+## Purpose
+
+Code lives in repos. Knowledge lives in people's heads — until they leave, forget, or context-switch. This skill extracts implicit knowledge from a codebase and crystallizes it into atomic, cross-linked notes following the Zettelkasten method.
+
+Why Zettelkasten for code knowledge:
+- **Atomic notes** force clarity — one concept per note means no buried insights
+- **Cross-linking** reveals hidden relationships between components, decisions, and patterns
+- **Graph View** in Obsidian turns your project into a navigable knowledge map
+- **Status progression** (#baby -> #child -> #adult) tracks note maturity over time
+
+## Modes of Operation
+
+### Mode 1: Full Project Scan (no arguments)
+
+Trigger: `/zettelkasten` with no arguments.
+
+**Workflow:**
+
+1. **Explore the codebase** — Read project structure, package.json/pyproject.toml, README, key source files, config files, tests. Use the Explore sub-agent for large codebases.
+2. **Identify knowledge atoms** — Extract distinct concepts:
+   - Overall architecture and system boundaries
+   - Key design decisions and their rationale (ADRs if present)
+   - Data flow / pipeline descriptions
+   - Technology stack choices and why
+   - Database schema and relationships
+   - API contracts and integration points
+   - Security model and access control
+   - Deployment and infrastructure patterns
+   - Testing strategy
+   - Non-obvious patterns or conventions
+3. **Generate notes** — One .md file per concept, output to `docs/zettelkasten/`.
+4. **Create tag files** — .md files with content in `docs/zettelkasten/tags/` for every new tag introduced.
+5. **Generate MOC** — Create `docs/zettelkasten/_MOC.md` linking all generated notes.
+6. **Report** — List all created files and suggest next steps.
+
+### Mode 2: Topic-Focused (with topic argument)
+
+Trigger: `/zettelkasten <topic>` (e.g., `/zettelkasten OAuth authentication`).
+
+**Workflow:**
+
+1. **Search the codebase** for everything related to the topic — grep for keywords, read relevant files, trace call chains.
+2. **Generate 2-6 atomic notes** covering different facets of the topic within the project context.
+3. **Cross-link** with any existing notes in `docs/zettelkasten/` if present.
+4. **Update MOC** — Append new notes to `docs/zettelkasten/_MOC.md` (create if missing).
+5. **Create any new tag files** needed.
+
+### Mode 3: Review Existing Note (with "review" keyword)
+
+Trigger: `/zettelkasten review <path-to-note>`.
+
+**Workflow:**
+
+1. **Read the note** and extract its claims/descriptions.
+2. **Verify against current code** — Check if described patterns, file paths, APIs, schemas still exist and are accurate.
+3. **Update the note** — Fix inaccuracies, add new information, update links to renamed files.
+4. **Suggest status promotion** if the note is accurate and comprehensive (e.g., #baby -> #child).
+5. **Report changes** made.
+
+---
+
+## Output Format
+
+### Atomic Note (for architecture, decisions, patterns, concepts)
+
+```markdown
+2026-03-08 14:30
+
+Status: #baby
+
+Tags: [[claude-skill]] [[project-name]] [[architecture]]
+source: claude-skill
+
+# Title — Clear and Descriptive
+
+Content goes here. Write in the project's content language (default: pt-BR). Technical terms and code identifiers stay in English.
+
+Use short paragraphs. Be direct. Each note covers ONE concept.
+
+## Como funciona
+
+Explain the mechanism. Reference specific files:
+
+> O servico de embedding em `src/services/embedding.ts` utiliza a API da OpenAI com o modelo `text-embedding-3-small` para gerar vetores de 1536 dimensoes.
+
+Use code blocks for important signatures or configs:
+
+```typescript
+interface EmbeddingResult {
+  vector: number[];
+  tokenCount: number;
+}
+```
+
+## Por que essa decisao
+
+Explain the rationale. This is the most valuable part — the WHY behind code choices.
+
+> [!NOTE]
+> Use callout boxes for important caveats or gotchas.
+
+## Relacoes
+
+- Depende de: [[Project Name - Outra Nota Relevante]]
+- Impacta: [[Project Name - Nota Que Depende Desta]]
+- Alternativa considerada: [[Project Name - Alternativa Descartada]]
+
+## References
+
+- [[Project Name - Nota Relacionada 1]]
+- [[Project Name - Nota Relacionada 2]]
+- `src/path/to/relevant/file.ts`
+```
+
+### Source Material Note (for external references cited in notes)
+
+```markdown
+---
+title: "Reference Title"
+source: "https://url.com"
+author:
+  - "[[Author Name]]"
+published: 2024-01-15
+created: 2026-03-08
+description: "Brief description of the reference"
+tags:
+  - "clippings"
+  - "claude-skill"
+---
+
+# Reference Title
+
+Summary and relevance to the project.
+
+## References
+
+- [[note-that-cites-this]]
+```
+
+### MOC (Map of Content) — `_MOC.md`
+
+```markdown
+2026-03-08 14:30
+
+Status: #baby
+
+Tags: [[claude-skill]] [[project-name]] [[moc]]
+source: claude-skill
+
+# Project Name — Map of Content
+
+> [!INFO] Projeto
+> **Project Name** — breve descricao do que o projeto faz (1-2 frases).
+> Todas as notas abaixo pertencem a este projeto e estao conectadas pela tag [[project-name]].
+
+> [!NOTE]
+> Mapa de conteudo gerado automaticamente pelo skill `zettelkasten`.
+> Notas comecam como #baby. Promova manualmente conforme revisar.
+
+## Arquitetura
+
+- [[Project Name - Arquitetura Geral]] — Visao geral do sistema
+- [[Project Name - Fluxo de Dados]] — Pipeline de dados
+- [[Project Name - Modelo de Seguranca]] — Autenticacao e autorizacao
+
+## Decisoes Tecnicas
+
+- [[Project Name - Decisao Banco de Dados]] — Escolha e rationale
+- [[Project Name - Decisao Stack Embedding]] — Modelo e pipeline
+
+## Componentes
+
+- [[Project Name - Servico de Embedding]] — Geracao de vetores
+- [[Project Name - Vault Watcher]] — Deteccao de mudancas
+- [[Project Name - MCP Server]] — Interface com Claude
+
+## Infraestrutura
+
+- [[Project Name - Deploy GCP]] — Cloud Run e IAP
+- [[Project Name - VPN Wireguard]] — Acesso seguro
+
+## Tags
+
+- [[claude-skill]] — notas geradas por este skill
+- [[project-name]] — notas deste projeto
+```
+
+### Tag File (in `docs/zettelkasten/tags/` locally, the vault's tags folder in Obsidian)
+
+```markdown
+Tags: #moc
+
+# tag-name
+
+Brief description of what this tag represents in the project context.
+```
+
+Tag files serve as backlink hubs in Obsidian — the "Backlinks" pane shows every note that references `[[tag-name]]`, creating an automatic index. They are NOT empty. Each tag file has a `Tags: #moc` line, H1 with the tag name, and a one-line description. This mirrors the tags folder convention in the user's vault.
+
+Only create tag files for domain-specific concepts (e.g., `pgvector`, `embedding`, `zettelkasten`). Do NOT create tag files for generic programming concepts (e.g., `react`, `typescript`, `api`) unless they don't already exist in the vault — check first using `mcp__lox-brain__search_text` if available.
+
+---
+
+## File Naming Conventions
+
+### Local files (`docs/zettelkasten/`)
+- **Lowercase, hyphens for spaces**: `fluxo-de-dados.md`, `embedding-service.md`
+- **MOC is always `_MOC.md`** (underscore prefix sorts it first)
+- **Tag files** in `docs/zettelkasten/tags/`: same lowercase convention
+
+### Obsidian vault files
+- **Atomic notes** in the vault's atomic notes folder: Use project prefix + title case
+  - Pattern: `Project Name - Note Title.md`
+  - Example: `Lox - Embedding Service.md`, `MyApp - Auth Pipeline.md`
+- **MOC**: `Project Name - MOC.md`
+- **Tags** in the vault's tags folder: Lowercase, same as local tag file names
+  - Example: `pgvector.md`, `embedding.md`
+
+### Wikilink resolution
+- Inter-note links use the Obsidian display name: `[[Project Name - Note Title]]`
+- Tag links use the short name: `[[tag-name]]`
+- This ensures links resolve correctly in BOTH `docs/zettelkasten/` (if opened in Obsidian as vault) AND the main Obsidian vault
+
+## Project Identity
+
+Every set of notes belongs to a specific project. The project tag (e.g., `[[lox]]`) is the backbone that ties all notes together in the Graph View.
+
+How to establish project identity:
+- **Detect the project name** from `package.json` (name field), `CLAUDE.md`, `README.md`, or the root folder name
+- **Create a project tag file** in `docs/zettelkasten/tags/` — this is the first tag file created
+- **Every note MUST include the project tag** in its Tags line, right after `[[claude-skill]]`
+- **The MOC title includes the project name** (e.g., "Lox — Map of Content")
+- **The MOC has a "Projeto" callout** at the top explaining what the project is in 1-2 sentences
+
+This way, when a user opens the Graph View in Obsidian, they see the project tag as a central hub connecting all related notes. If the user has notes from multiple projects, each project forms its own cluster.
+
+## Cross-Linking Guidelines
+
+Cross-linking is what makes Zettelkasten powerful. Without links, notes are just files.
+
+### Two types of wikilinks
+
+There are two distinct types of wikilinks. Mixing them up causes ghost notes in Obsidian:
+
+1. **Tag links** — Short names pointing to tag files in the vault's tags folder. Used in the `Tags:` metadata line and when referencing broad concepts.
+   - Example: `[[pgvector]]`, `[[security]]`, `[[claude-skill]]`, `[[my-project]]`
+   - These resolve to files in the tags folder: `pgvector.md`, `security.md`, etc.
+
+2. **Inter-note links** — Full display names pointing to other atomic notes. Used in `## Relacoes`, `## References`, and inline mentions.
+   - Example: `[[Project Name - Embedding Service]]`, `[[Project Name - Auth Pipeline]]`
+   - These resolve to files in the atomic notes folder
+   - The prefix is derived from the project name
+
+Why this matters: if you write `[[embedding-service]]` but the vault file is named `Project Name - Embedding Service.md`, Obsidian creates an empty ghost note called `embedding-service.md` when the user clicks it. Always use the full display name for inter-note links.
+
+### Linking rules
+
+- **Every note MUST link to at least 2 other notes** (via `## References` or inline `[[links]]`)
+- **Use inline inter-note links** when mentioning another note: "O [[Project Name - Embedding Service]] utiliza..."
+- **Use tag links** only in the `Tags:` line and when referencing broad categories
+- **Use the Relacoes section** for structural relationships (depends-on, impacts, alternative-to)
+- **Link to the MOC** is implicit — the MOC links to notes, not the reverse
+- **Always contextualize within the project**: describe a component's specific role in THIS project, not generic concepts
+
+## Required Metadata
+
+Every generated note MUST include:
+1. Timestamp on first line (YYYY-MM-DD HH:MM)
+2. `Status: #baby` (always starts as baby)
+3. `Tags:` with `[[claude-skill]]` followed by `[[project-name]]` (detected from codebase) and then topic tags
+4. `source: claude-skill` on the line after Tags (for local files). When writing to Obsidian vault, use Dataview inline fields instead: `[source:: claude-skill]` and `[imported:: YYYY-MM-DD]`
+5. H1 title
+
+The project tag is the anchor that groups all notes from the same project. It MUST always be present as the second tag (after `[[claude-skill]]`).
+
+This metadata is NOT in YAML fences. This matches Obsidian's Atomic Notes convention.
+
+## Quality Checklist
+
+Before finalizing output, verify:
+- [ ] Each note covers exactly ONE concept (atomic)
+- [ ] No note exceeds ~300 lines (split if larger)
+- [ ] All notes have the required metadata header
+- [ ] **Project tag** (`[[project-name]]`) present in every note as second tag
+- [ ] Cross-links between notes are bidirectional where appropriate
+- [ ] Tag files created for every new `[[tag]]` introduced
+- [ ] MOC lists all generated notes, grouped by theme
+- [ ] MOC has project callout explaining what the project is
+- [ ] Content language matches the project's language (default: pt-BR), code/technical terms in English
+- [ ] Each note describes concepts **in the context of this specific project**, not generically
+- [ ] File paths referenced in notes actually exist in the codebase
+- [ ] No secrets, credentials, or sensitive data in note content
+- [ ] Inter-note wikilinks use full Obsidian display names (`[[Project Name - Note Title]]`)
+- [ ] Tag wikilinks use short names (`[[tag-name]]`)
+- [ ] Tag files have content (Tags: #moc, H1, description) — not empty
+- [ ] If Lox MCP is available, notes ingested to vault with correct paths
+
+## Sub-Agent Delegation
+
+For large codebases (Mode 1 full scan):
+- Use **Explore** (haiku) to survey the codebase structure and identify key files
+- Use **coder-sonnet** (sonnet) to generate individual notes in parallel batches
+- Use the main agent to assemble the MOC and verify cross-links
+
+For topic-focused (Mode 2):
+- Use **Explore** (haiku) to find all code related to the topic
+- Generate notes in the main agent (typically 2-6 notes, manageable)
+
+For review (Mode 3):
+- Handle entirely in the main agent (single note, focused task)
+
+## Obsidian Vault Ingestion
+
+After generating notes locally in `docs/zettelkasten/`, ingest them into the Obsidian vault using the Lox MCP server (if available). This step is automatic — do not ask the user unless MCP is unavailable.
+
+### MCP tools used
+
+- `mcp__lox-brain__write_note` — Write a note to the vault
+- `mcp__lox-brain__search_text` — Check for existing notes/tags before creating duplicates
+
+### Deduplication
+
+Before creating any note or tag file in the vault, search for existing content using `mcp__lox-brain__search_text`. If a matching note already exists, update it rather than creating a duplicate.
+
+### Naming convention for Obsidian
+
+Local files use short names (`arquitetura-geral.md`), but Obsidian files use descriptive display names with a project prefix:
+
+| Local file | Obsidian path |
+|------------|---------------|
+| `arquitetura-geral.md` | `<atomic-notes-folder>/Project Name - Arquitetura Geral.md` |
+| `_MOC.md` | `<atomic-notes-folder>/Project Name - MOC.md` |
+
+The project prefix is a short form of the project name (e.g., "Lox" for lox-brain, "MyApp" for my-app).
+
+The `<atomic-notes-folder>` and `<tags-folder>` are determined by the user's configured preset (see Configuration section above).
+
+### Ingestion steps
+
+1. **Atomic notes** — Write to the vault's atomic notes folder with project prefix
+2. **Tag files** — Write to the vault's tags folder (check for existing tags first to avoid overwriting)
+3. **Metadata adjustment** — Replace `source: claude-skill` with Dataview inline fields:
+   ```
+   [source:: claude-skill]
+   [imported:: YYYY-MM-DD]
+   ```
+   Place these lines after the `Tags:` line and before the H1 title.
+
+### Wikilink consistency
+
+All wikilinks in notes written to Obsidian MUST use the same full display names as the vault files. Since the local `docs/zettelkasten/` files also use these full names in their inter-note links, the content should be identical — just with the metadata adjustment above.
+
+## Example Session
+
+- `/zettelkasten` — Full scan. Reads config, explores codebase, generates ~8-12 atomic notes + tag files + MOC in `docs/zettelkasten/`, then ingests to vault if MCP is available.
+- `/zettelkasten embedding pipeline` — Topic-focused. Searches for related code, generates 2-6 notes, cross-links with existing notes, updates MOC.
+- `/zettelkasten review docs/zettelkasten/arquitetura-geral.md` — Reads the note, verifies claims against current code, fixes inaccuracies, suggests status promotion.


### PR DESCRIPTION
## Summary

First PR for #85. Ships the first Claude Skill with Lox and establishes the infrastructure for future skills.

## What's included

### /zettelkasten skill (`skills/zettelkasten/SKILL.md`)
Genericized from Eduardo's personal skill. Three modes:
1. **Full scan** — analyze a project codebase, generate 8-12 atomic notes + MOC
2. **Topic-focused** — deep-dive into a specific topic, generate 2-6 notes
3. **Review** — verify existing notes against current code, suggest status promotion

Configuration reads from `~/.lox/config.json` (`vault.preset`, `vault.local_path`). Folder mapping adapts per preset (zettelkasten vs para). No personal references (email, company, project names).

### Infrastructure
- **Post-install skill copy**: `step-post-install.ts` copies `skills/` to `~/.claude/skills/` automatically after config save
- **Splash screen**: tagline updated to `Obsidian + pgvector + MCP Server + Claude Skills + WireGuard VPN`

### Documentation
- **README.md**: added Claude Skills section with shipped skills table, corrected monorepo structure (removed phantom `cli/` package, added `skills/` and `templates/`), fixed security section ("VM public IP restricted to VPN endpoint" per v0.6.16)

## Next PRs
- PR 2/3: `/obsidian-ingest` (content ingestion)
- PR 3/3: `/sync-calendar` + `/para`

## Test plan
- [x] 464 tests pass, tsc clean
- [x] Skill file verified: 380 lines, no personal references
- [x] `grep -r 'credifit\|linkpj\|eduardo\|iSorensen' skills/` returns nothing

Refs #85