### PR TITLE
fix(core): ensure created_by column exists at startup

### DIFF
--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -29,6 +29,23 @@ export class DbClient {
     this.pool = pool;
   }
 
+  /**
+   * Ensure the database schema is up-to-date.
+   *
+   * Runs idempotent ALTER TABLE statements so that columns introduced after
+   * the initial CREATE TABLE (e.g. `created_by` from team-mode) exist on
+   * databases that were provisioned before those columns were added.
+   *
+   * Safe to call on every startup — ADD COLUMN IF NOT EXISTS is a no-op
+   * when the column already exists.
+   */
+  async ensureSchema(): Promise<void> {
+    await this.pool.query(`
+      ALTER TABLE vault_embeddings
+        ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''
+    `);
+  }
+
   private buildSearchOptions(
     limitOrOptions: number | Partial<SearchOptions> | undefined,
     defaults: SearchOptions,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -159,6 +159,10 @@ async function loadTeamFeatures(): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  // Ensure schema is up-to-date (adds columns introduced after initial setup).
+  await dbClient.ensureSchema();
+  console.error('Schema migration check complete');
+
   try {
     await dbClient.reindexEmbeddings();
     console.error('Reindexed ivfflat embedding index');

--- a/packages/core/src/scripts/index-vault.ts
+++ b/packages/core/src/scripts/index-vault.ts
@@ -85,6 +85,11 @@ async function main(): Promise<void> {
   const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
   const embeddingService = new EmbeddingService(openai);
   const dbClient = new DbClient(pool);
+
+  // Ensure schema is up-to-date before indexing.
+  await dbClient.ensureSchema();
+  console.log('[index-vault] Schema migration check complete');
+
   const watcher = new VaultWatcher(VAULT_PATH!, embeddingService, dbClient);
 
   console.log(`[index-vault] Scanning vault at: ${VAULT_PATH}`);

--- a/packages/core/src/watcher/index.ts
+++ b/packages/core/src/watcher/index.ts
@@ -30,6 +30,10 @@ async function processFile(filePath: string, label: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  // Ensure schema is up-to-date (adds columns introduced after initial setup).
+  await dbClient.ensureSchema();
+  console.log('Schema migration check complete');
+
   // chokidar v5 is ESM-only; dynamic import is required from CommonJS modules.
   const chokidar = await import('chokidar');
 

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DbClient } from '../../src/lib/db-client.js';
-import type { NoteRow, SearchOptions } from '@lox-brain/shared';
+import type { NoteRow } from '@lox-brain/shared';
 
 describe('DbClient', () => {
   let client: DbClient;
@@ -11,6 +11,27 @@ describe('DbClient', () => {
       query: vi.fn(),
     };
     client = new DbClient(mockPool);
+  });
+
+  describe('ensureSchema', () => {
+    it('should run ALTER TABLE ADD COLUMN IF NOT EXISTS for created_by', async () => {
+      mockPool.query.mockResolvedValue({ rowCount: 0 });
+
+      await client.ensureSchema();
+
+      expect(mockPool.query).toHaveBeenCalledTimes(1);
+      const [sql] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('ALTER TABLE vault_embeddings');
+      expect(sql).toContain('ADD COLUMN IF NOT EXISTS created_by');
+      expect(sql).toContain('TEXT');
+      expect(sql).toContain("DEFAULT ''");
+    });
+
+    it('should propagate pool.query rejection', async () => {
+      mockPool.query.mockRejectedValue(new Error('permission denied'));
+
+      await expect(client.ensureSchema()).rejects.toThrow('permission denied');
+    });
   });
 
   describe('upsertNote', () => {


### PR DESCRIPTION
## Summary

- Fixes #159 — personal instances fail on all MCP tool calls (`list_recent`, `search_semantic`, `search_text`) because `created_by` column was never added to pre-existing databases
- Adds `DbClient.ensureSchema()` that runs idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` at startup
- Called from MCP server, watcher, and index-vault entry points

## Test plan

- [x] 131 tests passing (2 new for `ensureSchema`)
- [x] TypeScript type check clean
- [x] Manually verified on personal VM — `list_recent` returns 4998 notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)