### PR TITLE
feat: add task management and daily log tools

### DIFF
--- a/infra/postgres/schema.sql
+++ b/infra/postgres/schema.sql
@@ -27,3 +27,29 @@ CREATE INDEX IF NOT EXISTS idx_vault_embeddings_tags
 
 CREATE INDEX IF NOT EXISTS idx_vault_embeddings_updated_at
   ON vault_embeddings (updated_at DESC);
+
+-- Full-text search index (Portuguese stemming + ranking)
+CREATE INDEX IF NOT EXISTS idx_vault_embeddings_fulltext
+  ON vault_embeddings USING GIN(to_tsvector('portuguese', content));
+
+-- Tasks table
+CREATE TABLE IF NOT EXISTS tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  details TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  priority TEXT NOT NULL DEFAULT 'medium',
+  due_date DATE,
+  tags TEXT[] DEFAULT '{}',
+  project_context TEXT,
+  created_by TEXT,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date
+  ON tasks(due_date) WHERE status NOT IN ('done', 'cancelled');
+CREATE INDEX IF NOT EXISTS idx_tasks_tags ON tasks USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_tasks_project_context ON tasks(project_context);

--- a/infra/postgres/schema.sql
+++ b/infra/postgres/schema.sql
@@ -28,10 +28,6 @@ CREATE INDEX IF NOT EXISTS idx_vault_embeddings_tags
 CREATE INDEX IF NOT EXISTS idx_vault_embeddings_updated_at
   ON vault_embeddings (updated_at DESC);
 
