### PR TITLE
fix(deploy): restart lox-mcp.service too in team mode (v0.13.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.4] — 2026-06-30
+
+### Fixed
+- **`infra/deploy.sh` now also restarts `lox-mcp.service` when the unit exists (team mode).** Team-mode deployments run the MCP server over HTTP as a systemd service; previously only `lox-watcher` was restarted, so after an upgrade the MCP server kept running the old code. Personal/stdio installs have no such unit and are unaffected (the restart is guarded by `systemctl cat lox-mcp.service`).
+
 ## [0.13.3] — 2026-06-29
 
 ### Added

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -43,11 +43,20 @@ echo "--- kill stale MCP processes ---"
 pkill -f 'tsx src/mcp/index.ts' || true
 pkill -f 'tsx packages/core/src/mcp/index.ts' || true
 
-echo "--- restart watcher ---"
+echo "--- restart services ---"
 sudo systemctl restart lox-watcher
+# Team mode also runs the MCP server as a systemd service (HTTP transport).
+# Restart it too when the unit exists so it picks up the new code; personal
+# (stdio) installs have no such unit and skip this.
+if systemctl cat lox-mcp.service >/dev/null 2>&1; then
+  sudo systemctl restart lox-mcp
+fi
 
-echo "--- verify watcher ---"
+echo "--- verify services ---"
 systemctl is-active lox-watcher
+if systemctl cat lox-mcp.service >/dev/null 2>&1; then
+  systemctl is-active lox-mcp
+fi
 
 echo "=== Lox deploy completed at $(date -u) ==="
 echo "DEPLOY_SUCCESS"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
`deploy.sh` only restarted `lox-watcher`, so team-mode installs (MCP server over HTTP as a systemd unit) would keep running the old code after an upgrade. Now restarts `lox-mcp.service` as well when the unit exists (guarded by `systemctl cat`); personal/stdio installs have no such unit and skip it. Prep for upgrading the Credifit (team-mode) VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)