### PR TITLE
fix(installer): redirect stdin from /dev/tty for curl|bash installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.4] — 2026-04-07
+
+### Fixed
+- **`curl|bash` install crashes on interactive prompts (#164).** Redirected stdin from `/dev/tty` in `install.sh` so `@inquirer/prompts` can read user input even when the script itself is piped through bash.
+
 ## [0.8.3] — 2026-04-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ npm ci --silent
 echo "Building..."
 npm run build --workspaces --silent
 echo ""
-node packages/installer/dist/index.js
+node packages/installer/dist/index.js < /dev/tty
 
 # Cleanup
 rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- `curl -fsSL ... | bash` consumes stdin, blocking `@inquirer/prompts` interactive input
- Added `< /dev/tty` redirect to the `node` invocation in `install.sh`
- Standard pattern used by rustup, nvm, Homebrew

Closes #164

## Test plan
- [ ] `curl -fsSL https://raw.githubusercontent.com/isorensen/lox-brain/main/scripts/install.sh | bash` shows prompts and accepts input

🤖 Generated with [Claude Code](https://claude.com/claude-code)