### PR TITLE
feat(installer): add `lox upgrade` self-service command (v0.13.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.3] — 2026-06-29
+
+### Added
+- **`lox upgrade` — self-service updater for the VM.** Pulls the latest code, rebuilds, re-applies `schema.sql` (idempotent), and restarts the watcher, streaming progress live. A thin, tested wrapper over `infra/deploy.sh` (no duplicated logic); resolves the install directory from `~/.lox/config.json` with sensible fallbacks. Replaces the removed push-coupled auto-deploy with an operator-driven flow each user runs on their own VM. Linux/macOS only (the watcher/MCP host); errors clearly on Windows.
+
 ## [0.13.2] — 2026-06-29
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -47,6 +47,11 @@ async function main(): Promise<void> {
     console.log('  2. Ask Claude Code to search your notes (full stack)');
     return;
   }
+  if (args[0] === 'upgrade') {
+    const { runUpgrade } = await import('./upgrade.js');
+    await runUpgrade();
+    return;
+  }
 
   let ctx: InstallerContext = { config: {}, locale: 'en' };
   let startFromStep = 1;

--- a/packages/installer/src/upgrade.ts
+++ b/packages/installer/src/upgrade.ts
@@ -1,0 +1,93 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { getConfigPath } from '@lox-brain/shared';
+import { getPlatform } from './utils/shell.js';
+
+/** Relative location of the deploy/upgrade script inside an install. */
+const DEPLOY_SCRIPT = path.join('infra', 'deploy.sh');
+
+function hasDeployScript(dir: string): boolean {
+  return existsSync(path.join(dir, DEPLOY_SCRIPT));
+}
+
+/**
+ * Locate the Lox install directory to upgrade.
+ *
+ * Prefers `install_dir` from ~/.lox/config.json, then falls back to the current
+ * working directory and the conventional install locations. A directory only
+ * qualifies if it actually contains `infra/deploy.sh` (so we never try to
+ * upgrade a half-checked-out or wrong path).
+ *
+ * Params are injectable for testing; they default to the real environment.
+ */
+export function resolveInstallDir(
+  configPath: string = getConfigPath(),
+  home: string = process.env.HOME ?? process.env.USERPROFILE ?? '',
+  cwd: string = process.cwd(),
+): string {
+  if (existsSync(configPath)) {
+    try {
+      const cfg = JSON.parse(readFileSync(configPath, 'utf-8'));
+      if (typeof cfg.install_dir === 'string' && hasDeployScript(cfg.install_dir)) {
+        return cfg.install_dir;
+      }
+    } catch {
+      /* corrupt config — fall through to conventional locations */
+    }
+  }
+
+  const candidates = [
+    cwd,
+    path.join(home, 'obsidian_open_brain'),
+    path.join(home, 'lox-brain'),
+  ];
+  for (const dir of candidates) {
+    if (hasDeployScript(dir)) return dir;
+  }
+
+  throw new Error(
+    'Could not locate a Lox install to upgrade (no infra/deploy.sh found). ' +
+      'Run this on the VM that hosts Lox, or set "install_dir" in ~/.lox/config.json.',
+  );
+}
+
+/** Resolve and validate the absolute path of the deploy script. */
+export function resolveDeployScript(installDir: string): string {
+  const script = path.join(installDir, DEPLOY_SCRIPT);
+  if (!existsSync(script)) {
+    throw new Error(`Deploy script not found at ${script}.`);
+  }
+  return script;
+}
+
+/**
+ * `lox upgrade` — pull + build + (re-)apply schema + restart, self-service.
+ *
+ * Thin wrapper over infra/deploy.sh (the single source of truth for the
+ * upgrade steps) so there is no duplicated bash/TS logic. Streams the script
+ * output live via stdio inheritance.
+ */
+export async function runUpgrade(): Promise<void> {
+  if (getPlatform() === 'windows') {
+    throw new Error(
+      'lox upgrade runs on the Linux VM that hosts the watcher and MCP server, not on Windows.',
+    );
+  }
+
+  const installDir = resolveInstallDir();
+  const script = resolveDeployScript(installDir);
+
+  console.log(`\n  Upgrading Lox in ${installDir} …\n`);
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('bash', [script], { stdio: 'inherit', cwd: installDir });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Upgrade failed: infra/deploy.sh exited with code ${code}.`));
+    });
+  });
+
+  console.log('\n  ✓ Lox upgraded.\n');
+}

--- a/packages/installer/tests/upgrade.test.ts
+++ b/packages/installer/tests/upgrade.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveInstallDir, resolveDeployScript } from '../src/upgrade.js';
+
+async function makeInstall(root: string, name: string): Promise<string> {
+  const dir = path.join(root, name);
+  await mkdir(path.join(dir, 'infra'), { recursive: true });
+  await writeFile(path.join(dir, 'infra', 'deploy.sh'), '#!/usr/bin/env bash\n');
+  return dir;
+}
+
+describe('resolveInstallDir', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'lox-upgrade-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  // An empty cwd so the first fallback candidate (process.cwd()) never matches
+  // the real repo checkout during tests.
+  const noCwd = () => path.join(tmp, 'no-cwd');
+
+  it('uses install_dir from config when it has a deploy script', async () => {
+    const installDir = await makeInstall(tmp, 'from-config');
+    const configPath = path.join(tmp, 'config.json');
+    await writeFile(configPath, JSON.stringify({ install_dir: installDir }));
+
+    expect(resolveInstallDir(configPath, tmp, noCwd())).toBe(installDir);
+  });
+
+  it('falls back to ~/obsidian_open_brain when config is absent', async () => {
+    const installDir = await makeInstall(tmp, 'obsidian_open_brain');
+
+    // non-existent config path -> fall through to home candidates
+    expect(resolveInstallDir(path.join(tmp, 'nope.json'), tmp, noCwd())).toBe(installDir);
+  });
+
+  it('ignores a config whose install_dir lacks a deploy script', async () => {
+    const fallback = await makeInstall(tmp, 'lox-brain');
+    const configPath = path.join(tmp, 'config.json');
+    await writeFile(configPath, JSON.stringify({ install_dir: path.join(tmp, 'ghost') }));
+
+    expect(resolveInstallDir(configPath, tmp, noCwd())).toBe(fallback);
+  });
+
+  it('tolerates a corrupt config and still falls back', async () => {
+    const fallback = await makeInstall(tmp, 'obsidian_open_brain');
+    const configPath = path.join(tmp, 'config.json');
+    await writeFile(configPath, '{ not valid json');
+
+    expect(resolveInstallDir(configPath, tmp, noCwd())).toBe(fallback);
+  });
+
+  it('prefers the current working directory when it is an install', async () => {
+    const cwdInstall = await makeInstall(tmp, 'cwd-install');
+    expect(resolveInstallDir(path.join(tmp, 'nope.json'), tmp, cwdInstall)).toBe(cwdInstall);
+  });
+
+  it('throws an actionable error when no install is found', () => {
+    expect(() => resolveInstallDir(path.join(tmp, 'nope.json'), tmp, noCwd())).toThrow(/Could not locate a Lox install/);
+  });
+});
+
+describe('resolveDeployScript', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'lox-upgrade-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('returns the script path when present', async () => {
+    const dir = await makeInstall(tmp, 'install');
+    expect(resolveDeployScript(dir)).toBe(path.join(dir, 'infra', 'deploy.sh'));
+  });
+
+  it('throws when the deploy script is missing', () => {
+    expect(() => resolveDeployScript(path.join(tmp, 'empty'))).toThrow(/Deploy script not found/);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Adds a `lox upgrade` subcommand to the CLI so each user updates their own VM with one command — replacing the removed push-coupled auto-deploy with an operator-driven flow.

It's a thin, tested wrapper over `infra/deploy.sh` (the single source of truth for the upgrade steps — no duplicated bash/TS logic): resolves the install directory from `~/.lox/config.json` (with fallbacks), validates the deploy script, and streams the upgrade live (`git pull` → build → re-apply `schema.sql` → restart). Linux/macOS only; errors clearly on Windows.

Tests cover install-dir resolution (config, fallbacks, corrupt config, cwd preference, not-found) and deploy-script validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)