### PR TITLE
fix(team): populate created_by for add_task and daily_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.6] — 2026-07-09
+
+### Fixed
+- **Team mode: `add_task` and `daily_log` now record the authoring peer in `created_by` (#187).** The authorship middleware's `WRITE_TOOLS` allowlist only contained `write_note`, so the task/daily-log tools added in #166 were returned unwrapped — their handlers already read `_created_by`, but the middleware never injected the peer identity (resolved from the caller's WireGuard IP), leaving `created_by` as `null` on every created task. Added `add_task` and `daily_log` to the allowlist. `update_task` stays excluded by design so edits from other peers don't overwrite the original author. Regression tests cover injection for the new tools. No schema change (the `tasks.created_by` column already exists); personal/stdio mode is unaffected.
+
 ## [0.13.5] — 2026-07-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "description": "Lox — Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/team/package.json
+++ b/packages/team/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/team",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "main": "dist/index.js",

--- a/packages/team/src/multi-user/created-by-middleware.ts
+++ b/packages/team/src/multi-user/created-by-middleware.ts
@@ -7,8 +7,13 @@ export interface Tool {
   handler: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
-/** Tools that mutate vault state and require authorship attribution. */
-const WRITE_TOOLS = new Set(['write_note']);
+/**
+ * Tools that create authored content and require authorship attribution.
+ * The middleware injects the resolved peer's name as `_created_by` for these.
+ * `update_task` is intentionally excluded — it must not overwrite the original
+ * author when a different peer edits the task.
+ */
+const WRITE_TOOLS = new Set(['write_note', 'add_task', 'daily_log']);
 
 export function wrapToolWithCreatedBy(
   tool: Tool,

--- a/packages/team/tests/multi-user/created-by-middleware.test.ts
+++ b/packages/team/tests/multi-user/created-by-middleware.test.ts
@@ -19,6 +19,30 @@ describe('wrapToolWithCreatedBy', () => {
     });
   });
 
+  it('should inject _created_by into add_task args', async () => {
+    const innerHandler = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const tool = { name: 'add_task', description: 'Add task', inputSchema: {}, handler: innerHandler };
+    const wrapped = wrapToolWithCreatedBy(tool, resolver, () => '10.20.0.2');
+    await wrapped.handler({ title: 'Ship Lox' });
+    expect(innerHandler).toHaveBeenCalledWith({ title: 'Ship Lox', _created_by: 'eduardo' });
+  });
+
+  it('should inject _created_by into daily_log args', async () => {
+    const innerHandler = vi.fn().mockResolvedValue({ written: 'daily-logs/2026-07-09.md' });
+    const tool = { name: 'daily_log', description: 'Daily log', inputSchema: {}, handler: innerHandler };
+    const wrapped = wrapToolWithCreatedBy(tool, resolver, () => '10.20.0.2');
+    await wrapped.handler({ entry: 'shipped the fix' });
+    expect(innerHandler).toHaveBeenCalledWith({ entry: 'shipped the fix', _created_by: 'eduardo' });
+  });
+
+  it('should not inject _created_by for update_task (must not overwrite original author)', async () => {
+    const innerHandler = vi.fn().mockResolvedValue({ id: 'task-1' });
+    const tool = { name: 'update_task', description: 'Update task', inputSchema: {}, handler: innerHandler };
+    const wrapped = wrapToolWithCreatedBy(tool, resolver, () => '10.20.0.2');
+    await wrapped.handler({ id: 'task-1', status: 'done' });
+    expect(innerHandler).toHaveBeenCalledWith({ id: 'task-1', status: 'done' });
+  });
+
   it('should not inject _created_by for read_note', async () => {
     const innerHandler = vi.fn().mockResolvedValue({ content: 'data' });
     const tool = { name: 'read_note', description: 'Read', inputSchema: {}, handler: innerHandler };


### PR DESCRIPTION
## Summary

In team mode, tasks created via `add_task` were stored with `created_by: null` — authorship attribution silently failed even though the calling peer is identifiable by WireGuard IP.

**Root cause:** the authorship middleware's allowlist only contained `write_note`:

```ts
const WRITE_TOOLS = new Set(['write_note']);
```

`wrapToolWithCreatedBy` only injects `_created_by` (resolved from the caller's VPN IP via `PeerResolver`) for tools in this set. #166 added `add_task` and `daily_log`, whose handlers already read `args._created_by` and forward it to the DB — but because neither was in the allowlist, the middleware returned them unwrapped, so `created_by` was never populated.

## Fix

```ts
const WRITE_TOOLS = new Set(['write_note', 'add_task', 'daily_log']);
```

`update_task` stays excluded by design — it strips `_created_by` (`tools.ts:315`) so a different peer editing a task can't overwrite the original author.

## Tests

- 3 new middleware tests: injection for `add_task` and `daily_log`, non-injection for `update_task`.
- Full `team` suite: 37 passing. Type check clean across all workspaces.

## Notes

- Team-mode only; personal/stdio mode has no peer to attribute and is unaffected.
- No schema change — `tasks.created_by` already exists (added in #166).
- Existing rows with `created_by: null` stay null; backfill out of scope.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)