--- Full-text search index (Portuguese stemming + ranking)
-CREATE INDEX IF NOT EXISTS idx_vault_embeddings_fulltext
-  ON vault_embeddings USING GIN(to_tsvector('portuguese', content));
-
 -- Tasks table
 CREATE TABLE IF NOT EXISTS tasks (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -1,5 +1,8 @@
 import type { Pool } from 'pg';
-import type { NoteRow, SearchResult, RecentNote, SearchOptions, PaginatedResult } from '@lox-brain/shared';
+import type {
+  NoteRow, SearchResult, RecentNote, SearchOptions, PaginatedResult,
+  TaskRow, TaskStatus, TaskPriority, TaskListOptions,
+} from '@lox-brain/shared';
 
 const SEMANTIC_DEFAULTS: SearchOptions = {
   limit: 5,
@@ -43,6 +46,36 @@ export class DbClient {
     await this.pool.query(`
       ALTER TABLE vault_embeddings
         ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''
+    `);
+
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS tasks (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        title TEXT NOT NULL,
+        details TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        priority TEXT NOT NULL DEFAULT 'medium',
+        due_date DATE,
+        tags TEXT[] DEFAULT '{}',
+        project_context TEXT,
+        created_by TEXT,
+        completed_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+      CREATE INDEX IF NOT EXISTS idx_tasks_due_date
+        ON tasks(due_date) WHERE status NOT IN ('done', 'cancelled');
+      CREATE INDEX IF NOT EXISTS idx_tasks_tags ON tasks USING GIN(tags);
+      CREATE INDEX IF NOT EXISTS idx_tasks_project_context ON tasks(project_context);
+    `);
+
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_fulltext
+        ON vault_embeddings USING GIN(to_tsvector('portuguese', content))
     `);
   }
 
@@ -262,13 +295,11 @@ export class DbClient {
 
     let paramIdx = 1;
 
-    // $1 = query pattern
     const queryParamIdx = paramIdx++;
 
     let tagsClause = '';
-    let tagsParamIdx = 0;
     if (tags && tags.length > 0) {
-      tagsParamIdx = paramIdx++;
+      const tagsParamIdx = paramIdx++;
       tagsClause = ` AND tags @> $${tagsParamIdx}`;
     }
 
@@ -280,15 +311,16 @@ export class DbClient {
 
     const sql = `
       SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by,
+             ts_rank(to_tsvector('portuguese', content), plainto_tsquery('portuguese', $${queryParamIdx})) AS rank,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
-      WHERE content ILIKE $${queryParamIdx}${tagsClause}
-      ORDER BY updated_at DESC
+      WHERE to_tsvector('portuguese', content) @@ plainto_tsquery('portuguese', $${queryParamIdx})${tagsClause}
+      ORDER BY rank DESC
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
     `;
 
-    const params: unknown[] = [`%${query}%`];
+    const params: unknown[] = [query];
     if (tags && tags.length > 0) {
       params.push(tags);
     }
@@ -296,5 +328,181 @@ export class DbClient {
 
     const result = await this.pool.query(sql, params);
     return this.buildPaginatedResult(result.rows, opts);
+  }
+
+  // --- Tasks ---
+
+  async addTask(params: {
+    title: string;
+    details?: string;
+    priority?: TaskPriority;
+    due_date?: string;
+    tags?: string[];
+    project_context?: string;
+    created_by?: string;
+  }): Promise<TaskRow> {
+    const result = await this.pool.query<TaskRow>(
+      `INSERT INTO tasks (title, details, priority, due_date, tags, project_context, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        params.title,
+        params.details ?? null,
+        params.priority ?? 'medium',
+        params.due_date ?? null,
+        params.tags ?? [],
+        params.project_context ?? null,
+        params.created_by ?? null,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  async listTasks(options: TaskListOptions = {}): Promise<{ results: TaskRow[]; total: number }> {
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+    let paramIdx = 1;
+
+    const status = options.status ?? 'pending';
+    if (status) {
+      conditions.push(`status = $${paramIdx++}`);
+      values.push(status);
+    }
+    if (options.priority) {
+      conditions.push(`priority = $${paramIdx++}`);
+      values.push(options.priority);
+    }
+    if (options.project_context) {
+      conditions.push(`project_context = $${paramIdx++}`);
+      values.push(options.project_context);
+    }
+    if (options.tags && options.tags.length > 0) {
+      conditions.push(`tags && $${paramIdx++}`);
+      values.push(options.tags);
+    }
+    if (options.due_before) {
+      conditions.push(`due_date <= $${paramIdx++}`);
+      values.push(options.due_before);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = options.limit ?? 20;
+    const offset = options.offset ?? 0;
+
+    const countResult = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM tasks ${where}`, values,
+    );
+    const total = Number(countResult.rows[0].count);
+
+    const result = await this.pool.query<TaskRow>(
+      `SELECT * FROM tasks ${where}
+       ORDER BY
+         CASE priority WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 END,
+         due_date ASC NULLS LAST,
+         created_at DESC
+       LIMIT $${paramIdx++} OFFSET $${paramIdx}`,
+      [...values, limit, offset],
+    );
+
+    return { results: result.rows, total };
+  }
+
+  async updateTask(id: string, updates: Partial<{
+    title: string;
+    details: string;
+    status: TaskStatus;
+    priority: TaskPriority;
+    due_date: string;
+    tags: string[];
+    project_context: string;
+  }>): Promise<TaskRow | null> {
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+    let paramIdx = 1;
+
+    const idIdx = paramIdx++;
+    if (updates.title !== undefined) { setClauses.push(`title = $${paramIdx++}`); values.push(updates.title); }
+    if (updates.details !== undefined) { setClauses.push(`details = $${paramIdx++}`); values.push(updates.details); }
+    if (updates.status !== undefined) {
+      setClauses.push(`status = $${paramIdx++}`);
+      values.push(updates.status);
+      if (updates.status === 'done') {
+        setClauses.push(`completed_at = NOW()`);
+      }
+    }
+    if (updates.priority !== undefined) { setClauses.push(`priority = $${paramIdx++}`); values.push(updates.priority); }
+    if (updates.due_date !== undefined) { setClauses.push(`due_date = $${paramIdx++}`); values.push(updates.due_date); }
+    if (updates.tags !== undefined) { setClauses.push(`tags = $${paramIdx++}`); values.push(updates.tags); }
+    if (updates.project_context !== undefined) { setClauses.push(`project_context = $${paramIdx++}`); values.push(updates.project_context); }
+
+    if (setClauses.length === 0) return null;
+
+    setClauses.push('updated_at = NOW()');
+
+    const result = await this.pool.query<TaskRow>(
+      `UPDATE tasks SET ${setClauses.join(', ')} WHERE id = $${idIdx} RETURNING *`,
+      [id, ...values],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async completeTask(idOrTitle: string): Promise<TaskRow | null> {
+    // Try by ID first
+    let result = await this.pool.query<TaskRow>(
+      `UPDATE tasks SET status = 'done', completed_at = NOW(), updated_at = NOW()
+       WHERE id = $1 RETURNING *`,
+      [idOrTitle],
+    );
+    if (result.rows[0]) return result.rows[0];
+
+    // Fallback to fuzzy title match
+    result = await this.pool.query<TaskRow>(
+      `UPDATE tasks SET status = 'done', completed_at = NOW(), updated_at = NOW()
+       WHERE id = (SELECT id FROM tasks WHERE title ILIKE $1 AND status != 'done' ORDER BY created_at DESC LIMIT 1)
+       RETURNING *`,
+      [`%${idOrTitle}%`],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  // --- Daily Log ---
+
+  async appendDailyLog(entry: string, tags?: string[], createdBy?: string): Promise<{ id: string; date: string; entries_count: number }> {
+    const today = new Date().toISOString().split('T')[0];
+    const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+    const formattedEntry = `\n### ${timestamp}\n${entry}`;
+
+    // Try to find existing daily log for today
+    const existing = await this.pool.query<{ id: string; content: string; tags: string[] }>(
+      `SELECT id, content, tags FROM vault_embeddings
+       WHERE file_path = $1 AND chunk_index = 0`,
+      [`daily-logs/${today}.md`],
+    );
+
+    if (existing.rows[0]) {
+      const updatedContent = existing.rows[0].content + formattedEntry;
+      const mergedTags = [...new Set([...existing.rows[0].tags, ...(tags ?? [])])];
+      await this.pool.query(
+        `UPDATE vault_embeddings SET content = $1, tags = $2, updated_at = NOW()
+         WHERE id = $3`,
+        [updatedContent, mergedTags, existing.rows[0].id],
+      );
+      const entriesCount = (updatedContent.match(/^### \d{2}:\d{2}/gm) ?? []).length;
+      return { id: existing.rows[0].id, date: today, entries_count: entriesCount };
+    }
+
+    // Create new daily log
+    const content = `# Daily Log - ${today}${formattedEntry}`;
+    const allTags = ['daily_log', ...(tags ?? [])];
+    const { randomUUID } = await import('node:crypto');
+    const id = randomUUID();
+
+    await this.pool.query(
+      `INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, chunk_index, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8)`,
+      [id, `daily-logs/${today}.md`, today, content, allTags, null, '', createdBy ?? ''],
+    );
+
+    return { id, date: today, entries_count: 1 };
   }
 }

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -73,10 +73,6 @@ export class DbClient {
       CREATE INDEX IF NOT EXISTS idx_tasks_project_context ON tasks(project_context);
     `);
 
-    await this.pool.query(`
-      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_fulltext
-        ON vault_embeddings USING GIN(to_tsvector('portuguese', content))
-    `);
   }
 
   private buildSearchOptions(
@@ -311,16 +307,15 @@ export class DbClient {
 
     const sql = `
       SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by,
-             ts_rank(to_tsvector('portuguese', content), plainto_tsquery('portuguese', $${queryParamIdx})) AS rank,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
-      WHERE to_tsvector('portuguese', content) @@ plainto_tsquery('portuguese', $${queryParamIdx})${tagsClause}
-      ORDER BY rank DESC
+      WHERE content ILIKE $${queryParamIdx}${tagsClause}
+      ORDER BY updated_at DESC
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
     `;
 
-    const params: unknown[] = [query];
+    const params: unknown[] = [`%${query}%`];
     if (tags && tags.length > 0) {
       params.push(tags);
     }

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import type { DbClient } from '../lib/db-client.js';
 import type { EmbeddingService } from '../lib/embedding-service.js';
-import type { SearchOptions } from '@lox-brain/shared';
+import type { SearchOptions, TaskStatus, TaskPriority, TASK_STATUSES, TASK_PRIORITIES } from '@lox-brain/shared';
 
 export interface Tool {
   name: string;
@@ -214,6 +214,140 @@ export function createTools(
         };
 
         return dbClient.listRecent(searchOptions);
+      },
+    },
+
+    // --- Task Management ---
+
+    {
+      name: 'add_task',
+      description: 'Create a task with title, priority, due date, and tags. Returns the created task.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', description: 'Task title' },
+          details: { type: 'string', description: 'Optional markdown details' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'], description: 'Priority (default: medium)' },
+          due_date: { type: 'string', description: 'Due date in YYYY-MM-DD format' },
+          tags: { type: 'array', items: { type: 'string' }, description: 'Tags for filtering' },
+          project_context: { type: 'string', description: 'Which project this task relates to' },
+        },
+        required: ['title'],
+      },
+      async handler(args: Record<string, unknown>): Promise<unknown> {
+        const title = args.title;
+        if (typeof title !== 'string' || title.trim() === '') {
+          throw new Error('title must be a non-empty string');
+        }
+        const createdBy = typeof args._created_by === 'string' ? args._created_by : undefined;
+        return dbClient.addTask({
+          title,
+          details: args.details as string | undefined,
+          priority: args.priority as TaskPriority | undefined,
+          due_date: args.due_date as string | undefined,
+          tags: args.tags as string[] | undefined,
+          project_context: args.project_context as string | undefined,
+          created_by: createdBy,
+        });
+      },
+    },
+    {
+      name: 'list_tasks',
+      description: 'List tasks sorted by priority and due date. Defaults to pending tasks.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', enum: ['pending', 'in_progress', 'done', 'cancelled'], description: 'Filter by status (default: pending)' },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'], description: 'Filter by priority' },
+          project_context: { type: 'string', description: 'Filter by project' },
+          tags: { type: 'array', items: { type: 'string' }, description: 'Filter by tags (overlap)' },
+          due_before: { type: 'string', description: 'Show tasks due before this date (YYYY-MM-DD)' },
+          limit: { type: 'number', description: 'Max results (default: 20)' },
+          offset: { type: 'number', description: 'Pagination offset (default: 0)' },
+        },
+      },
+      async handler(args: Record<string, unknown>): Promise<unknown> {
+        return dbClient.listTasks({
+          status: args.status as TaskStatus | undefined,
+          priority: args.priority as TaskPriority | undefined,
+          project_context: args.project_context as string | undefined,
+          tags: args.tags as string[] | undefined,
+          due_before: args.due_before as string | undefined,
+          limit: args.limit as number | undefined,
+          offset: args.offset as number | undefined,
+        });
+      },
+    },
+    {
+      name: 'update_task',
+      description: 'Update any field of a task by ID.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Task UUID' },
+          title: { type: 'string' },
+          details: { type: 'string' },
+          status: { type: 'string', enum: ['pending', 'in_progress', 'done', 'cancelled'] },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+          due_date: { type: 'string', description: 'YYYY-MM-DD' },
+          tags: { type: 'array', items: { type: 'string' } },
+          project_context: { type: 'string' },
+        },
+        required: ['id'],
+      },
+      async handler(args: Record<string, unknown>): Promise<unknown> {
+        const id = args.id;
+        if (typeof id !== 'string' || id.trim() === '') {
+          throw new Error('id must be a non-empty string');
+        }
+        const { id: _, _created_by: __, ...updates } = args;
+        const result = await dbClient.updateTask(id, updates as Record<string, unknown>);
+        if (!result) throw new Error(`Task not found: ${id}`);
+        return result;
+      },
+    },
+    {
+      name: 'complete_task',
+      description: 'Mark a task as done by ID or fuzzy title match. Sets completed_at timestamp.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id_or_title: { type: 'string', description: 'Task UUID or partial title to match' },
+        },
+        required: ['id_or_title'],
+      },
+      async handler(args: Record<string, unknown>): Promise<unknown> {
+        const idOrTitle = args.id_or_title;
+        if (typeof idOrTitle !== 'string' || idOrTitle.trim() === '') {
+          throw new Error('id_or_title must be a non-empty string');
+        }
+        const result = await dbClient.completeTask(idOrTitle);
+        if (!result) throw new Error(`No pending task found matching: ${idOrTitle}`);
+        return result;
+      },
+    },
+
+    // --- Daily Log ---
+
+    {
+      name: 'daily_log',
+      description: 'Append a timestamped entry to today\'s daily log. Auto-creates if no log exists for today.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          entry: { type: 'string', description: 'What you learned, solved, or observed' },
+          tags: { type: 'array', items: { type: 'string' }, description: 'Tags for this entry' },
+        },
+        required: ['entry'],
+      },
+      async handler(args: Record<string, unknown>): Promise<unknown> {
+        const entry = args.entry;
+        if (typeof entry !== 'string' || entry.trim() === '') {
+          throw new Error('entry must be a non-empty string');
+        }
+        const tags = args.tags as string[] | undefined;
+        const createdBy = typeof args._created_by === 'string' ? args._created_by : undefined;
+        return dbClient.appendDailyLog(entry, tags, createdBy);
       },
     },
   ];

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -24,7 +24,6 @@ describe('DbClient', () => {
       expect(allSql).toContain('ALTER TABLE vault_embeddings');
       expect(allSql).toContain('ADD COLUMN IF NOT EXISTS created_by');
       expect(allSql).toContain('CREATE TABLE IF NOT EXISTS tasks');
-      expect(allSql).toContain('idx_vault_embeddings_fulltext');
     });
 
     it('should propagate pool.query rejection', async () => {
@@ -418,10 +417,9 @@ describe('DbClient', () => {
 
       expect(mockPool.query).toHaveBeenCalledTimes(1);
       const [sql, params] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('to_tsvector');
-      expect(sql).toContain('plainto_tsquery');
+      expect(sql).toContain('ILIKE');
       expect(sql).toContain('tags @>');
-      expect(params[0]).toBe('matching');
+      expect(params[0]).toBe('%matching%');
       expect(result).toHaveProperty('results');
       expect(result).toHaveProperty('total');
     });
@@ -432,10 +430,9 @@ describe('DbClient', () => {
       await client.searchText('query');
 
       const [sql, params] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('to_tsvector');
-      expect(sql).toContain('ts_rank');
+      expect(sql).toContain('ILIKE');
       expect(sql).not.toContain('tags @>');
-      expect(params[0]).toBe('query');
+      expect(params[0]).toBe('%query%');
     });
 
     it('should SELECT created_by in text search results', async () => {

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -19,12 +19,12 @@ describe('DbClient', () => {
 
       await client.ensureSchema();
 
-      expect(mockPool.query).toHaveBeenCalledTimes(1);
-      const [sql] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('ALTER TABLE vault_embeddings');
-      expect(sql).toContain('ADD COLUMN IF NOT EXISTS created_by');
-      expect(sql).toContain('TEXT');
-      expect(sql).toContain("DEFAULT ''");
+      expect(mockPool.query).toHaveBeenCalled();
+      const allSql = mockPool.query.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(allSql).toContain('ALTER TABLE vault_embeddings');
+      expect(allSql).toContain('ADD COLUMN IF NOT EXISTS created_by');
+      expect(allSql).toContain('CREATE TABLE IF NOT EXISTS tasks');
+      expect(allSql).toContain('idx_vault_embeddings_fulltext');
     });
 
     it('should propagate pool.query rejection', async () => {
@@ -418,9 +418,10 @@ describe('DbClient', () => {
 
       expect(mockPool.query).toHaveBeenCalledTimes(1);
       const [sql, params] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('ILIKE');
+      expect(sql).toContain('to_tsvector');
+      expect(sql).toContain('plainto_tsquery');
       expect(sql).toContain('tags @>');
-      expect(params[0]).toBe('%matching%');
+      expect(params[0]).toBe('matching');
       expect(result).toHaveProperty('results');
       expect(result).toHaveProperty('total');
     });
@@ -431,9 +432,10 @@ describe('DbClient', () => {
       await client.searchText('query');
 
       const [sql, params] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('ILIKE');
+      expect(sql).toContain('to_tsvector');
+      expect(sql).toContain('ts_rank');
       expect(sql).not.toContain('tags @>');
-      expect(params[0]).toBe('%query%');
+      expect(params[0]).toBe('query');
     });
 
     it('should SELECT created_by in text search results', async () => {

--- a/packages/core/tests/mcp/mcp-tools.test.ts
+++ b/packages/core/tests/mcp/mcp-tools.test.ts
@@ -71,9 +71,9 @@ describe('createTools', () => {
   });
 
   describe('tool definitions', () => {
-    it('should define exactly 6 tools', () => {
+    it('should define exactly 11 tools', () => {
       const tools = createTools(dbClient, embeddingService, tempVaultPath);
-      expect(tools).toHaveLength(6);
+      expect(tools).toHaveLength(11);
     });
 
     it('should define tools with correct names', () => {
@@ -85,6 +85,11 @@ describe('createTools', () => {
       expect(names).toContain('search_semantic');
       expect(names).toContain('search_text');
       expect(names).toContain('list_recent');
+      expect(names).toContain('add_task');
+      expect(names).toContain('list_tasks');
+      expect(names).toContain('update_task');
+      expect(names).toContain('complete_task');
+      expect(names).toContain('daily_log');
     });
 
     it('each tool should have name, description, inputSchema, and handler', () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -51,3 +51,36 @@ export interface RecentNote {
   updated_at: Date;
   created_by?: string;
 }
+
+// --- Tasks ---
+
+export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'cancelled';
+export type TaskPriority = 'low' | 'medium' | 'high';
+
+export const TASK_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'done', 'cancelled'];
+export const TASK_PRIORITIES: TaskPriority[] = ['low', 'medium', 'high'];
+
+export interface TaskRow {
+  id: string;
+  title: string;
+  details: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  due_date: string | null;
+  tags: string[];
+  project_context: string | null;
+  created_by: string | null;
+  completed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface TaskListOptions {
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  project_context?: string;
+  tags?: string[];
+  due_before?: string;
+  limit?: number;
+  offset?: number;
+}


### PR DESCRIPTION
## Summary

This PR adds **5 new MCP tools** to lox-brain for task management and daily logging.

### New Tools

| Tool | Description |
|------|-------------|
| `add_task` | Create tasks with title, priority, due date, tags, and project context |
| `list_tasks` | List/filter tasks by status, priority, project, tags, due date. Sorted by priority then due date |
| `update_task` | Update any task field by ID. Auto-sets `completed_at` when status changes to `done` |
| `complete_task` | Mark task as done by UUID or fuzzy title match |
| `daily_log` | Append timestamped entries to auto-created daily logs. Merges tags across entries |

### Schema Changes

**New `tasks` table:**

| Column | Type | Description |
|--------|------|-------------|
| id | UUID | Primary key, auto-generated |
| title | TEXT | Task title (required) |
| details | TEXT | Optional markdown content |
| status | TEXT | pending, in_progress, done, cancelled |
| priority | TEXT | low, medium, high |
| due_date | DATE | Optional deadline |
| tags | TEXT[] | Array for filtering |
| project_context | TEXT | Which project this relates to |
| created_by | TEXT | Team mode compatible |
| completed_at | TIMESTAMPTZ | Auto-set when marked done |

**Indexes:** status, due_date (partial), tags (GIN), project_context

**Migration:** ensureSchema() handles existing databases with CREATE TABLE/INDEX IF NOT EXISTS

### Design Decisions

1. **Separate tasks table** — tasks have structured fields (status, priority, due_date) that don't fit vault_embeddings and need different query patterns
2. **daily_log writes to vault_embeddings** — daily logs are searchable text content, using file_path = daily-logs/YYYY-MM-DD.md convention
3. **complete_task supports fuzzy title match** — allows completing by partial title when UUID isn't known
4. **Team mode compatible** — all tools respect _created_by middleware, tasks table includes created_by

### Test Results

- All **688 tests pass** (shared: 35, core: 131, installer: 488, team: 34)
- TypeScript build passes across all 4 workspaces
- No changes to existing searchText behavior (ILIKE preserved)