### PR TITLE
docs(vm-claude): add daily Telegram digest examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.5] — 2026-07-05
+
+### Added
+- **VM daily Telegram digest examples (`sync-calendar` drop-ins + silent-failure runner) in `infra/vm-claude`.** Versioned templates for turning the `lox-claude-sync-calendar` timer into a daily Telegram digest: a `.timer.d` drop-in to change the schedule, a `.service.d` drop-in to point `ExecStart=` at the runner, and `sync-calendar-run.sh.example`. The runner treats the absence of the skill's success marker as a failure (`exit 1`) so an empty `exit 0` no longer slips past `OnFailure=`. Docs only — no personal values or secrets; a new README section covers install and the UTC-conversion gotcha in `systemctl list-timers`.
+
 ## [0.13.4] — 2026-06-30
 
 ### Fixed

--- a/infra/vm-claude/README.md
+++ b/infra/vm-claude/README.md
@@ -120,6 +120,57 @@ If your Obsidian vault or lox-brain repo lives somewhere other than `$HOME/obsid
 
 Multi-VM support via the installer is a follow-up; see issue #171.
 
+## Daily Telegram digest
+
+The `lox-claude-sync-calendar` timer can double as a **daily Telegram digest**. Instead of only writing calendar notes to the vault, the runner invokes `/sync-calendar auto` and then sends **two separate Telegram messages** via the telegram reply tool:
+
+1. A summary of the day's calendar.
+2. `📋 Atividades em aberto` — open tasks pulled from the `lox-brain` MCP (`list_tasks` for `pending` + `in_progress`), grouped by priority (high → medium → low), with overdue tasks flagged `⚠️`.
+
+Both the schedule and the command are customized with **systemd drop-ins** layered over the base `lox-claude-sync-calendar.{timer,service}` — no edits to the shipped units. Three examples live in this folder:
+
+- `lox-claude-sync-calendar.timer.d/override.conf.example` — overrides `OnCalendar=` (the empty `OnCalendar=` line first resets the inherited value, so the two don't add up).
+- `lox-claude-sync-calendar.service.d/execstart.conf.example` — points `ExecStart=` at the runner and puts `bun` on `PATH` (systemd does not inherit your shell's `PATH`).
+- `sync-calendar-run.sh.example` — the runner itself, with silent-failure detection.
+
+### Install the drop-ins
+
+```bash
+# Timer drop-in — change the schedule
+sudo mkdir -p /etc/systemd/system/lox-claude-sync-calendar.timer.d/
+sudo cp infra/vm-claude/lox-claude-sync-calendar.timer.d/override.conf.example \
+        /etc/systemd/system/lox-claude-sync-calendar.timer.d/override.conf
+
+# Service drop-in — point ExecStart at the runner
+sudo mkdir -p /etc/systemd/system/lox-claude-sync-calendar.service.d/
+sudo cp infra/vm-claude/lox-claude-sync-calendar.service.d/execstart.conf.example \
+        /etc/systemd/system/lox-claude-sync-calendar.service.d/execstart.conf
+
+# The runner script (referenced by the service drop-in)
+cp infra/vm-claude/sync-calendar-run.sh.example ~/.config/lox-claude/sync-calendar-run.sh
+chmod +x ~/.config/lox-claude/sync-calendar-run.sh
+
+sudo systemctl daemon-reload
+sudo systemctl restart lox-claude-sync-calendar.timer
+```
+
+Verify the next run:
+
+```bash
+systemctl list-timers | grep lox-claude-sync-calendar
+# NOTE: if the VM is in UTC, the LEFT/NEXT columns show the time converted to UTC,
+# not the America/Sao_Paulo wall-clock time in your OnCalendar= line.
+```
+
+> The `execstart.conf.example` drop-in uses the same `__LOX_VM_USER__` placeholder as the base units (see **Setup → step 3**). Substitute it with your actual VM user before installing the drop-in:
+> ```bash
+> sed -i "s/__LOX_VM_USER__/$USER/g" infra/vm-claude/lox-claude-sync-calendar.service.d/execstart.conf.example
+> ```
+
+### Silent-failure detection
+
+`claude -p "/sync-calendar auto"` can exit `0` **without having synced anything** (Google connectors missing in headless, or the skill aborting early). That empty success used to slip past `OnFailure=`. The runner treats the **absence of the skill's success marker** (`Sync complete` / `Sync summary`) in the output as a failure (`exit 1`), so the unit's `OnFailure=` fires a Telegram alert instead of a silent no-op.
+
 ## Refreshing auth when it expires
 
 The OAuth session in `~/.claude/.credentials.json` includes a refresh token, but per [anthropics/claude-code#50743](https://github.com/anthropics/claude-code/issues/50743), automatic refresh is unreliable in headless Linux. Practically: expect to re-login every few weeks.

--- a/infra/vm-claude/lox-claude-sync-calendar.service.d/execstart.conf.example
+++ b/infra/vm-claude/lox-claude-sync-calendar.service.d/execstart.conf.example
@@ -1,0 +1,9 @@
+[Service]
+# bun no PATH (systemd nao herda o PATH do shell) — necessario p/ o plugin telegram.
+# Troque __LOX_VM_USER__ pelo seu usuario (o padrao das units base usa sed no install).
+Environment="PATH=/home/__LOX_VM_USER__/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Substitui o ExecStart do unit base por um wrapper que detecta falha silenciosa
+# (ver sync-calendar-run.sh.example). A linha ExecStart= vazia reseta o valor herdado.
+ExecStart=
+ExecStart=/home/__LOX_VM_USER__/.config/lox-claude/sync-calendar-run.sh

--- a/infra/vm-claude/lox-claude-sync-calendar.timer.d/override.conf.example
+++ b/infra/vm-claude/lox-claude-sync-calendar.timer.d/override.conf.example
@@ -1,0 +1,6 @@
+[Timer]
+# Drop-in para ajustar o horario do digest diario. A linha OnCalendar= vazia
+# RESETA o valor herdado do .timer base (senao os dois valores se somam).
+# Ajuste o horario e o timezone ao seu gosto (systemd >= 252 honra o timezone).
+OnCalendar=
+OnCalendar=*-*-* 07:00 America/Sao_Paulo

--- a/infra/vm-claude/sync-calendar-run.sh.example
+++ b/infra/vm-claude/sync-calendar-run.sh.example
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Runner do digest diario, com deteccao de falha silenciosa.
+# `claude -p "/sync-calendar auto"` pode sair com codigo 0 SEM ter feito o sync
+# (ex.: conectores Google ausentes em headless, skill abortando cedo). Esse "exit 0
+# vazio" passava batido e nao disparava o OnFailure. Aqui tratamos a AUSENCIA do
+# marcador de sucesso da skill como falha (exit 1), acionando o unit OnFailure
+# (alerta no Telegram).
+set -uo pipefail
+
+SETTINGS="$HOME/.config/lox-claude/settings.json"
+PROMPT='/sync-calendar auto
+
+(After the skill finishes, send a Telegram summary of the calendar via the telegram reply tool.)
+
+(Then send a SECOND, separate Telegram message to the same chat — do NOT merge it with the calendar summary. Build it from open tasks: call the lox-brain list_tasks tool with status pending, then again with status in_progress. Title the message "📋 Atividades em aberto". Group by priority in this order: high, medium, low. One line per task: "- <title> [<project_context>] <due if present>". Prefix any task whose due_date is before today with "⚠️ ". If both lists are empty, send exactly "📋 Nenhuma atividade em aberto." Keep it concise and do not invent tasks.)'
+
+OUT="$(/usr/local/bin/claude -p "$PROMPT" --settings "$SETTINGS" 2>&1)"
+CODE=$?
+
+printf '%s\n' "$OUT"
+
+if [ "$CODE" -ne 0 ]; then
+  printf '[runner] claude saiu com codigo %s\n' "$CODE" >&2
+  exit "$CODE"
+fi
+
+# Marcador emitido pela skill ao concluir. Sem ele, o run nao fez o trabalho.
+if ! printf '%s' "$OUT" | grep -qiE 'Sync complete|Sync summary'; then
+  printf '[runner] sem marcador de sucesso na saida — tratando como falha silenciosa\n' >&2
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Versions the **daily Telegram digest** mechanism as generic templates in `infra/vm-claude/`. Until now the digest (calendar summary + open-tasks list, pushed to Telegram) was scheduled and run entirely by systemd drop-ins + a runner script that lived **only on the VM**, unversioned — the repo's base units (`06:00`/`19:00`) didn't reflect reality.

## Changes

New examples in `infra/vm-claude/`:
- `lox-claude-sync-calendar.timer.d/override.conf.example` — drop-in to change the digest schedule (empty `OnCalendar=` resets the inherited value).
- `lox-claude-sync-calendar.service.d/execstart.conf.example` — points `ExecStart=` at the runner + puts `bun` on `PATH`.
- `sync-calendar-run.sh.example` — the runner, with **silent-failure detection** (an empty `exit 0` without the skill's success marker is treated as failure so `OnFailure=` fires a Telegram alert).

Also: new `README.md` section (install steps + UTC-conversion gotcha in `systemctl list-timers`), `CHANGELOG` entry, version bump `0.13.4 → 0.13.5`.

## Notes

- Templates use the `__LOX_VM_USER__` placeholder (consistent with sibling units) — **not** `%h`, which resolves to `/root` in system units.
- No personal values or secrets; schedule value in the example is a neutral `07:00`.
- `packages/team` left at `0.1.0` (independent version track; this PR doesn't touch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)