### PR TITLE
feat: ship /sync-calendar and /para skills (#85, PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.7.1] — 2026-04-05
+## [0.7.2] — 2026-04-05
+
+### Added
+- **Ship `/sync-calendar` and `/para` Claude Skills (#85, PR 3/3).** `/sync-calendar` syncs Google Calendar events to Obsidian meeting notes with optional Gemini AI summary integration via Gmail. Calendar list, timezone, and folder structure are configurable via `~/.lox/config.json`. `/para` organizes content using the PARA method in three modes: ingest (classify + create), review (suggest reclassifications), and dashboard (generate bucket overviews). Both skills genericized — no hardcoded paths, emails, company names, or personal references. This completes the initial skill set proposed in #85.
+
+
 
 ### Added
 - **Ship `/obsidian-ingest` Claude Skill (#85, PR 2/3).** Ingest URLs, images, PDFs, and text into the Obsidian vault with semantic deduplication, content categorization, and structured note creation. 8-step workflow: read → check tags → check duplicates → categorize → preview → write → create MOCs → confirm. Folder routing adapts per vault preset (zettelkasten vs para). Supports PDF text extraction with fallback chain (pdftotext → pdfminer → pypdf). Genericized from personal skill — no hardcoded paths, company names, or personal references.

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Lox ships with Claude Skills that provide opinionated workflows on top of the MC
 |-------|-------------|
 | `/zettelkasten` | Generate atomic smart notes from project codebases (3 modes: full scan, topic-focused, review) |
 | `/obsidian-ingest` | Ingest URLs, images, PDFs, and text into the vault with semantic deduplication and categorization |
-
-More skills coming: `/sync-calendar` (Google Calendar → vault), `/para` (PARA method notes).
+| `/sync-calendar` | Sync Google Calendar events to meeting notes, with optional Gemini AI summary integration |
+| `/para` | Organize content using the PARA method (Projects, Areas, Resources, Archives) |
 
 ## Monorepo Structure
 
@@ -111,6 +111,8 @@ lox-brain/
   skills/
     zettelkasten/          # /zettelkasten Claude Skill
     obsidian-ingest/       # /obsidian-ingest Claude Skill
+    sync-calendar/         # /sync-calendar Claude Skill
+    para/                  # /para Claude Skill
   docs/
     plans/                 # Design docs and implementation plan
   templates/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3775,7 +3775,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@lox-brain/shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -3794,7 +3794,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -3957,7 +3957,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skills/para/SKILL.md
+++ b/skills/para/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: para
+description: Organize content using the PARA method (Projects, Areas, Resources, Archives) in the Obsidian vault via the Lox MCP Server
+---
+
+# PARA — Content Organization for Obsidian
+
+## Configuration
+
+This skill reads your Lox configuration from `~/.lox/config.json`:
+- `vault.preset`: must be `para` (this skill is designed for the PARA template)
+- `vault.local_path`: path to your Obsidian vault (default: `~/Obsidian/Lox`)
+
+If `vault.preset` is `zettelkasten`, this skill will warn and suggest using `/zettelkasten` instead.
+
+Folder mapping:
+| Bucket | Folder | Description |
+|--------|--------|-------------|
+| Projects | `2 - Projects/` | Active efforts with a deadline or deliverable |
+| Areas | `3 - Areas/` | Ongoing responsibilities (no deadline) |
+| Resources | `4 - Resources/` | Reference material for future use |
+| Archives | `5 - Archive/` | Completed projects, inactive areas |
+
+Content language defaults to pt-BR. Technical terms and code identifiers stay in English. If the project's primary language is different (detected from README, CLAUDE.md, or user preference), adapt accordingly.
+
+## Purpose
+
+The PARA method (by Tiago Forte) organizes information by actionability, not by topic. This skill automates PARA classification, note creation, lifecycle transitions, and dashboard generation inside the user's Obsidian vault via the Lox MCP Server.
+
+Why PARA for a second brain:
+- **Actionability-first** sorting ensures active work stays visible and reference material stays accessible
+- **Lifecycle transitions** (Project -> Archive, Resource -> Project) keep the vault current
+- **Dashboards** per bucket provide instant situational awareness
+- **Cross-linking** between buckets reveals how resources feed projects and areas
+
+## Modes of Operation
+
+### Mode 1: Ingest (default)
+
+Trigger: `/para` or `/para <content/url/idea>`
+
+Given content (text, URL, idea, or pasted material), classify it into the correct PARA bucket and create a note.
+
+**Workflow:**
+
+1. **Receive content** — The user provides text, a URL, a concept, or raw material to capture.
+2. **Classify** — Determine the correct PARA bucket using these rules:
+   - **Project**: Has a deadline, deliverable, or end state. Ask: "Can this be completed?"
+   - **Area**: Ongoing responsibility with a standard to maintain. Ask: "Is this something I maintain indefinitely?"
+   - **Resource**: Reference material, topic of interest, useful information. Ask: "Might I need this later?"
+   - **Archive**: Completed or inactive. Ask: "Is this done or no longer relevant?"
+   - If ambiguous, ask the user. Never guess between Project and Area.
+3. **Check for duplicates** — Use `mcp__lox-brain__search_text` to find existing notes on the same topic. If found, offer to update instead of creating a new note.
+4. **Create note** — Write the note to the correct folder using `mcp__lox-brain__write_note`.
+5. **Cross-link** — Search for related notes in other buckets and add `[[wikilinks]]` in the Related section.
+6. **Report** — Show the created file path, bucket classification, and any cross-links added.
+
+### Mode 2: Review
+
+Trigger: `/para review`
+
+Scan existing notes and suggest reclassifications based on staleness and activity patterns.
+
+**Workflow:**
+
+1. **List recent notes** — Use `mcp__lox-brain__list_recent` and `mcp__lox-brain__search_text` to gather notes across all PARA folders.
+2. **Analyze each bucket:**
+   - **Projects**: Flag notes older than 30 days without updates as candidates for Archive.
+   - **Areas**: Flag notes that have acquired a deadline or deliverable as candidates for Project.
+   - **Resources**: Flag notes being actively referenced or edited as candidates for Project promotion.
+   - **Archives**: Flag notes recently referenced as candidates for reactivation.
+3. **Present recommendations** — Show a table of suggested moves with rationale:
+   ```
+   | Note | Current Bucket | Suggested Bucket | Reason |
+   ```
+4. **Execute moves** — After user confirmation, update the note's `para_bucket` field, move the file to the new folder, and update any dashboard notes.
+
+### Mode 3: Dashboard
+
+Trigger: `/para dashboard` or `/para dashboard <bucket>`
+
+Generate or update an overview note (MOC-style) for one or all PARA buckets.
+
+**Workflow:**
+
+1. **Scan bucket folder(s)** — List all notes in the target bucket folder(s).
+2. **Generate dashboard note** — Create a MOC-style note per bucket:
+   - `2 - Projects/_Dashboard.md`
+   - `3 - Areas/_Dashboard.md`
+   - `4 - Resources/_Dashboard.md`
+   - `5 - Archive/_Dashboard.md`
+3. **Include metadata** — Each dashboard lists notes grouped by status (#baby, #child, #adult), with last-updated dates and brief descriptions extracted from note content.
+4. **Cross-bucket links** — If a Project references a Resource, show that link in both dashboards.
+5. **Write to vault** — Use `mcp__lox-brain__write_note` to create/update the dashboard files.
+
+---
+
+## Output Format
+
+### PARA Note
+
+```markdown
+# Note Title
+
+**Date:** 2026-04-05
+**Status:** #baby
+**Bucket:** Project | Area | Resource | Archive
+**Tags:** [[tag1]] [[tag2]]
+
+[source:: user-input | url | claude-skill]
+[imported:: 2026-04-05]
+[para_bucket:: projects | areas | resources | archives]
+
+## Content
+
+Main content goes here. Write in the project's content language (default: pt-BR).
+Technical terms and code identifiers stay in English.
+
+Use short paragraphs. Be direct. One main topic per note.
+
+> [!NOTE]
+> Use callout boxes for important caveats or context.
+
+## Related
+- [[Other Note in Same Bucket]]
+- [[Note in Different Bucket]]
+```
+
+### Dashboard Note
+
+```markdown
+# Projects Dashboard
+
+**Updated:** 2026-04-05
+**Bucket:** Projects
+**Tags:** [[para]] [[dashboard]]
+
+[source:: claude-skill]
+[para_bucket:: projects]
+
+> [!INFO]
+> Dashboard gerado automaticamente pelo skill `para`.
+> Mostra todos os projetos ativos com status e ultima atualizacao.
+
+## Active (#baby / #child)
+
+- [[Project Note 1]] — Brief description (updated: 2026-04-01)
+- [[Project Note 2]] — Brief description (updated: 2026-03-28)
+
+## Mature (#adult)
+
+- [[Project Note 3]] — Brief description (updated: 2026-03-15)
+
+## Candidates for Archive
+
+- [[Stale Project]] — No updates in 45 days. Consider archiving.
+```
+
+---
+
+## File Naming Conventions
+
+### Vault files
+- **Notes** in bucket folders: Title case, descriptive names
+  - Pattern: `<bucket-folder>/Note Title.md`
+  - Example: `2 - Projects/Website Redesign.md`, `4 - Resources/Git Workflow Guide.md`
+- **Dashboards** always use `_Dashboard.md` (underscore prefix sorts first)
+  - Example: `2 - Projects/_Dashboard.md`
+
+### Wikilink resolution
+- Inter-note links use the Obsidian display name: `[[Note Title]]`
+- If the note is in a subfolder, Obsidian resolves by filename alone — no folder prefix needed in wikilinks
+- Tag links use short names: `[[para]]`, `[[dashboard]]`
+
+## PARA Classification Rules
+
+Use these rules to classify content. When in doubt, ask the user.
+
+| Signal | Bucket | Example |
+|--------|--------|---------|
+| Has a deadline or due date | Project | "Launch site by May 15" |
+| Has a clear deliverable | Project | "Write API documentation" |
+| Can be marked as "done" | Project | "Migrate database to v2" |
+| Ongoing responsibility | Area | "Health", "Finances", "Team management" |
+| Standard to maintain | Area | "Code quality", "Home maintenance" |
+| No end date | Area | "Professional development" |
+| Interesting topic | Resource | "Machine learning resources" |
+| Future reference | Resource | "Design patterns cheat sheet" |
+| External material | Resource | "Article about distributed systems" |
+| Project completed | Archive | "Q1 2026 report (delivered)" |
+| Area no longer relevant | Archive | "Old apartment maintenance" |
+| Resource outdated | Archive | "Deprecated API docs" |
+
+## Lifecycle Transitions
+
+Notes move between buckets as their status changes. This skill supports these transitions:
+
+| Transition | Trigger | Action |
+|------------|---------|--------|
+| Project -> Archive | Project completed or abandoned | Move file, update `para_bucket`, update dashboards |
+| Area -> Project | Area acquires a deadline | Move file, update `para_bucket`, add deadline to note |
+| Resource -> Project | Resource becomes active work | Move file, update `para_bucket`, set status to #baby |
+| Archive -> Project | Archived item reactivated | Move file, update `para_bucket`, reset status to #baby |
+| Project -> Area | Deadline removed, becomes ongoing | Move file, update `para_bucket` |
+
+When moving a note:
+1. Read the note content with `mcp__lox-brain__read_note`
+2. Update the `para_bucket` inline field
+3. Update the `**Bucket:**` metadata line
+4. Write to the new location with `mcp__lox-brain__write_note`
+5. Update both source and destination dashboards
+
+## Required Metadata
+
+Every generated note MUST include:
+1. H1 title
+2. `**Date:**` with creation date (YYYY-MM-DD)
+3. `**Status:**` with `#baby` (always starts as baby)
+4. `**Bucket:**` with the PARA bucket name (Project, Area, Resource, or Archive)
+5. `**Tags:**` with relevant `[[wikilinks]]`
+6. `[source:: user-input | url | claude-skill]` (Dataview inline field)
+7. `[imported:: YYYY-MM-DD]` (Dataview inline field)
+8. `[para_bucket:: projects | areas | resources | archives]` (Dataview inline field)
+
+The `para_bucket` field enables Dataview queries to list notes by bucket across the vault.
+
+## MCP Tools Used
+
+- `mcp__lox-brain__write_note` — Write a note to the vault
+- `mcp__lox-brain__search_text` — Search for existing notes, check duplicates, find cross-links
+- `mcp__lox-brain__read_note` — Read note content for review or transitions
+- `mcp__lox-brain__list_recent` — List recently modified notes for review mode
+
+### Deduplication
+
+Before creating any note, search for existing content using `mcp__lox-brain__search_text`. If a matching note exists in the same bucket, update it. If it exists in a different bucket, ask the user whether to update in place or move it.
+
+## Sub-Agent Delegation
+
+For **Ingest mode** (single note):
+- Handle entirely in the main agent (single note, focused task)
+
+For **Review mode** (vault-wide scan):
+- Use **Explore** (haiku) to list and categorize notes across all PARA folders
+- Use **coder-sonnet** (sonnet) to generate the recommendations table
+- Use the main agent to present results and execute confirmed moves
+
+For **Dashboard mode**:
+- Use **Explore** (haiku) to scan bucket folders and extract note metadata
+- Use **coder-sonnet** (sonnet) to generate dashboard notes in parallel (one per bucket)
+- Use the main agent to write dashboards to vault via MCP
+
+## Quality Checklist
+
+Before finalizing output, verify:
+- [ ] Note is placed in the correct PARA bucket folder
+- [ ] All required metadata fields are present (Date, Status, Bucket, Tags, source, imported, para_bucket)
+- [ ] `para_bucket` inline field matches the actual folder placement
+- [ ] Duplicate check performed via `mcp__lox-brain__search_text` before creating
+- [ ] Cross-links added in the Related section where appropriate
+- [ ] Wikilinks use Obsidian display names (filename without extension)
+- [ ] Content language matches the project's language (default: pt-BR), technical terms in English
+- [ ] No secrets, credentials, or sensitive data in note content
+- [ ] Dashboard notes updated if a new note was added to a bucket
+- [ ] Lifecycle transitions update both source and destination dashboards
+- [ ] Status always starts as `#baby` for new notes
+
+## Example Session
+
+- `/para` — User provides content interactively. Skill asks for text/URL/idea, classifies it, creates note in the correct bucket.
+- `/para Build CI/CD pipeline for staging by April 30` — Ingest mode. Classifies as Project (has deadline), creates note in `2 - Projects/`, cross-links with related resources.
+- `/para https://martinfowler.com/articles/microservices.html` — Ingest mode. Classifies as Resource, creates note in `4 - Resources/` with summary and source link.
+- `/para review` — Review mode. Scans all buckets, presents reclassification suggestions, executes after confirmation.
+- `/para dashboard` — Dashboard mode. Generates/updates `_Dashboard.md` for all four buckets.
+- `/para dashboard projects` — Dashboard mode for Projects only. Updates `2 - Projects/_Dashboard.md`.

--- a/skills/sync-calendar/SKILL.md
+++ b/skills/sync-calendar/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: sync-calendar
+description: Sync Google Calendar events to Obsidian meeting notes via the Lox MCP Server, with optional Gemini AI meeting summary integration via Gmail
+---
+
+# Sync Calendar — Google Calendar to Obsidian via Lox
+
+Syncs Google Calendar events to Obsidian meeting notes, including Gemini AI meeting summaries when available. Uses three MCP servers: Google Calendar, Gmail, and Lox MCP Server.
+
+## Prerequisites
+
+- **Google Calendar MCP** — connected via Claude.ai OAuth (provides `gcal_list_events`)
+- **Gmail MCP** — connected via Claude.ai OAuth (provides `gmail_search_messages`, `gmail_read_message`) — optional, needed only for Gemini meeting summaries
+- **Lox MCP Server** — running and accessible (provides `write_note`, `search_text`, `read_note`)
+
+If any required MCP server is unavailable, stop and tell the user which one is missing.
+
+## Configuration
+
+This skill reads calendar sync settings from `~/.lox/config.json`:
+
+```json
+{
+  "sync_calendar": {
+    "calendars": [
+      { "id": "primary", "label": "Work" },
+      { "id": "user@company.com", "label": "Secondary" }
+    ],
+    "timezone": "America/Sao_Paulo"
+  }
+}
+```
+
+If `sync_calendar` is not configured, the skill prompts the user for setup on first run.
+
+- **`calendars`** — list of Google Calendar IDs to sync. The `id` is passed directly to `gcal_list_events`; the `label` is used in notes and the summary output.
+- **`timezone`** — IANA timezone string. Defaults to the user's system timezone if omitted.
+
+Folder mapping by preset:
+
+| Preset | Meeting notes folder |
+|--------|---------------------|
+| zettelkasten | `7 - Meeting Notes/` |
+| para | `2 - Projects/Meetings/` |
+
+## Arguments
+
+The skill receives an optional date or date range as argument:
+
+- No argument -> today's date
+- Single date -> that day (e.g., `2026-03-11`)
+- Date range -> inclusive range (e.g., `2026-03-10 2026-03-12` or `2026-03-10..2026-03-12`)
+
+Parse flexibly: accept `YYYY-MM-DD`, `DD/MM/YYYY`, `today`, `yesterday`, `last monday`, etc.
+
+## Workflow
+
+### Step 1: Fetch Events
+
+Read `~/.lox/config.json` to get the `sync_calendar.calendars` list and `timezone`. For each date in the range, call `gcal_list_events` **once per calendar**. Since the calls are independent, run them **in parallel**:
+
+```
+gcal_list_events(
+  calendarId: "<calendar_id>",
+  timeMin: "YYYY-MM-DDT00:00:00",
+  timeMax: "YYYY-MM-DDT23:59:59",
+  timeZone: "<configured timezone>",
+  condenseEventDetails: false   // CRITICAL: need attendees + attachments
+)
+```
+
+After fetching, **merge** all results into a single list sorted by start time. Tag each event with its calendar label so it can be used in notes and the summary.
+
+**Deduplication across calendars:** When the same event appears in multiple calendars (same `id` prefix before the underscore, OR same summary + same start time + overlapping attendees), keep only one copy. Prefer the version from the first calendar in the config list (primary).
+
+For multi-day ranges, make a single call per calendar spanning the full range (not one call per day per calendar).
+
+**Chunking for large ranges (> 7 days):** The Calendar API with `condenseEventDetails: false` returns very large payloads. For ranges longer than 7 days, split into weekly chunks and process each week sequentially. Present a week-by-week summary to the user and process one week at a time.
+
+**Token overflow handling:** When API results exceed the MCP tool output limit (~100KB), the result is saved to a temporary file. Use **Python** (not jq — zsh escapes break jq filters) to extract only needed fields (`id`, `summary`, `start`, `end`, `htmlLink`, `organizer`, `attendees[:15]`, `attachments`, `selfStatus`, `isSolo`) and save to `/tmp/weekN_filtered.json`.
+
+### Step 2: Filter Events
+
+Remove events that should not become notes:
+
+1. **Skip `workingLocation` events** — these are "working from home/office" status entries, not real meetings
+2. **Skip declined events** — where `myResponseStatus === "declined"`
+3. **Skip optional events without response** — where `myResponseStatus === "needsAction"` AND the user is marked `optional: true`
+4. **Skip all-day events without attendees** — typically holidays, OOO markers, reminders
+5. **Skip `birthday` events** — contact birthday reminders from Google Contacts (`eventType === "birthday"`)
+
+**Do NOT skip solo events (no attendees, not all-day).** Personal appointments are valid notes. Tag them appropriately (e.g., `[[personal]]`, `[[health]]`, `[[fitness]]`).
+
+**Detect duplicates:** When two events overlap in time and have similar summaries, flag them and recommend a single merged note.
+
+Present the filtered list to the user before proceeding. Show: time, title, attendee count, calendar label, and whether Gemini notes exist. List skipped events with reasons. Wait for user confirmation before creating any notes.
+
+**Bulk confirmation for large ranges:** For ranges > 7 days, after the first week's confirmation, ask if they want to approve remaining weeks in bulk or review week by week.
+
+### Step 3: Check for Gemini Notes
+
+**Only search Gmail for events that have a Gemini attachment.** Check the `attachments` array for items with title containing specifically "Anotacoes do Gemini" (or "Gemini notes" in English, depending on Google account language). **Warning:** Other attachments like "Notes -- Weekly Meeting" or "Meeting notes" are Google Docs collaborative notes, NOT Gemini AI summaries — do not search Gmail for these.
+
+For events WITH the Gemini attachment, search Gmail:
+
+```
+gmail_search_messages(
+  q: "from:gemini-notes@google.com subject:\"<event summary>\"",
+  maxResults: 3
+)
+```
+
+Then read the most recent matching email:
+
+```
+gmail_read_message(messageId: "<id from search>")
+```
+
+**For recurring events:** Add a date filter to get the correct occurrence:
+
+```
+gmail_search_messages(
+  q: "from:gemini-notes@google.com subject:\"<event summary>\" after:YYYY/MM/DD before:YYYY/MM/DD",
+  maxResults: 3
+)
+```
+
+**Skip Gmail for future events:** Do not search Gmail for events after today's date.
+
+**Fallback strategy:** If Gmail search returns no results, try broadening (remove date filter, search by partial subject). If still nothing, proceed without Gemini notes and include a callout prompting manual entry.
+
+**Parallelization:** Launch all Gmail searches and vault duplicate checks in parallel.
+
+### Step 4: Check for Existing Notes
+
+Start with a single broad search to find all existing calendar-imported notes:
+
+```
+obsidian search_text(query: "calendar_event_id", limit: 50)
+```
+
+This returns all notes that have a `calendar_event_id` field. Match events by ID or title locally in-memory. Only fall back to individual per-event searches if the broad search returns 50+ results.
+
+**Cross-calendar dedup:** The existing-note check applies regardless of which calendar the current event comes from. The `calendar_event_id` prefix match (before the underscore) is the primary dedup key; title + time overlap is the fallback.
+
+**If a note exists:**
+1. Read the existing note with `read_note`
+2. Classify the note's state:
+   - **Enriched** (status `#child` or `#adult`, or has manually-written content beyond the template) -> recommend **skip**
+   - **Skeleton** (status `#baby`, only template structure) -> recommend **complement** if new Gemini data is available (promote to `#child`), otherwise **skip**
+   - **Outdated** (has Gemini content but event was updated since) -> recommend **update**
+3. Show the user a summary table with recommendations
+4. Ask for confirmation — never overwrite without explicit approval
+
+**If no note exists:** proceed to create it.
+
+**All notes already exist?** If every event already has a note and none need updating, show the summary and finish.
+
+### Step 5: Create Meeting Note
+
+#### Batch creation with subagents
+
+For ranges with many events (>5), delegate note creation to subagents in batches of 5-8 events. Each subagent receives the filtered event JSON, Gemini notes content, and the note template. Use `mode: auto` and `model: sonnet` for efficiency.
+
+#### File path
+
+Use the meeting notes folder from the configured preset (default: `7 - Meeting Notes/`):
+
+```
+<meeting_notes_folder>/YYYY-MM-DD <Title>.md
+```
+
+Where `<Title>` is the event summary, cleaned and enriched:
+- Replace `|`, `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>` with ` - ` or remove them
+- Keep accents and non-ASCII characters
+- Spaces are fine (Obsidian handles them)
+- **Enrich generic titles:** If the summary is vague (e.g., "1-1", "Sync", "Quick chat"), append the other participant's name (for 1-1s) or the organizer's name
+- Trim trailing whitespace from summaries
+- **Filename collision handling:** When multiple events on the same day have identical titles, disambiguate with a time suffix: `2026-03-04 Topic (morning).md` and `2026-03-04 Topic (afternoon).md`
+
+#### Note format
+
+The vault uses **plain text + Dataview inline fields**, NOT YAML frontmatter. Never pass the `tags` parameter to `write_note` (it generates YAML frontmatter).
+
+**Status field:** Use `#child` when Gemini notes are available. Use `#baby` when no Gemini notes (skeleton only). Solo/personal events always get `#baby`.
+
+```markdown
+YYYY-MM-DD HH:MM
+
+Status: #child (if Gemini notes available) or #baby (if no Gemini notes)
+
+Tags: [[meeting]] [[calendar-label-tag]] [[meeting-type-tag]] [[gemini-notes]]
+
+[source:: google-calendar]
+[imported:: YYYY-MM-DD]
+[calendar_event_id:: <event id>]
+[calendar_source:: <calendar label>]
+
+# <emoji> YYYY-MM-DD <emoji> HH:MM
+
+## <emoji> Meeting: <Event Title>
+
+### Related companies:
+
+- [[Company1]]
+- [[Company2]]
+
+### <emoji> Attendees:
+
+- [[Name1]] (organizer) <status>
+- [[Name2]] <status>
+
+---
+
+### <emoji> Topics Discussed:
+
+<If Gemini notes available: structured summary with numbered topics>
+<If no Gemini notes: callout below>
+
+> [!NOTE] No automatic notes
+> This event does not have Gemini notes. Add your notes manually below.
+
+---
+
+### <emoji> Actions and Next Steps:
+
+<If Gemini notes have action items: checklist with responsible and due>
+
+- [ ] Action description
+  [responsible:: Person Name]
+  [due:: ]
+
+---
+
+### <emoji> References and Attachments:
+
+- [Google Calendar Event](<calendar event link>)
+- [Gemini Notes (Google Doc)](<doc link if available>)
+
+## Key Topics
+
+> [!NOTE] Guidance
+> After the meeting, identify the most important topics and insights. Each should become a separate Atomic Note, linked back to this one.
+
+- [[Key topic 1]]
+- [[Key topic 2]]
+```
+
+#### Personal/solo event format
+
+For events without attendees, use a simplified template — no Attendees, no Companies, no Actions:
+
+```markdown
+YYYY-MM-DD HH:MM
+
+Status: #baby
+
+Tags: [[personal]] [[relevant-tag]]
+
+[source:: google-calendar]
+[imported:: YYYY-MM-DD]
+[calendar_event_id:: <event id>]
+[calendar_source:: <calendar label>]
+
+# <emoji> YYYY-MM-DD <emoji> HH:MM — <Event Title>
+
+<description if available, or location>
+
+---
+
+### <emoji> References and Attachments:
+
+- [Google Calendar Event](<calendar event link>)
+```
+
+Tag personal events contextually: `[[health]]` for medical, `[[fitness]]` for gym, `[[personal]]` as default.
+
+#### Emoji usage
+
+Use the same emojis as the existing vault template:
+- Title line: calendar date, clock time
+- Meeting section: memo
+- Attendees: people
+- Topics: pushpin
+- Actions: checkmark
+- References: folder
+
+#### Attendee status mapping
+
+Map `responseStatus` from the Calendar API:
+- `accepted` -> checkmark
+- `declined` -> cross
+- `tentative` -> question
+- `needsAction` -> hourglass
+
+Mark the organizer with `(organizer)`.
+
+**Attendee truncation:** For events with more than 15 attendees, list only the first 15 (prioritizing the organizer and accepted attendees) and add a note: `... and X more attendees`.
+
+#### People wikilinks
+
+Every attendee name in the Attendees section is wrapped in `[[wikilinks]]`. This connects meeting notes to people notes in the vault's Graph View.
+
+**Name resolution:** Use the attendee's display name from the Calendar API. If only an email is available, derive the name from the email prefix (e.g., `carlos.gomes@company.com` -> `Carlos Gomes`). Capitalize properly, remove email suffixes.
+
+**No automatic people note creation.** The skill only creates the wikilink — the user can click stubs later.
+
+**Self-exclusion:** Do NOT create a wikilink for the user's own name (`self: true` attendee). List them as plain text.
+
+#### Tags
+
+Always include `[[meeting]]`. Add contextual tags based on:
+- Calendar label from config -> `[[calendar-label]]` (lowercase, hyphenated)
+- Company names from attendees' email domains or event description -> `[[company-name]]`
+- If Gemini notes present -> `[[gemini-notes]]`
+- Meeting type if identifiable: `[[1-1]]`, `[[sprint]]`, `[[standup]]`, `[[review]]`, etc.
+
+#### Gemini summary formatting
+
+When Gemini notes are available, structure the "Topics Discussed" section as:
+
+```markdown
+**Summary (Gemini):** <one-line overall summary>
+
+1. **<Topic Title>**
+   <Topic details as paragraph>
+
+2. **<Topic Title>**
+   <Topic details as paragraph>
+```
+
+Extract action items into the "Actions and Next Steps" section as checkboxes with `[responsible::]` and `[due::]` Dataview fields.
+
+#### Key Topics section
+
+If Gemini notes are available, suggest 2-4 key topics as wikilinks based on the main themes discussed. If no Gemini notes, leave placeholder wikilinks.
+
+### Step 6: Summary
+
+After processing all events, show a summary:
+
+Show: created notes (with calendar label and Gemini notes indicator), skipped (already existed), skipped (user choice), and deduplicated events.
+
+## Edge Cases
+
+- **Recurring events:** Each occurrence gets its own note (date in filename differentiates them)
+- **Events spanning midnight:** Use the start date for the filename
+- **Multiple Gemini emails for same event:** Use the most recent one
+- **Event title with date already:** Don't duplicate the date prefix
+- **Same-day duplicate titles:** Append time-of-day suffix (morning/afternoon) or time (HH:MM) to the filename
+- **Token overflow on Calendar API:** Process the saved file with Python to extract structured event data (see Step 1)
+
+## What This Skill Does NOT Do
+
+- Does not create MOC files in tag folders (that's obsidian-ingest's job)
+- Does not process past events automatically — always requires user invocation
+- Does not modify events in Google Calendar
+- Does not send emails or calendar responses


### PR DESCRIPTION
## Summary

Final PR for #85. Ships the remaining two Claude Skills, completing the initial set of 4 skills.

## /sync-calendar (358 lines)
Sync Google Calendar events to Obsidian meeting notes with optional Gemini AI summary integration via Gmail.
- Calendar list + timezone configurable via `~/.lox/config.json`
- Event filtering (decline, working location, birthdays, optional w/o response)
- Cross-calendar deduplication
- Sub-agent delegation for large date ranges
- Prerequisites: Google Calendar MCP + Gmail MCP + Lox MCP Server

## /para (275 lines)
Organize content using the PARA method (Projects, Areas, Resources, Archives).
- 3 modes: ingest (classify + create), review (reclassification suggestions), dashboard (bucket overviews)
- Lifecycle transitions (Project → Archive, Resource → Project, etc.)
- Designed for `vault.preset = 'para'`; warns if preset is zettelkasten

## Complete skill set

| Skill | Lines | Released |
|-------|-------|---------|
| `/zettelkasten` | 380 | v0.7.0 |
| `/obsidian-ingest` | 239 | v0.7.1 |
| `/sync-calendar` | 358 | this PR |
| `/para` | 275 | this PR |

## Test plan

- [x] 464 tests pass, tsc clean
- [x] `grep -riE 'credifit|linkpj|eduardo|iSorensen' skills/` returns nothing across all 4 skills
- [x] README.md updated with all 4 skills

Closes #85