### PR TITLE
feat: add area and source_type metadata filtering

### DIFF
--- a/infra/postgres/schema.sql
+++ b/infra/postgres/schema.sql
@@ -27,3 +27,13 @@ CREATE INDEX IF NOT EXISTS idx_vault_embeddings_tags
 
 CREATE INDEX IF NOT EXISTS idx_vault_embeddings_updated_at
   ON vault_embeddings (updated_at DESC);
+
+-- Optional metadata columns for domain filtering
+ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS area TEXT;
+ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS source_type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_vault_embeddings_area
+  ON vault_embeddings(area) WHERE area IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vault_embeddings_source_type
+  ON vault_embeddings(source_type) WHERE source_type IS NOT NULL;

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -44,6 +44,15 @@ export class DbClient {
       ALTER TABLE vault_embeddings
         ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''
     `);
+
+    await this.pool.query(`
+      ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS area TEXT;
+      ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS source_type TEXT;
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_area
+        ON vault_embeddings(area) WHERE area IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_source_type
+        ON vault_embeddings(source_type) WHERE source_type IS NOT NULL;
+    `);
   }
 
   private buildSearchOptions(
@@ -77,6 +86,25 @@ export class DbClient {
     return { sql: 'content', params: [], nextParamIndex: paramIndex };
   }
 
+  private buildMetadataFilters(
+    opts: SearchOptions,
+    startParamIdx: number,
+  ): { clauses: string[]; params: unknown[]; nextParamIndex: number } {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = startParamIdx;
+
+    if (opts.area) {
+      clauses.push(`area = $${paramIdx++}`);
+      params.push(opts.area);
+    }
+    if (opts.source_type) {
+      clauses.push(`source_type = $${paramIdx++}`);
+      params.push(opts.source_type);
+    }
+    return { clauses, params, nextParamIndex: paramIdx };
+  }
+
   private buildPaginatedResult<T>(
     rows: Array<T & { total_count?: string }>,
     opts: SearchOptions,
@@ -88,8 +116,8 @@ export class DbClient {
 
   async upsertNote(note: NoteRow): Promise<void> {
     const sql = `
-      INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, chunk_index, created_by, updated_at)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+      INSERT INTO vault_embeddings (id, file_path, title, content, tags, embedding, file_hash, chunk_index, created_by, area, source_type, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
       ON CONFLICT (file_path, chunk_index) DO UPDATE SET
         title = EXCLUDED.title,
         content = EXCLUDED.content,
@@ -97,6 +125,8 @@ export class DbClient {
         embedding = EXCLUDED.embedding,
         file_hash = EXCLUDED.file_hash,
         created_by = COALESCE(vault_embeddings.created_by, EXCLUDED.created_by),
+        area = COALESCE(EXCLUDED.area, vault_embeddings.area),
+        source_type = COALESCE(EXCLUDED.source_type, vault_embeddings.source_type),
         updated_at = NOW()
     `;
 
@@ -110,6 +140,8 @@ export class DbClient {
       note.file_hash,
       note.chunk_index,
       note.created_by ?? null,
+      note.area ?? null,
+      note.source_type ?? null,
     ]);
   }
 
@@ -143,15 +175,21 @@ export class DbClient {
     const contentCol = this.buildContentColumn(opts, paramIdx);
     paramIdx = contentCol.nextParamIndex;
 
+    const filters = this.buildMetadataFilters(opts, paramIdx);
+    paramIdx = filters.nextParamIndex;
+
     const limitIdx = paramIdx++;
     const offsetIdx = paramIdx++;
+
+    const whereClause = filters.clauses.length > 0 ? `WHERE ${filters.clauses.join(' AND ')}` : '';
 
     const sql = `
       SELECT id, file_path, title, ${contentCol.sql}, tags,
              1 - (embedding <=> $1::vector) AS similarity,
-             updated_at, created_by,
+             updated_at, created_by, area, source_type,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
+      ${whereClause}
       ORDER BY embedding <=> $1::vector
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
@@ -160,6 +198,7 @@ export class DbClient {
     const params = [
       JSON.stringify(embedding),
       ...contentCol.params,
+      ...filters.params,
       opts.limit,
       opts.offset,
     ];
@@ -194,19 +233,25 @@ export class DbClient {
     const contentCol = this.buildContentColumn(opts, paramIdx);
     paramIdx = contentCol.nextParamIndex;
 
+    const filters = this.buildMetadataFilters(opts, paramIdx);
+    paramIdx = filters.nextParamIndex;
+
     const limitIdx = paramIdx++;
     const offsetIdx = paramIdx++;
 
+    const whereClause = filters.clauses.length > 0 ? `WHERE ${filters.clauses.join(' AND ')}` : '';
+
     const sql = `
-      SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by,
+      SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by, area, source_type,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
+      ${whereClause}
       ORDER BY updated_at DESC
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
     `;
 
-    const params = [...contentCol.params, opts.limit, opts.offset];
+    const params = [...contentCol.params, ...filters.params, opts.limit, opts.offset];
 
     const result = await this.pool.query(sql, params);
     return this.buildPaginatedResult(result.rows, opts);
@@ -266,11 +311,14 @@ export class DbClient {
     const queryParamIdx = paramIdx++;
 
     let tagsClause = '';
-    let tagsParamIdx = 0;
     if (tags && tags.length > 0) {
-      tagsParamIdx = paramIdx++;
+      const tagsParamIdx = paramIdx++;
       tagsClause = ` AND tags @> $${tagsParamIdx}`;
     }
+
+    const filters = this.buildMetadataFilters(opts, paramIdx);
+    paramIdx = filters.nextParamIndex;
+    const metadataClause = filters.clauses.length > 0 ? ` AND ${filters.clauses.join(' AND ')}` : '';
 
     const contentCol = this.buildContentColumn(opts, paramIdx);
     paramIdx = contentCol.nextParamIndex;
@@ -279,10 +327,10 @@ export class DbClient {
     const offsetIdx = paramIdx++;
 
     const sql = `
-      SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by,
+      SELECT id, file_path, title, ${contentCol.sql}, tags, updated_at, created_by, area, source_type,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
-      WHERE content ILIKE $${queryParamIdx}${tagsClause}
+      WHERE content ILIKE $${queryParamIdx}${tagsClause}${metadataClause}
       ORDER BY updated_at DESC
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
@@ -292,7 +340,7 @@ export class DbClient {
     if (tags && tags.length > 0) {
       params.push(tags);
     }
-    params.push(...contentCol.params, opts.limit, opts.offset);
+    params.push(...filters.params, ...contentCol.params, opts.limit, opts.offset);
 
     const result = await this.pool.query(sql, params);
     return this.buildPaginatedResult(result.rows, opts);

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -141,6 +141,8 @@ export function createTools(
           offset: { type: 'number', description: 'Pagination offset (default: 0)' },
           include_content: { type: 'boolean', description: 'Include content in results (default: false)' },
           content_preview_length: { type: 'number', description: 'Truncate content to N chars, 0 for full (default: 300)' },
+          area: { type: 'string', description: 'Filter by area (e.g. ia, programacao, lideranca, comunicacao, financas)' },
+          source_type: { type: 'string', description: 'Filter by source type (e.g. study, book_summary, news, free_note, daily_log)' },
         },
         required: ['query'],
       },
@@ -155,6 +157,8 @@ export function createTools(
           offset: (args.offset as number | undefined) ?? 0,
           includeContent: (args.include_content as boolean | undefined) ?? false,
           contentPreviewLength: (args.content_preview_length as number | undefined) ?? 300,
+          area: args.area as string | undefined,
+          source_type: args.source_type as string | undefined,
         };
 
         const embedding = await embeddingService.generateEmbedding(query);
@@ -163,12 +167,14 @@ export function createTools(
     },
     {
       name: 'search_text',
-      description: 'Search notes by text content. Returns metadata only by default. Supports pagination via limit/offset. Use read_note for full content.',
+      description: 'Search notes by text content (case-insensitive). Returns metadata only by default. Use read_note for full content.',
       inputSchema: {
         type: 'object',
         properties: {
           query: { type: 'string', description: 'Text to search for (case-insensitive)' },
           tags: { type: 'array', items: { type: 'string' }, description: 'Optional tags to filter by' },
+          area: { type: 'string', description: 'Filter by area (e.g. ia, programacao, lideranca, comunicacao, financas)' },
+          source_type: { type: 'string', description: 'Filter by source type (e.g. study, book_summary, news, free_note, daily_log)' },
           limit: { type: 'number', description: 'Maximum number of results (default: 20)' },
           offset: { type: 'number', description: 'Pagination offset (default: 0)' },
           include_content: { type: 'boolean', description: 'Include content in results (default: false)' },
@@ -188,6 +194,8 @@ export function createTools(
           offset: (args.offset as number | undefined) ?? 0,
           includeContent: (args.include_content as boolean | undefined) ?? false,
           contentPreviewLength: (args.content_preview_length as number | undefined) ?? 300,
+          area: args.area as string | undefined,
+          source_type: args.source_type as string | undefined,
         };
 
         return dbClient.searchText(query, tags, searchOptions);
@@ -203,6 +211,8 @@ export function createTools(
           offset: { type: 'number', description: 'Pagination offset (default: 0)' },
           include_content: { type: 'boolean', description: 'Include content in results (default: false)' },
           content_preview_length: { type: 'number', description: 'Truncate content to N chars, 0 for full (default: 300)' },
+          area: { type: 'string', description: 'Filter by area' },
+          source_type: { type: 'string', description: 'Filter by source type' },
         },
       },
       async handler(args: Record<string, unknown>): Promise<unknown> {
@@ -211,6 +221,8 @@ export function createTools(
           offset: (args.offset as number | undefined) ?? 0,
           includeContent: (args.include_content as boolean | undefined) ?? false,
           contentPreviewLength: (args.content_preview_length as number | undefined) ?? 300,
+          area: args.area as string | undefined,
+          source_type: args.source_type as string | undefined,
         };
 
         return dbClient.listRecent(searchOptions);

--- a/packages/core/src/watcher/vault-watcher.ts
+++ b/packages/core/src/watcher/vault-watcher.ts
@@ -22,6 +22,26 @@ export class VaultWatcher {
     return path.relative(this.vaultPath, filePath).replace(/\\/g, '/');
   }
 
+  deriveArea(relativePath: string): string | null {
+    const parts = relativePath.split('/');
+    if (parts.length >= 2 && (parts[0] === 'studies' || parts[0] === 'Livros')) {
+      const validAreas = ['ia', 'programacao', 'lideranca', 'comunicacao', 'financas'];
+      if (validAreas.includes(parts[1])) return parts[1];
+    }
+    if (parts[0] === 'api-docs') return 'programacao';
+    return null;
+  }
+
+  deriveSourceType(relativePath: string): string | null {
+    const parts = relativePath.split('/');
+    if (parts[0] === 'studies') return 'study';
+    if (parts[0] === 'Livros' && path.basename(relativePath).startsWith('summary')) return 'book_summary';
+    if (parts[0] === 'news') return 'news';
+    if (parts[0] === 'daily-logs') return 'daily_log';
+    if (parts[0] === 'api-docs') return 'study';
+    return 'free_note';
+  }
+
   async handleFileChange(filePath: string, content: string): Promise<void> {
     const relative = this.relativePath(filePath);
     const newHash = this.embeddingService.computeHash(content);
@@ -44,6 +64,9 @@ export class VaultWatcher {
       }
 
       // Phase 2: All embeddings succeeded — now upsert all chunks
+      const area = this.deriveArea(relative);
+      const sourceType = this.deriveSourceType(relative);
+
       for (let i = 0; i < chunkData.length; i++) {
         await this.dbClient.upsertNote({
           id: randomUUID(),
@@ -55,6 +78,8 @@ export class VaultWatcher {
           file_hash: newHash,
           chunk_index: i,
           created_by: metadata.created_by,
+          area,
+          source_type: sourceType,
         });
       }
 

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -19,12 +19,14 @@ describe('DbClient', () => {
 
       await client.ensureSchema();
 
-      expect(mockPool.query).toHaveBeenCalledTimes(1);
-      const [sql] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('ALTER TABLE vault_embeddings');
-      expect(sql).toContain('ADD COLUMN IF NOT EXISTS created_by');
-      expect(sql).toContain('TEXT');
-      expect(sql).toContain("DEFAULT ''");
+      expect(mockPool.query).toHaveBeenCalled();
+      const allSql = mockPool.query.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(allSql).toContain('ALTER TABLE vault_embeddings');
+      expect(allSql).toContain('ADD COLUMN IF NOT EXISTS created_by');
+      expect(allSql).toContain('ADD COLUMN IF NOT EXISTS area');
+      expect(allSql).toContain('ADD COLUMN IF NOT EXISTS source_type');
+      expect(allSql).toContain('idx_vault_embeddings_area');
+      expect(allSql).toContain('idx_vault_embeddings_source_type');
     });
 
     it('should propagate pool.query rejection', async () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -15,6 +15,8 @@ export interface NoteRow {
   file_hash: string;
   chunk_index: number;
   created_by?: string;
+  area?: string | null;
+  source_type?: string | null;
 }
 
 export interface SearchOptions {
@@ -22,6 +24,8 @@ export interface SearchOptions {
   offset: number;
   includeContent: boolean;
   contentPreviewLength: number; // 0 = full content, >0 = truncate at N chars
+  area?: string;
+  source_type?: string;
 }
 
 export interface PaginatedResult<T> {


### PR DESCRIPTION
## Summary

Adds two optional metadata columns (`area`, `source_type`) to `vault_embeddings` for domain-based filtering. The vault watcher derives values automatically from file paths during indexing.

### What it enables

```
search_semantic(query: "circuit breaker", area: "programacao")
search_text(query: "feedback", source_type: "book_summary")
list_recent(area: "lideranca")
```

### How it works

**Schema (nullable columns, no migration needed for existing data):**
```sql
ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS area TEXT;
ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS source_type TEXT;
```

**Partial indexes (only index non-null values):**
- `idx_vault_embeddings_area` — WHERE area IS NOT NULL
- `idx_vault_embeddings_source_type` — WHERE source_type IS NOT NULL

**Vault watcher auto-derives from file paths:**

| Path pattern | area | source_type |
|---|---|---|
| `studies/programacao/...` | programacao | study |
| `studies/lideranca/...` | lideranca | study |
| `Livros/ia/.../summary*.md` | ia | book_summary |
| `news/*.md` | — | news |
| `daily-logs/*.md` | — | daily_log |
| `api-docs/*.md` | programacao | study |
| anything else | — | free_note |

**Valid areas:** ia, programacao, lideranca, comunicacao, financas

### Existing notes

Columns are nullable — existing notes without area/source_type continue working. Filters only apply when the parameter is provided; omitting them returns all results (same behavior as before).

### Files changed (6 files, +118/-17 lines)

| File | Change |
|------|--------|
| `infra/postgres/schema.sql` | Two new columns + partial indexes |
| `packages/shared/src/types.ts` | `area` and `source_type` in NoteRow + SearchOptions |
| `packages/core/src/lib/db-client.ts` | `buildMetadataFilters()` helper + filters in search/list queries + upsertNote with area/source_type |
| `packages/core/src/mcp/tools.ts` | `area` and `source_type` params in search_semantic, search_text, list_recent |
| `packages/core/src/watcher/vault-watcher.ts` | `deriveArea()` and `deriveSourceType()` methods |
| `packages/core/tests/lib/db-client.test.ts` | Updated ensureSchema assertions |

### Test results

- All **688 tests pass** (shared: 35, core: 131, installer: 488, team: 34)
- TypeScript build passes across all 4 workspaces