### PR TITLE
fix(core): move import inside declare module to preserve ambient scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-04-07
+
+### Fixed
+- **Ambient `.d.ts` declaration was silently ignored due to top-level import (#161).** Moved `import type { LoxConfig }` inside the `declare module` block so the file remains a script (global ambient declaration) rather than becoming a module (scoped augmentation). Without this fix, TypeScript still couldn't resolve `@lox-brain/team` on fresh clones.
+
 ## [0.8.2] — 2026-04-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/types/lox-brain-team.d.ts
+++ b/packages/core/src/types/lox-brain-team.d.ts
@@ -9,9 +9,9 @@
  *
  * Keep in sync with packages/team/src/index.ts.
  */
-import type { LoxConfig } from '@lox-brain/shared';
-
 declare module '@lox-brain/team' {
+  import type { LoxConfig } from '@lox-brain/shared';
+
   export interface Tool {
     name: string;
     description: string;

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fixes the regression from #162 where the `.d.ts` ambient declaration was silently ignored
- Top-level `import type` turned the file into a TypeScript *module*, making `declare module` a scoped augmentation instead of a global ambient declaration
- Moving the import **inside** the `declare module` block keeps it as a script — TypeScript now correctly resolves `@lox-brain/team`
- Version bump to `0.8.3`

Closes #161

## Test plan
- [x] `npx tsc --noEmit` passes on all packages
- [x] 688 tests passing
- [x] Clean build from scratch (`rm -rf */dist && npm run build --workspaces`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)