### PR TITLE
fix(core): probe information_schema before ALTER TABLE in ensureSchema (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.5] — 2026-04-13
+
+### Fixed
+- **Watcher crash loop on non-owner DB users (#169).** `DbClient.ensureSchema()` issued `ALTER TABLE vault_embeddings ADD COLUMN IF NOT EXISTS created_by ...` on every startup, but Postgres runs the ownership check *before* evaluating `IF NOT EXISTS` — so any connection role with full DML grants (`arwdDxt`) but without table ownership crashed with `error 42501 (insufficient_privilege)`, even on the no-op path. The watcher exited, systemd restarted it every 10s, and the service sat in a silent crash loop (observed: ~10 days, 57k restarts) while `write_note` kept writing files to disk — the filesystem and DB silently diverged. `ensureSchema()` now probes `information_schema.columns` first and only issues `ALTER TABLE` when the column is actually missing. The common path (schema already correct) no longer needs table ownership.
+
 ## [0.8.4] — 2026-04-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -32,18 +32,33 @@ export class DbClient {
   /**
    * Ensure the database schema is up-to-date.
    *
-   * Runs idempotent ALTER TABLE statements so that columns introduced after
-   * the initial CREATE TABLE (e.g. `created_by` from team-mode) exist on
-   * databases that were provisioned before those columns were added.
-   *
-   * Safe to call on every startup — ADD COLUMN IF NOT EXISTS is a no-op
-   * when the column already exists.
+   * Probes `information_schema.columns` first and only issues `ALTER TABLE`
+   * when a missing column is detected. Postgres runs the ownership check
+   * before evaluating `IF NOT EXISTS`, so a plain `ALTER TABLE ADD COLUMN
+   * IF NOT EXISTS` fails with 42501 for any connection role that holds
+   * full DML grants but is not the table owner — even on the no-op path.
+   * See issue #169.
    */
   async ensureSchema(): Promise<void> {
-    await this.pool.query(`
-      ALTER TABLE vault_embeddings
-        ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''
+    const { rows } = await this.pool.query(`
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'vault_embeddings'
+        AND column_name = 'created_by'
+      LIMIT 1
     `);
+    if (rows.length === 0) {
+      // IF NOT EXISTS kept as a guard against a race between concurrent
+      // owner-privileged startups probing and ALTERing at the same time.
+      // Non-owner callers never reach this branch in normal operation
+      // (the probe sees the column on an already-migrated DB), so the
+      // 42501 path from #169 is not reintroduced.
+      await this.pool.query(`
+        ALTER TABLE vault_embeddings
+          ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT ''
+      `);
+    }
   }
 
   private buildSearchOptions(

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -14,23 +14,50 @@ describe('DbClient', () => {
   });
 
   describe('ensureSchema', () => {
-    it('should run ALTER TABLE ADD COLUMN IF NOT EXISTS for created_by', async () => {
-      mockPool.query.mockResolvedValue({ rowCount: 0 });
+    it('probes information_schema and skips ALTER when created_by already exists', async () => {
+      // information_schema read returns a row -> column already present
+      mockPool.query.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
 
       await client.ensureSchema();
 
+      // Only the information_schema probe should run — no ALTER TABLE at all.
+      // This is the no-owner path (issue #169): non-owner users cannot ALTER
+      // even when the statement would be a no-op, so we must avoid issuing it.
       expect(mockPool.query).toHaveBeenCalledTimes(1);
-      const [sql] = mockPool.query.mock.calls[0];
-      expect(sql).toContain('ALTER TABLE vault_embeddings');
-      expect(sql).toContain('ADD COLUMN IF NOT EXISTS created_by');
-      expect(sql).toContain('TEXT');
-      expect(sql).toContain("DEFAULT ''");
+      const [probeSql] = mockPool.query.mock.calls[0];
+      expect(probeSql).toContain('information_schema.columns');
+      expect(probeSql).toContain("table_name = 'vault_embeddings'");
+      expect(probeSql).toContain("column_name = 'created_by'");
+      expect(probeSql).not.toContain('ALTER TABLE');
     });
 
-    it('should propagate pool.query rejection', async () => {
-      mockPool.query.mockRejectedValue(new Error('permission denied'));
+    it('issues ALTER TABLE ADD COLUMN when created_by is missing', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [] }) // probe -> missing
+        .mockResolvedValueOnce({ rowCount: 0 }); // ALTER
+
+      await client.ensureSchema();
+
+      expect(mockPool.query).toHaveBeenCalledTimes(2);
+      const [alterSql] = mockPool.query.mock.calls[1];
+      expect(alterSql).toContain('ALTER TABLE vault_embeddings');
+      expect(alterSql).toContain('ADD COLUMN IF NOT EXISTS created_by');
+      expect(alterSql).toContain('TEXT');
+      expect(alterSql).toContain("DEFAULT ''");
+    });
+
+    it('propagates pool.query rejection from the probe', async () => {
+      mockPool.query.mockRejectedValueOnce(new Error('permission denied'));
 
       await expect(client.ensureSchema()).rejects.toThrow('permission denied');
+    });
+
+    it('propagates ALTER TABLE rejection when probe returns empty', async () => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValueOnce(new Error('42501: must be owner of table'));
+
+      await expect(client.ensureSchema()).rejects.toThrow('42501');
     });
   });
 

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- `DbClient.ensureSchema()` now probes `information_schema.columns` before issuing `ALTER TABLE`, so the common path (schema already correct) no longer requires table ownership.
- Fixes a silent crash loop on deployments where the connection role holds full DML grants (`arwdDxt`) but does not own `vault_embeddings` — Postgres runs the ownership check **before** evaluating `IF NOT EXISTS`, so the previous code failed with `42501` on every startup even though the ALTER was a no-op.
- Observed impact (our own team deployment): ~10 days / 57k systemd restarts, during which `write_note` kept writing files to disk but nothing was indexed into `vault_embeddings`, silently diverging the filesystem from the DB. Required manual backfill via `scripts/index-vault.ts`.

## Approach

`ensureSchema()` now:

1. Probes `information_schema.columns` for the `created_by` column. Reads on `information_schema` don't require ownership.
2. Only issues `ALTER TABLE ... ADD COLUMN IF NOT EXISTS created_by ...` when the column is actually missing. `IF NOT EXISTS` is kept as a guard against a race between concurrent owner-privileged startups; non-owner callers never reach this branch on an already-migrated DB, so the original 42501 path is not reintroduced.

## Test plan

- [x] `npm run test --workspace=packages/core` — 133/133 passing
- [x] `npx tsc --noEmit --project packages/core/tsconfig.json` clean
- [x] New unit tests in `db-client.test.ts`:
  - probe returns row → skips ALTER entirely (the #169 crash scenario)
  - probe returns empty → issues ALTER
  - probe rejects → error propagates
  - ALTER rejects after probe empty → error propagates
- [ ] Post-merge: deploy to team VM running as non-owner role and verify watcher starts cleanly without ownership grants

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)