### PR TITLE
feat(infra): add Telegram channel listener service for VM Claude runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-12
+
+### Added
+- **Telegram channel listener for the VM Claude runner (#177).** A second, optional VM service — `infra/systemd/lox-claude-telegram.service` — keeps a long-running `claude --channels plugin:telegram@claude-plugins-official` session listening on Telegram. DMs from the operator's phone arrive as user messages in the session; Claude responds with full vault + connector access (`mcp__lox-brain__*`, Google Calendar, Gmail, Drive). Sibling to the cron `/sync-calendar` runner (`Type=oneshot`): this one is `Type=simple` with `Restart=on-failure` so it stays up across MCP crashes. Auth and skill setup are shared with the cron runner; the only additional prerequisites are Bun (for the plugin's `server.ts`) and a one-time interactive pairing flow (BotFather token → `/telegram:configure` → DM-driven 6-character pairing code → `/telegram:access policy allowlist` lockdown). Permissions are tighter than the cron runner: read-only across MCPs by default plus `mcp__lox-brain__write_note` for note capture, with `Bash`/`Write`/`Edit`/`WebFetch`/`WebSearch` explicitly denied — chat-livre blast radius is larger than a fixed slash command, so the posture starts tight and any expansion goes through phone-side permission relay. Setup, security model, and troubleshooting documented in `infra/vm-claude/README.md`; settings template at `infra/vm-claude/telegram-settings.json.example`.
+
 ## [0.9.2] — 2026-05-12
 
 ### Changed

--- a/infra/systemd/lox-claude-telegram.service
+++ b/infra/systemd/lox-claude-telegram.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=Lox Claude Telegram channel listener — interactive chat from anywhere
+Documentation=https://github.com/isorensen/lox-brain/blob/main/infra/vm-claude/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Long-running (vs. oneshot used by the cron sync-calendar units).
+# Restart=on-failure recovers from MCP crashes; the plugin reconnects to Telegram on its own.
+Type=simple
+User=__LOX_VM_USER__
+# Auth comes from ~/.claude/.credentials.json populated by `claude login` (see README).
+# We do NOT use CLAUDE_CODE_OAUTH_TOKEN — empirically the long-lived token from
+# `claude setup-token` is rejected as "Invalid bearer token" in this context
+# (see https://github.com/anthropics/claude-code/issues/50743).
+ExecStartPre=/usr/bin/test -x /usr/local/bin/claude
+ExecStartPre=/usr/bin/test -f /home/__LOX_VM_USER__/.claude/.credentials.json
+# The telegram plugin keeps its bot token in .env and its allowlist/policy in access.json.
+# Refusing to start when either is missing avoids the "service runs, drops messages silently" trap.
+ExecStartPre=/usr/bin/test -f /home/__LOX_VM_USER__/.claude/channels/telegram/.env
+ExecStartPre=/usr/bin/test -f /home/__LOX_VM_USER__/.claude/channels/telegram/access.json
+# If `bun` is installed under the user's home (default for the official installer),
+# systemd does NOT inherit the shell's PATH — uncomment and adjust the next line so the
+# plugin's `server.ts` (which `claude --channels` spawns) can resolve `bun`.
+# Environment="PATH=/home/__LOX_VM_USER__/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/local/bin/claude --channels plugin:telegram@claude-plugins-official --settings /home/__LOX_VM_USER__/.config/lox-claude/telegram-settings.json
+Restart=on-failure
+RestartSec=15
+# Channel session start includes Bun init + Telegram handshake + MCP spawn.
+# 30s was empirically tight; 90s leaves headroom on slow/cold VMs without masking real hangs.
+TimeoutStartSec=90
+NoNewPrivileges=yes
+ProtectSystem=strict
+# `.claude` is listed once and covers the recursive subtree, including
+# `.claude/channels/telegram/` where the plugin writes session state (systemd >= 232).
+# Do not narrow this to a non-recursive path without also adding `.claude/channels/telegram/`.
+ReadWritePaths=/home/__LOX_VM_USER__/obsidian /home/__LOX_VM_USER__/.claude /home/__LOX_VM_USER__/.config/lox-claude /home/__LOX_VM_USER__/lox-brain
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/vm-claude/README.md
+++ b/infra/vm-claude/README.md
@@ -1,8 +1,13 @@
-# VM Claude Runner
+# VM Claude
 
-Headless Claude Code on the lox-brain VM, running scheduled MCP-aware tasks via systemd timers.
+Headless Claude Code on the lox-brain VM in two complementary modes:
 
-## What it does
+1. **Cron runner (default)** — scheduled MCP-aware tasks via systemd timers. Captures calendar events and Gemini meeting notes on a fixed schedule.
+2. **Telegram channel listener (optional)** — a long-running session listening on Telegram so you can chat with Claude from your phone with full vault + connector access. See [Telegram listener](#telegram-listener-long-running) below.
+
+Both modes share the same auth (`~/.claude/.credentials.json` from `claude login`), the same MCP setup, and the same skills installed under `~/.claude/skills/` on the VM.
+
+## What the cron runner does
 
 Two systemd timers trigger `claude -p "/sync-calendar"` on the VM:
 
@@ -164,6 +169,149 @@ systemctl --failed
 ```
 
 For MVP this is enough. If failures become silent or frequent, see follow-up: Cloud Logging + log-based alerting (out of scope for this PR).
+
+## Telegram listener (long-running)
+
+A second, optional VM service: `lox-claude-telegram.service` keeps a long-running `claude --channels` session listening on Telegram. Send a DM from your phone, Claude responds with full vault + connector access.
+
+Unlike the cron runner (`Type=oneshot`), this service is `Type=simple` with `Restart=on-failure` so it stays up and recovers from the occasional MCP crash.
+
+### Architecture
+
+```
+claude --channels plugin:telegram@claude-plugins-official
+```
+
+The session loads the `telegram` plugin from `claude-plugins-official`. The plugin spawns its Bun-based MCP server, which connects to Telegram via grammy. Inbound DMs/mentions arrive as user messages in the session; Claude responds; the plugin's `reply` tool sends back to Telegram. Tool-approval prompts can be relayed to the phone (permission relay) so write operations are confirmed on-device.
+
+### Security model
+
+State lives in `~/.claude/channels/telegram/access.json` and is re-read on every inbound message. Three policies:
+
+| Policy | Behavior |
+|---|---|
+| `pairing` (initial) | DM from unknown sender → bot replies with a 6-character pairing code → operator approves with `/telegram:access pair <code>` in a live Claude session. The code is sent only via Telegram to the sender, never logged, so a hostile DM cannot self-approve without access to a running session. |
+| `allowlist` (recommended steady state) | DM from non-allowlisted sender → dropped silently, no reply. |
+| `disabled` | Drop everything, including allowlisted users. Kill switch. |
+
+**Groups are opt-in per group**, with `requireMention: true` by default.
+
+The pairing window is the only soft spot. Telegram bots are **publicly discoverable by username** (anyone can open `t.me/<botname>` and DM them) — there is no "guessing" if the name is at all predictable. Between starting the service in `pairing` mode and switching to `allowlist`, any Telegram user who finds the bot receives a pairing code. The code alone is useless: approving it requires access to a running Claude session on the VM. But the smaller the window, the smaller the risk. **Do not share the bot username publicly until step 3 below is complete and the policy is set to `allowlist`.**
+
+### Prerequisites
+
+In addition to the cron-runner prerequisites:
+
+- **Bun** installed and on `$PATH` for `User=__LOX_VM_USER__` — the plugin's `server.ts` runs on Bun, not Node. Verify: `bun --version`.
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+- **Telegram plugin** installed in the VM user's Claude config (one-time, interactive). Verify: `claude plugin list | grep telegram`.
+- **Bot token** from BotFather, saved to `~/.claude/channels/telegram/.env` (handled by `/telegram:configure`).
+- **`access.json`** with at least one allowlisted Telegram numeric user ID and `dmPolicy: "allowlist"`.
+
+### Setup (interactive on the VM)
+
+The first four steps run in an interactive Claude session on the VM (`ssh obsidian-vm`, then `claude`). This is unavoidable — pairing requires a live session — but only happens once.
+
+#### 1. Create the bot and save the token
+
+Talk to [@BotFather](https://t.me/BotFather), `/newbot`, follow the prompts. Save the token.
+
+#### 2. Install the plugin and write the token to the VM
+
+```bash
+ssh obsidian-vm
+claude   # interactive session, NOT `claude -p`
+```
+
+Inside the session:
+
+```
+/plugin install telegram@claude-plugins-official
+/reload-plugins
+/telegram:configure <BOT_TOKEN>
+/exit
+```
+
+`/telegram:configure` writes `~/.claude/channels/telegram/.env`.
+
+#### 3. Pair from your phone, then lock down
+
+Still on the VM, start a channel session:
+
+```bash
+ssh obsidian-vm
+claude --channels plugin:telegram@claude-plugins-official
+```
+
+From your phone, DM your bot anything. You receive a 6-character pairing code. Back in the SSH session, approve it:
+
+```
+/telegram:access pair <code>
+```
+
+Immediately after pairing succeeds, switch the policy:
+
+```
+/telegram:access policy allowlist
+```
+
+Verify `~/.claude/channels/telegram/access.json`:
+
+```bash
+cat ~/.claude/channels/telegram/access.json
+# expect: dmPolicy: "allowlist", your numeric ID in allowFrom
+```
+
+`/exit` the session.
+
+#### 4. Copy the Telegram settings file
+
+```bash
+cp infra/vm-claude/telegram-settings.json.example ~/.config/lox-claude/telegram-settings.json
+```
+
+This template is **stricter** than the cron runner's `settings.json`: read-only across all MCPs by default, `mcp__lox-brain__write_note` allowed for note capture, and `Bash`/`Write`/`Edit`/`WebFetch`/`WebSearch` explicitly denied. The chat-livre blast radius is larger than a fixed slash command — any inbound message can ask for anything — so the posture starts tight and any expansion goes through phone-side permission approval.
+
+#### 5. Install the systemd unit
+
+```bash
+sed "s/__LOX_VM_USER__/$USER/g" infra/systemd/lox-claude-telegram.service | sudo tee /etc/systemd/system/lox-claude-telegram.service > /dev/null
+sudo systemctl daemon-reload
+sudo systemctl enable --now lox-claude-telegram.service
+```
+
+#### 6. Verify end-to-end
+
+```bash
+systemctl status lox-claude-telegram.service     # active (running)
+journalctl -u lox-claude-telegram.service -f     # live tail
+```
+
+From your phone, DM the bot something that exercises an MCP, e.g. `resume hoje`. Expect a reply within ~30s referencing today's calendar.
+
+From a non-allowlisted account (a friend's, ideally), DM the bot. Expect **no reply**; the journal should log the drop.
+
+Reboot the VM and confirm the service comes back up: `systemctl is-enabled lox-claude-telegram.service` should report `enabled`.
+
+### Telegram listener troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Service fails to start with `ExecStartPre` exit 1 on `.env` | `/telegram:configure` never ran | Run step 2 |
+| Service fails to start with `ExecStartPre` exit 1 on `access.json` | Pairing never completed | Run step 3 |
+| Bot replies with pairing codes to strangers | Policy still `pairing`, not `allowlist` | `/telegram:access policy allowlist` in a live channel session |
+| `bun: command not found` in journal | Bun not on `$PATH` for the service's `User=` (systemd does NOT source `.bashrc`/`.zshrc`) | Uncomment the `Environment="PATH=..."` line in the unit file. Default for the official Bun installer: `Environment="PATH=/home/__LOX_VM_USER__/.bun/bin:/usr/local/bin:/usr/bin:/bin"` (re-run the `sed` substitution after editing, then `daemon-reload` + restart) |
+| Inbound DMs from authorized user get no reply | Service down, or MCP unavailable | `systemctl status lox-claude-telegram.service`; check `claude mcp list` on the VM |
+| Bot replies but cannot answer "resume hoje" | Skill `/sync-calendar` not installed on the VM, or Calendar connector not registered | Same fix as the cron runner — see the gap warning at the top of this README |
+| Service restart loop every 15s | OAuth credentials expired (401) | `claude login` on the VM |
+
+### What's *not* in the listener
+
+- **No multi-channel** (Slack/Discord). Telegram only.
+- **No voice/audio** by default. The `elevenlabs-voice` skill can be invoked on-demand if you ask for it, but is not in the default reply flow.
+- **No multi-user / team mode.** Personal account only.
 
 ## Design spec
 

--- a/infra/vm-claude/telegram-settings.json.example
+++ b/infra/vm-claude/telegram-settings.json.example
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__lox-brain__read_note",
+      "mcp__lox-brain__search_text",
+      "mcp__lox-brain__search_semantic",
+      "mcp__lox-brain__list_recent",
+      "mcp__lox-brain__write_note",
+      "mcp__claude_ai_Google_Calendar__list_events",
+      "mcp__claude_ai_Google_Calendar__get_event",
+      "mcp__claude_ai_Google_Calendar__list_calendars",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Google_Drive__read_file_content",
+      "mcp__claude_ai_Google_Drive__search_files",
+      "Read"
+    ],
+    "deny": [
+      "Bash",
+      "Write",
+      "Edit",
+      "WebFetch",
+      "WebSearch",
+      "mcp__lox-brain__delete_note",
+      "mcp__claude_ai_Google_Calendar__create_event",
+      "mcp__claude_ai_Google_Calendar__update_event",
+      "mcp__claude_ai_Google_Calendar__delete_event",
+      "mcp__claude_ai_Google_Calendar__respond_to_event",
+      "mcp__claude_ai_Gmail__create_draft",
+      "mcp__claude_ai_Gmail__create_label",
+      "mcp__claude_ai_Gmail__delete_label",
+      "mcp__claude_ai_Gmail__update_label",
+      "mcp__claude_ai_Gmail__label_message",
+      "mcp__claude_ai_Gmail__label_thread",
+      "mcp__claude_ai_Gmail__unlabel_message",
+      "mcp__claude_ai_Gmail__unlabel_thread",
+      "mcp__claude_ai_Google_Drive__create_file",
+      "mcp__claude_ai_Google_Drive__copy_file"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- New optional VM service `lox-claude-telegram.service` that keeps a long-running `claude --channels plugin:telegram@claude-plugins-official` session listening on Telegram — sibling to the existing cron `/sync-calendar` runner. DMs from the operator's phone get full vault + connector access (`mcp__lox-brain__*`, Google Calendar, Gmail, Drive).
- Stricter permissions template `infra/vm-claude/telegram-settings.json.example` than the cron runner's: read-only across MCPs + `write_note`, with `Bash`/`Write`/`Edit`/`WebFetch`/`WebSearch` and Calendar/Gmail/Drive mutating tools explicitly denied. Chat-livre blast radius is larger than a fixed slash command, so the posture starts tight and any expansion goes through phone-side permission relay.
- README extended with 6-step setup procedure (BotFather → `/telegram:configure` → pairing → `allowlist` lockdown → install unit → verify), security model table (pairing / allowlist / disabled), and dedicated troubleshooting rows (Bun PATH, plugin not installed, etc.).

Closes #177.

## What's not in scope

- Multi-channel (Slack/Discord) — Telegram only.
- Voice/audio by default — `elevenlabs-voice` skill can be invoked on demand.
- Multi-user / team mode — personal account only.

## Test plan

- [x] `npm run test --workspaces` — 488 tests pass (no TypeScript changed; sanity-checked nothing broke from version bumps)
- [x] `tsc --noEmit` on all 3 packages — clean
- [x] Pre-commit hooks pass (including secret detection — no real bot tokens, numeric IDs, GCP project IDs, or operator-specific paths leaked; only `__LOX_VM_USER__` and `<BOT_TOKEN>` placeholders)
- [x] Code review (`code-reviewer` agent) — 4 substantive findings addressed in the same commit (Calendar/Gmail/Drive denies, `TimeoutStartSec` 30→90s, `ReadWritePaths` recursive-subtree comment, honest pairing-window discoverability warning, concrete Bun `Environment="PATH=..."` fix)
- [ ] End-to-end validation on the obsidian-vm (manual, post-merge): Bun installed, plugin installed, bot paired, allowlist locked down, service active, authorized DM → reply, non-authorized DM → silently dropped, reboot survival

🤖 Generated with [Claude Code](https://claude.com/claude-code)