### PR TITLE
feat(infra): add VM headless Claude runner with systemd timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-09
+
+### Added
+- **VM headless Claude runner for scheduled MCP-aware tasks (#171).** Two systemd timers (`infra/systemd/lox-claude-{sync-calendar,gemini-notes}.{service,timer}`) trigger `claude -p "/sync-calendar"` on the VM at 06:00 and 19:00 daily — morning pass captures the day's new calendar events, evening pass captures Gemini meeting notes that arrive post-meeting with lag. Auth uses a long-lived OAuth token from the user's Claude Max plan via `claude setup-token` (no `ANTHROPIC_API_KEY`, no API billing). Permissions are constrained by an explicit allowlist in `~/.config/lox-claude/settings.json` — no `--dangerously-skip-permissions`. Logs flow through `journalctl`. Setup, customization, troubleshooting, and token renewal are documented in `infra/vm-claude/README.md`. Design rationale, alternatives considered, and security analysis: `docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md`.
+
 ## [0.8.5] — 2026-04-13
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,6 +38,7 @@ Build ecosystem and contributor base.
 - [ ] Documentation site (Docusaurus or similar)
 - [ ] Multi-LLM support — Claude, GPT-4, Llama3, Mistral via Ollama
 - [ ] Public GitHub Projects board
+- [ ] **VM headless runner** — systemd timers + Claude Code OAuth for scheduled MCP-aware skills (sync-calendar, etc.) without keeping a laptop online ([#171](https://github.com/isorensen/lox-brain/issues/171))
 
 ## Phase 3 — Managed Hosting (Optional SaaS Layer)
 

--- a/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
+++ b/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
@@ -1,0 +1,195 @@
+# VM Claude Runner — Headless scheduled MCP-aware tasks
+
+**Status:** Draft
+**Date:** 2026-05-09
+**Author:** Eduardo (isorensen) + Claude Opus 4.7
+**Issue:** TBD (será aberta após aprovação)
+
+## Contexto
+
+Hoje, tarefas como `/sync-calendar` (importar eventos do Google Calendar pro Obsidian Vault) e captura de notas Gemini de reuniões precisam ser disparadas manualmente, com o laptop ligado, conectado na VPN WireGuard, e via Claude Code interativo. Isso causa:
+
+- Esquecimento (sync não roda em dias que o laptop fica fechado)
+- Latência entre evento real e nota ingerida no vault
+- Acoplamento desnecessário ao desktop pessoal
+
+A VM `obsidian-vm` (GCE, Ubuntu 24.04) já hospeda o vault, o git sync, o pgvector, o watcher e o MCP server. Roda 24/7. Adicionar Claude Code rodando lá com OAuth seu (plano Max, sem `ANTHROPIC_API_KEY`) e systemd timers permite automação stateless e ordenada.
+
+## Goals
+
+- Rodar `/sync-calendar` diariamente às 06:00 e captura de Gemini notes às 19:00 sem intervenção
+- Reusar plano Claude Max via OAuth — zero gasto adicional de API
+- MCP `lox-brain` local (sem VPN), connectors da conta (Google Calendar, Gmail, Drive) disponíveis
+- Permissions configuradas como allowlist explícita — sem `--dangerously-skip-permissions`
+- Setup documentado, reproduzível em < 15 min em VM Ubuntu fresca
+
+## Non-Goals
+
+- Listener Telegram (tracked separadamente como Issue B; depende desta)
+- Suporte multi-VM / lox-teams Credifit (follow-up se houver demanda concreta)
+- Modos interativos / multi-turn (`--resume`, `--continue`)
+- Email/SMS alerts em falha (calendar reminder + `systemctl status` semanal basta pra MVP pessoal)
+- Egress firewall apertado (follow-up de hardening)
+- Rotação automática de OAuth token
+
+## Arquitetura
+
+```
+obsidian-vm (existente, user sorensen)
+│
+├── ~/.config/lox-claude/
+│   ├── env                  CLAUDE_CODE_OAUTH_TOKEN=... (mode 0600)
+│   └── settings.json        permissions allowlist
+│
+├── /etc/systemd/system/
+│   ├── lox-claude-sync-calendar.service     User=sorensen, Type=oneshot
+│   ├── lox-claude-sync-calendar.timer       OnCalendar=*-*-* 06:00:00
+│   ├── lox-claude-gemini-notes.service      User=sorensen, Type=oneshot
+│   └── lox-claude-gemini-notes.timer        OnCalendar=*-*-* 19:00:00
+│
+└── (services chamam diretamente: claude -p "/sync-calendar" --settings ~/.config/lox-claude/settings.json)
+```
+
+**Decisões de arquitetura:**
+
+- **Dois pares `.service+.timer` flat** em vez de template `@`. Mais explícitos pra N=2; copy-paste se um dia houver um terceiro job.
+- **Sem wrapper script.** `ExecStart=` chama `claude -p` diretamente; `ExecStartPre=` valida pré-condições inline.
+- **Sem `runner.sh` / `healthcheck.sh` / `install.sh`.** Setup é README + comandos diretos.
+- **Roda como `sorensen`** (mesmo user da VM), não como `lox-claude` dedicado. VM single-tenant pessoal não justifica isolamento via user.
+- **Logs via `journalctl`.** Sem Cloud Logging integration pra MVP pessoal.
+
+## Componentes & arquivos
+
+### `infra/systemd/lox-claude-sync-calendar.service`
+
+```ini
+[Unit]
+Description=Lox Claude Runner — sync Google Calendar to vault
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sorensen
+EnvironmentFile=/home/sorensen/.config/lox-claude/env
+ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
+ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
+ExecStart=/usr/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+TimeoutStartSec=600
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/lox-brain
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### `infra/systemd/lox-claude-sync-calendar.timer`
+
+```ini
+[Unit]
+Description=Daily sync of Google Calendar to Obsidian vault at 06:00
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+Unit=lox-claude-sync-calendar.service
+
+[Install]
+WantedBy=timers.target
+```
+
+`gemini-notes` é análogo, com `OnCalendar=*-*-* 19:00:00` e mesmo prompt `/sync-calendar`. Razão de ter duas execuções da mesma skill: a passada da manhã captura eventos novos do dia; a passada da noite recolhe Gemini notes que só chegam após as reuniões do dia terminarem (Gemini summaries são produzidos com lag pós-reunião). Nome `gemini-notes` reflete o propósito da execução, não comando diferente.
+
+### `infra/vm-claude/settings.json.example`
+
+Allowlist mínima inicial. Iterada conforme primeiros runs reportarem permissions necessárias:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__lox-brain__*",
+      "mcp__claude_ai_Google_Calendar__list_events",
+      "mcp__claude_ai_Google_Calendar__get_event",
+      "mcp__claude_ai_Google_Calendar__list_calendars",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Google_Drive__read_file_content",
+      "Read"
+    ]
+  }
+}
+```
+
+Princípio: começar tight, expandir quando run reportar `Permission denied: <tool>`. Não pré-autorizar especulativo.
+
+### `infra/vm-claude/README.md`
+
+Documenta:
+1. Pré-requisitos (Claude Code instalado, MCPs `lox-brain` configurados)
+2. Geração do token: `claude setup-token` (rodar como `sorensen` via SSH)
+3. Salvar token em `~/.config/lox-claude/env`
+4. Copiar `settings.json.example` → `~/.config/lox-claude/settings.json`
+5. `sudo cp infra/systemd/* /etc/systemd/system/`
+6. `sudo systemctl daemon-reload && sudo systemctl enable --now lox-claude-sync-calendar.timer lox-claude-gemini-notes.timer`
+7. Verificação: `systemctl list-timers | grep lox-claude`
+8. Renovação anual do token + lembrete no Google Calendar
+9. Troubleshooting: `journalctl -u lox-claude-sync-calendar.service -n 50`
+
+### `ROADMAP.md`
+
+Adiciona em Phase 2 (Community):
+- [ ] **VM Headless Runner** — systemd timers + Claude Code OAuth pra automação de skills agendadas (sync-calendar, etc.) sem laptop ligado
+
+## Modelo de auth
+
+- `claude setup-token` (manual, uma vez via SSH) gera token OAuth de 1 ano scoped à conta Max
+- Token vai pra `/home/sorensen/.config/lox-claude/env` mode 0600
+- systemd injeta via `EnvironmentFile=`
+- Em ~11 meses, lembrete no Google Calendar dispara renovação manual
+- Detecção de expiração: `journalctl` mostrará 401; usuário roda `claude setup-token` de novo
+
+**Por que `setup-token` e não `claude login`:** issue oficial #28827 — refresh de OAuth em modo non-interactive falha silenciosamente. `setup-token` gera long-lived token explicitamente projetado pra automação.
+
+## Permissions & Security
+
+- **Allowlist explícita** em `settings.json` (acima). Sem deny, sem `--dangerously-skip-permissions`.
+- **Hardening systemd mínimo**: `User=sorensen`, `NoNewPrivileges=yes`, `ProtectSystem=strict`, `ReadWritePaths=` limitado a vault + `~/.claude` + `~/lox-brain`.
+- **Token storage**: `~/.config/lox-claude/env` mode 0600 owner sorensen. Sem GCP Secret Manager pra MVP — VPN-only VM single-tenant não justifica.
+- **Trust boundary**: a allowlist é a defesa primária contra prompt injection (ex: evento de calendar com payload malicioso). Nada na allowlist atual permite `Bash`, `Write`, `WebFetch`, ou exfiltração — só leitura via MCPs específicos.
+
+## Observabilidade
+
+- `journalctl -u lox-claude-sync-calendar.service` — logs completos
+- `systemctl list-timers` — quando próxima execução
+- `systemctl --failed` — checagem manual semanal
+- Sintoma de falha de longo prazo: novos eventos não aparecem no vault → user nota durante uso normal
+
+Sem alerting ativo. É escolha consciente: 2 jobs/dia, vault é checado humanamente em uso normal, blast radius de falha = "evento ausente até user notar". Não justifica setup de SMTP/Cloud Monitoring na VM.
+
+## Acceptance Criteria
+
+- [ ] `sudo systemctl start lox-claude-sync-calendar.service` executa, termina exit 0
+- [ ] `journalctl -u lox-claude-sync-calendar.service` mostra log do `claude -p` com tool calls esperados (list_events, write_note)
+- [ ] `systemctl list-timers` mostra ambos os timers ativos com next-run em 06:00 e 19:00
+- [ ] Sem `CLAUDE_CODE_OAUTH_TOKEN`: `ExecStartPre` falha, `claude -p` não é invocado
+- [ ] Após 24h ativo: vault tem nota(s) de evento(s) do dia (validação manual)
+- [ ] README permite alguém com VM Ubuntu fresca completar setup em < 15 min
+
+## Out of Scope (follow-ups potenciais)
+
+| Item | Quando vale revisitar |
+|---|---|
+| Listener Telegram (Issue B) | Depois que esta issue mergiar; começa com spike empírico |
+| Suporte VM Credifit / lox-teams | Se houver pedido concreto de outro deployment |
+| Cloud Logging + alertas | Se confiabilidade virar problema (MVP rodando 30+ dias com falhas silenciosas) |
+| Rotação automática de token | Se issue #28827 for resolvida upstream |
+| Egress firewall granular | Audit de segurança ou se VM virar multi-tenant |
+
+## Riscos abertos
+
+1. **Plugins/connectors em headless**: documentação confirma OAuth funciona, mas comportamento exato dos `mcp__claude_ai_*` em `claude -p` headless não foi testado empiricamente. Mitigação: primeiro run manual antes de habilitar timer; ajustar allowlist conforme erros.
+2. **Rate limit do plano Max**: 50 RPM típico. 2 runs/dia, ~50 calls cada = 100 calls/dia. Folgadíssimo. Sem risco real.
+3. **ToS Anthropic**: uso pessoal autônomo via OAuth Max está dentro do "uso ordinário e individual". Não escalar pra alta frequência sem migrar pra API key.
+4. **Token expirando silenciosamente**: lembrete manual no calendar é mitigação suficiente; piora de UX só se user esquecer 30+ dias.

--- a/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
+++ b/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
@@ -35,16 +35,16 @@ A VM `obsidian-vm` (GCE, Ubuntu 24.04) já hospeda o vault, o git sync, o pgvect
 ## Arquitetura
 
 ```
-obsidian-vm (existente, user sorensen)
+obsidian-vm (existente, user existente da VM — referenciado como __LOX_VM_USER__)
 │
 ├── ~/.config/lox-claude/
 │   ├── env                  CLAUDE_CODE_OAUTH_TOKEN=... (mode 0600)
 │   └── settings.json        permissions allowlist
 │
 ├── /etc/systemd/system/
-│   ├── lox-claude-sync-calendar.service     User=sorensen, Type=oneshot
+│   ├── lox-claude-sync-calendar.service     User=__LOX_VM_USER__, Type=oneshot
 │   ├── lox-claude-sync-calendar.timer       OnCalendar=*-*-* 06:00:00
-│   ├── lox-claude-gemini-notes.service      User=sorensen, Type=oneshot
+│   ├── lox-claude-gemini-notes.service      User=__LOX_VM_USER__, Type=oneshot
 │   └── lox-claude-gemini-notes.timer        OnCalendar=*-*-* 19:00:00
 │
 └── (services chamam diretamente: claude -p "/sync-calendar" --settings ~/.config/lox-claude/settings.json)
@@ -55,7 +55,7 @@ obsidian-vm (existente, user sorensen)
 - **Dois pares `.service+.timer` flat** em vez de template `@`. Mais explícitos pra N=2; copy-paste se um dia houver um terceiro job.
 - **Sem wrapper script.** `ExecStart=` chama `claude -p` diretamente; `ExecStartPre=` valida pré-condições inline.
 - **Sem `runner.sh` / `healthcheck.sh` / `install.sh`.** Setup é README + comandos diretos.
-- **Roda como `sorensen`** (mesmo user da VM), não como `lox-claude` dedicado. VM single-tenant pessoal não justifica isolamento via user.
+- **Roda como o user existente da VM** (mesmo que roda obsidian + lox-brain + git sync hoje), não como user dedicado `lox-claude`. VM single-tenant pessoal não justifica isolamento via user. Nos unit files referenciado como placeholder `__LOX_VM_USER__`, substituído por sed no setup.
 - **Logs via `journalctl`.** Sem Cloud Logging integration pra MVP pessoal.
 
 ## Componentes & arquivos
@@ -70,16 +70,16 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=sorensen
-EnvironmentFile=/home/sorensen/.config/lox-claude/env
+User=__LOX_VM_USER__
+EnvironmentFile=%h/.config/lox-claude/env
 ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
 ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
-ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
-ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+ExecStartPre=/usr/bin/test -d %h/obsidian
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings %h/.config/lox-claude/settings.json
 TimeoutStartSec=600
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
+ReadWritePaths=%h/obsidian %h/.claude %h/.config/lox-claude %h/lox-brain
 
 [Install]
 WantedBy=multi-user.target
@@ -133,7 +133,7 @@ Princípio: começar tight, expandir quando run reportar `Permission denied: <to
 
 Documenta:
 1. Pré-requisitos (Claude Code instalado, MCPs `lox-brain` configurados)
-2. Geração do token: `claude setup-token` (rodar como `sorensen` via SSH)
+2. Geração do token: `claude setup-token` (rodar como o user da VM via SSH)
 3. Salvar token em `~/.config/lox-claude/env`
 4. Copiar `settings.json.example` → `~/.config/lox-claude/settings.json`
 5. `sudo cp infra/systemd/* /etc/systemd/system/`
@@ -150,7 +150,7 @@ Adiciona em Phase 2 (Community):
 ## Modelo de auth
 
 - `claude setup-token` (manual, uma vez via SSH) gera token OAuth de 1 ano scoped à conta Max
-- Token vai pra `/home/sorensen/.config/lox-claude/env` mode 0600
+- Token vai pra `~/.config/lox-claude/env` (mode 0600) do user da VM
 - systemd injeta via `EnvironmentFile=`
 - Em ~11 meses, lembrete no Google Calendar dispara renovação manual
 - Detecção de expiração: `journalctl` mostrará 401; usuário roda `claude setup-token` de novo
@@ -160,8 +160,8 @@ Adiciona em Phase 2 (Community):
 ## Permissions & Security
 
 - **Allowlist explícita** em `settings.json` (acima). Sem deny, sem `--dangerously-skip-permissions`.
-- **Hardening systemd mínimo**: `User=sorensen`, `NoNewPrivileges=yes`, `ProtectSystem=strict`, `ReadWritePaths=` limitado a vault + `~/.claude` + `~/lox-brain`.
-- **Token storage**: `~/.config/lox-claude/env` mode 0600 owner sorensen. Sem GCP Secret Manager pra MVP — VPN-only VM single-tenant não justifica.
+- **Hardening systemd mínimo**: `User=__LOX_VM_USER__`, `NoNewPrivileges=yes`, `ProtectSystem=strict`, `ReadWritePaths=` limitado a `%h/obsidian` + `%h/.claude` + `%h/.config/lox-claude` + `%h/lox-brain`.
+- **Token storage**: `~/.config/lox-claude/env` mode 0600 owner = user da VM. Sem GCP Secret Manager pra MVP — VPN-only VM single-tenant não justifica.
 - **Trust boundary**: a allowlist é a defesa primária contra prompt injection (ex: evento de calendar com payload malicioso). Nada na allowlist atual permite `Bash`, `Write`, `WebFetch`, ou exfiltração — só leitura via MCPs específicos.
 
 ## Observabilidade

--- a/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
+++ b/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
@@ -72,13 +72,14 @@ Wants=network-online.target
 Type=oneshot
 User=sorensen
 EnvironmentFile=/home/sorensen/.config/lox-claude/env
+ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
 ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
 ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
-ExecStart=/usr/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
 TimeoutStartSec=600
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/lox-brain
+ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
 
 [Install]
 WantedBy=multi-user.target
@@ -91,7 +92,7 @@ WantedBy=multi-user.target
 Description=Daily sync of Google Calendar to Obsidian vault at 06:00
 
 [Timer]
-OnCalendar=*-*-* 06:00:00
+OnCalendar=*-*-* 06:00:00 America/Sao_Paulo
 Persistent=true
 Unit=lox-claude-sync-calendar.service
 
@@ -109,7 +110,11 @@ Allowlist mínima inicial. Iterada conforme primeiros runs reportarem permission
 {
   "permissions": {
     "allow": [
-      "mcp__lox-brain__*",
+      "mcp__lox-brain__write_note",
+      "mcp__lox-brain__read_note",
+      "mcp__lox-brain__search_text",
+      "mcp__lox-brain__search_semantic",
+      "mcp__lox-brain__list_recent",
       "mcp__claude_ai_Google_Calendar__list_events",
       "mcp__claude_ai_Google_Calendar__get_event",
       "mcp__claude_ai_Google_Calendar__list_calendars",

--- a/infra/systemd/lox-claude-gemini-notes.service
+++ b/infra/systemd/lox-claude-gemini-notes.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Lox Claude Runner — capture Gemini meeting notes (evening)
+Documentation=https://github.com/isorensen/lox-brain/blob/main/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sorensen
+EnvironmentFile=/home/sorensen/.config/lox-claude/env
+ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
+ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
+ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
+# Intentionally invokes the same /sync-calendar skill as the morning job.
+# Reason: Gemini meeting summaries arrive after meetings end (with lag).
+# Morning run captures new events; evening run captures the post-meeting summaries.
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+TimeoutStartSec=600
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/lox-claude-gemini-notes.service
+++ b/infra/systemd/lox-claude-gemini-notes.service
@@ -6,19 +6,19 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=sorensen
-EnvironmentFile=/home/sorensen/.config/lox-claude/env
+User=__LOX_VM_USER__
+EnvironmentFile=%h/.config/lox-claude/env
 ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
 ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
-ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
+ExecStartPre=/usr/bin/test -d %h/obsidian
 # Intentionally invokes the same /sync-calendar skill as the morning job.
 # Reason: Gemini meeting summaries arrive after meetings end (with lag).
 # Morning run captures new events; evening run captures the post-meeting summaries.
-ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings %h/.config/lox-claude/settings.json
 TimeoutStartSec=600
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
+ReadWritePaths=%h/obsidian %h/.claude %h/.config/lox-claude %h/lox-brain
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/systemd/lox-claude-gemini-notes.timer
+++ b/infra/systemd/lox-claude-gemini-notes.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily evening sync to capture Gemini meeting notes at 19:00
+
+[Timer]
+OnCalendar=*-*-* 19:00:00 America/Sao_Paulo
+Persistent=true
+Unit=lox-claude-gemini-notes.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/systemd/lox-claude-sync-calendar.service
+++ b/infra/systemd/lox-claude-sync-calendar.service
@@ -6,16 +6,16 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=sorensen
-EnvironmentFile=/home/sorensen/.config/lox-claude/env
+User=__LOX_VM_USER__
+EnvironmentFile=%h/.config/lox-claude/env
 ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
 ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
-ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
-ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+ExecStartPre=/usr/bin/test -d %h/obsidian
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings %h/.config/lox-claude/settings.json
 TimeoutStartSec=600
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
+ReadWritePaths=%h/obsidian %h/.claude %h/.config/lox-claude %h/lox-brain
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/systemd/lox-claude-sync-calendar.service
+++ b/infra/systemd/lox-claude-sync-calendar.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Lox Claude Runner — sync Google Calendar to vault (morning)
+Documentation=https://github.com/isorensen/lox-brain/blob/main/docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sorensen
+EnvironmentFile=/home/sorensen/.config/lox-claude/env
+ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
+ExecStartPre=/usr/bin/test -n "${CLAUDE_CODE_OAUTH_TOKEN}"
+ExecStartPre=/usr/bin/test -d /home/sorensen/obsidian
+ExecStart=/usr/local/bin/claude -p "/sync-calendar" --settings /home/sorensen/.config/lox-claude/settings.json
+TimeoutStartSec=600
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/home/sorensen/obsidian /home/sorensen/.claude /home/sorensen/.config/lox-claude /home/sorensen/lox-brain
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/lox-claude-sync-calendar.timer
+++ b/infra/systemd/lox-claude-sync-calendar.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily morning sync of Google Calendar to Obsidian vault at 06:00
+
+[Timer]
+OnCalendar=*-*-* 06:00:00 America/Sao_Paulo
+Persistent=true
+Unit=lox-claude-sync-calendar.service
+
+[Install]
+WantedBy=timers.target

--- a/infra/vm-claude/README.md
+++ b/infra/vm-claude/README.md
@@ -22,14 +22,16 @@ Auth uses a long-lived OAuth token from your Claude Max plan. No `ANTHROPIC_API_
   ```
   or edit `ExecStart`/`ExecStartPre` paths in the `.service` files to match your install.
 - MCP server `lox-brain` configured locally (already running if this is the obsidian-vm)
-- Obsidian vault at `/home/sorensen/obsidian`
-- Lox brain repo at `/home/sorensen/lox-brain`
+- Obsidian vault at `$HOME/obsidian`
+- Lox brain repo at `$HOME/lox-brain`
+
+> The unit files use the systemd `%h` specifier, which resolves to the home directory of the user set in `User=` — so paths follow whoever you substitute in. See **Setup → step 4** below.
 
 ## Setup
 
 ### 1. Generate OAuth long-lived token
 
-SSH into the VM as the user that will run the timers (default: `sorensen`):
+SSH into the VM as the user that will run the timers (the user that already owns the Obsidian vault and the lox-brain repo on the VM):
 
 ```bash
 claude setup-token
@@ -57,12 +59,18 @@ Review the allowlist; tighten or expand as needed for your usage. The runtime pr
 
 ### 4. Install the systemd units
 
+The unit files ship with a `__LOX_VM_USER__` placeholder for the `User=` directive. Substitute it with your VM user before copying:
+
 ```bash
-sudo cp infra/systemd/lox-claude-*.service /etc/systemd/system/
+# Substitute the placeholder with the current user, then copy
+sed "s/__LOX_VM_USER__/$USER/g" infra/systemd/lox-claude-sync-calendar.service | sudo tee /etc/systemd/system/lox-claude-sync-calendar.service > /dev/null
+sed "s/__LOX_VM_USER__/$USER/g" infra/systemd/lox-claude-gemini-notes.service  | sudo tee /etc/systemd/system/lox-claude-gemini-notes.service  > /dev/null
 sudo cp infra/systemd/lox-claude-*.timer /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now lox-claude-sync-calendar.timer lox-claude-gemini-notes.timer
 ```
+
+All other paths inside the unit files use systemd's `%h` specifier (the user's home), so they follow whoever you substitute into `User=`.
 
 ### 5. Verify
 
@@ -75,12 +83,9 @@ journalctl -u lox-claude-sync-calendar.service -n 50
 # expect: claude -p output, calendar events written to vault
 ```
 
-## Customization (different user or paths)
+## Customization (different paths)
 
-The unit files hardcode `User=sorensen` and `/home/sorensen/...` paths. To run on a VM with different user or paths:
-
-1. Edit `infra/systemd/lox-claude-*.service` — replace `sorensen` and update `EnvironmentFile`, `ExecStartPre`, `ExecStart`, `ReadWritePaths`
-2. Re-run setup steps above
+If your Obsidian vault or lox-brain repo lives somewhere other than `$HOME/obsidian` and `$HOME/lox-brain`, edit `ExecStartPre`, `ExecStart`, and `ReadWritePaths` in the `.service` files to point at the actual locations. The `%h` specifier already handles the home prefix; you only need to change the trailing path components.
 
 Multi-VM support via the installer is a follow-up; see issue #171.
 

--- a/infra/vm-claude/README.md
+++ b/infra/vm-claude/README.md
@@ -1,0 +1,137 @@
+# VM Claude Runner
+
+Headless Claude Code on the lox-brain VM, running scheduled MCP-aware tasks via systemd timers.
+
+## What it does
+
+Two systemd timers trigger `claude -p "/sync-calendar"` on the VM:
+
+- **06:00 BRT daily** — captures the day's new calendar events into the Obsidian vault
+- **19:00 BRT daily** — second pass to capture Gemini meeting notes (which arrive after meetings end with some lag)
+
+Timers declare `America/Sao_Paulo` explicitly via `OnCalendar=`, so they fire at local Brazil time regardless of the VM's system timezone (most cloud VMs default to UTC).
+
+Auth uses a long-lived OAuth token from your Claude Max plan. No `ANTHROPIC_API_KEY`, no per-call billing.
+
+## Prerequisites
+
+- Ubuntu 22.04+ on the VM (systemd ≥ 247 for `OnCalendar` timezone support)
+- Claude Code CLI installed at `/usr/local/bin/claude`. If yours is elsewhere (e.g., nvm or `~/.local/bin`), either symlink it:
+  ```bash
+  sudo ln -sf "$(which claude)" /usr/local/bin/claude
+  ```
+  or edit `ExecStart`/`ExecStartPre` paths in the `.service` files to match your install.
+- MCP server `lox-brain` configured locally (already running if this is the obsidian-vm)
+- Obsidian vault at `/home/sorensen/obsidian`
+- Lox brain repo at `/home/sorensen/lox-brain`
+
+## Setup
+
+### 1. Generate OAuth long-lived token
+
+SSH into the VM as the user that will run the timers (default: `sorensen`):
+
+```bash
+claude setup-token
+```
+
+This prints a token valid for ~1 year. Copy it. Why `setup-token` instead of `claude login`: refresh of OAuth tokens fails silently in non-interactive mode (issue [anthropics/claude-code#28827](https://github.com/anthropics/claude-code/issues/28827)). `setup-token` produces a long-lived token explicitly designed for automation.
+
+### 2. Save the token
+
+```bash
+mkdir -p ~/.config/lox-claude
+printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' '<paste-token-here>' > ~/.config/lox-claude/env
+chmod 600 ~/.config/lox-claude/env
+```
+
+### 3. Copy the settings file
+
+From the lox-brain repo on the VM:
+
+```bash
+cp infra/vm-claude/settings.json.example ~/.config/lox-claude/settings.json
+```
+
+Review the allowlist; tighten or expand as needed for your usage. The runtime principle is start tight, expand on `Permission denied` errors — never pre-authorize speculative tools.
+
+### 4. Install the systemd units
+
+```bash
+sudo cp infra/systemd/lox-claude-*.service /etc/systemd/system/
+sudo cp infra/systemd/lox-claude-*.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now lox-claude-sync-calendar.timer lox-claude-gemini-notes.timer
+```
+
+### 5. Verify
+
+```bash
+systemctl list-timers | grep lox-claude
+# expect: two timers, next-run at 06:00 and 19:00
+
+sudo systemctl start lox-claude-sync-calendar.service
+journalctl -u lox-claude-sync-calendar.service -n 50
+# expect: claude -p output, calendar events written to vault
+```
+
+## Customization (different user or paths)
+
+The unit files hardcode `User=sorensen` and `/home/sorensen/...` paths. To run on a VM with different user or paths:
+
+1. Edit `infra/systemd/lox-claude-*.service` — replace `sorensen` and update `EnvironmentFile`, `ExecStartPre`, `ExecStart`, `ReadWritePaths`
+2. Re-run setup steps above
+
+Multi-VM support via the installer is a follow-up; see issue #171.
+
+## Renewing the OAuth token
+
+Tokens from `claude setup-token` last about 1 year. When yours nears expiration:
+
+1. Set a calendar reminder ~30 days before expiration when you first generate it
+2. SSH to the VM, run `claude setup-token` again
+3. Replace the value in `~/.config/lox-claude/env`
+4. No restart needed — next timer fire will pick up the new token
+
+If a sync run fails with `401 Unauthorized` in the journal, the token has expired:
+
+```bash
+journalctl -u lox-claude-sync-calendar.service | grep -i 401
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `ExecStartPre fails: exit 1` | Missing env file or `CLAUDE_CODE_OAUTH_TOKEN` unset | Recreate `~/.config/lox-claude/env` (step 2) |
+| `claude -p` exits 1 immediately | Token expired or invalid | Re-run `claude setup-token` |
+| `Permission denied: <tool>` | Allowlist too tight in `settings.json` | Add the tool to the `allow` array |
+| Timer never fires | Not enabled | `sudo systemctl enable --now <timer>` |
+| Many runs queued at boot | `Persistent=true` is replaying missed runs | Expected on first start; clears after first run |
+| MCP `lox-brain` not reachable | Service down on VM | `systemctl status lox-mcp.service` |
+| Vault has no new notes after 24h | Skill ran but vault not git-pushed | Check `lox-watcher.service` and git sync |
+
+## Logs and monitoring
+
+```bash
+# Recent logs from a specific service
+journalctl -u lox-claude-sync-calendar.service -n 100
+
+# Live tail
+journalctl -u lox-claude-sync-calendar.service -f
+
+# All lox-claude logs
+journalctl -u 'lox-claude-*' --since today
+
+# Check timer schedule
+systemctl list-timers --all | grep lox-claude
+
+# Check for failed services
+systemctl --failed
+```
+
+For MVP this is enough. If failures become silent or frequent, see follow-up: Cloud Logging + log-based alerting (out of scope for this PR).
+
+## Design spec
+
+Full design rationale, alternatives considered, and security analysis: [`docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md`](../../docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md)

--- a/infra/vm-claude/settings.json.example
+++ b/infra/vm-claude/settings.json.example
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__lox-brain__write_note",
+      "mcp__lox-brain__read_note",
+      "mcp__lox-brain__search_text",
+      "mcp__lox-brain__search_semantic",
+      "mcp__lox-brain__list_recent",
+      "mcp__claude_ai_Google_Calendar__list_events",
+      "mcp__claude_ai_Google_Calendar__get_event",
+      "mcp__claude_ai_Google_Calendar__list_calendars",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Google_Drive__read_file_content",
+      "Read"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2118,12 +2118,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2142,9 +2142,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2334,9 +2334,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2412,9 +2412,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -3897,7 +3897,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.7.2",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@lox-brain/shared": "*",
@@ -3917,7 +3917,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.7.2",
+      "version": "0.9.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -4082,7 +4082,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.7.2",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Adds two systemd timer/service pairs in `infra/systemd/` that run `claude -p "/sync-calendar"` headless on the VM at **06:00** and **19:00 BRT** (`America/Sao_Paulo` declared explicitly via `OnCalendar=`). Morning pass captures the day's new calendar events; evening pass captures Gemini meeting notes that arrive post-meeting with lag.
- Auth uses a long-lived OAuth token from the user's Claude Max plan via `claude setup-token` (no `ANTHROPIC_API_KEY`, no per-call API billing). Token lives in `~/.config/lox-claude/env` mode 0600, injected via `EnvironmentFile=`.
- Permissions are constrained by an explicit allowlist in `~/.config/lox-claude/settings.json` — no `--dangerously-skip-permissions`. The example file lists only the MCP read/write tools `/sync-calendar` actually needs.
- systemd hardening: `User=sorensen`, `Type=oneshot`, `NoNewPrivileges=yes`, `ProtectSystem=strict`, narrow `ReadWritePaths`, plus `ExecStartPre=` checks for the claude binary, the OAuth token, and the vault directory.
- Documentation: setup, customization (different user/path), token renewal, and troubleshooting in `infra/vm-claude/README.md`. Full design rationale, alternatives considered, and security analysis in `docs/superpowers/specs/2026-05-09-vm-claude-runner-design.md`.
- Bump to `0.9.0` (minor; new feature). CHANGELOG entry, ROADMAP bullet under Phase 2.

**Out of scope (explicitly):** Telegram listener (planned as a follow-up issue, depends on this; needs an empirical spike on the official `plugin_telegram_telegram` runtime in headless `claude -p`), multi-VM support, Cloud Logging + alerting, automatic token rotation. See spec for the rationale.

## Test plan

- [x] `npx tsc --noEmit` clean across `shared`, `core`, `installer`
- [x] `npm run test --workspaces --if-present` — 488 + 34 tests pass
- [x] `systemd-analyze calendar "*-*-* 06:00:00 America/Sao_Paulo"` returns `Next elapse: 06:00:00 -03 / 09:00 UTC`
- [x] `systemd-analyze verify` on the unit files (only complains about absent `/usr/local/bin/claude` on dev laptop — expected; binary lives on the VM)
- [x] Code review by `code-reviewer` (sonnet): 2 blocking + 2 important + 2 nits all addressed (timezone, gemini-notes intent comment, `~/.config/lox-claude` in `ReadWritePaths`, claude binary `ExecStartPre`, README BRT clarity, settings.json explicit list)
- [ ] Manual VM verification (after merge): `sudo systemctl start lox-claude-sync-calendar.service` → exit 0 → `journalctl` shows expected tool calls
- [ ] Manual VM verification: `systemctl list-timers | grep lox-claude` shows both timers with next-run at 06:00 and 19:00 local
- [ ] Manual VM verification: vault has new event note(s) within 24h of enabling the timers

🤖 Generated with [Claude Code](https://claude.com/claude-code)