### PR TITLE
docs(zettelkasten): refresh MCP server note + add created_by identity note

### DIFF
--- a/docs/zettelkasten/_MOC.md
+++ b/docs/zettelkasten/_MOC.md
@@ -20,7 +20,8 @@ source: claude-skill
 
 ## Componentes Core
 
-- [[Lox - MCP Server]] -- MCP Server com 6 tools (stdio over SSH)
+- [[Lox - MCP Server]] -- MCP Server: transportes stdio (pessoal) e HTTP (team), 11 tools core + 2 team
+- [[Lox - Atribuicao de Identidade created_by]] -- Resolução server-side de autoria: trusted-proxy actor -> WireGuard peer -> stripped
 - [[Lox - Servico de Embedding]] -- Biblioteca de embeddings, parsing e chunking
 - [[Lox - Vault Watcher]] -- Chokidar v5 + pipeline de indexacao automatica
 - [[Lox - Banco pgvector]] -- PostgreSQL 16 + pgvector, schema e DbClient
@@ -55,6 +56,7 @@ Lox - Arquitetura Geral
   +-- Lox - MCP Server
   |     +-- Lox - Banco pgvector
   |     +-- Lox - Servico de Embedding
+  |     +-- Lox - Atribuicao de Identidade created_by
   +-- Lox - Infraestrutura GCP
   |     +-- Lox - CI CD GitHub Actions
   +-- Lox - Seguranca Zero Trust
@@ -71,4 +73,5 @@ Lox - Arquitetura Geral
 *Zettelkasten gerado em 2026-03-14 via claude-skill (Mode 1: Full Project Scan)*
 *Atualizado em 2026-03-25: correcoes de precisao + 3 notas de skills adicionadas*
 *Atualizado em 2026-04-03: renomeado de Open Brain para Lox (repo: isorensen/lox-brain, monorepo, 150 testes)*
-*14 notas atomicas | Cobertura: arquitetura, componentes, infra, seguranca, qualidade, skills*
+*Atualizado em 2026-07-10: mcp-server atualizado (2 transportes, 11+2 tools) + nota de atribuicao created_by (#187/#191, team mode)*
+*15 notas atomicas | Cobertura: arquitetura, componentes, infra, seguranca, qualidade, skills*

--- a/docs/zettelkasten/identidade-created-by.md
+++ b/docs/zettelkasten/identidade-created-by.md
@@ -1,0 +1,48 @@
+2026-07-10 14:30
+
+Status: #baby
+
+Tags: [[claude-skill]] [[lox]] [[mcp]] [[seguranca]]
+source: claude-skill
+
+# Atribuição de Identidade (`created_by`)
+
+No modo team, todo write autorado precisa registrar **quem** o criou. O Lox resolve `created_by` **server-side, por requisição**, e nunca confia em um `_created_by` vindo nos args do cliente (anti-spoofing). Aplica-se a `write_note`, `add_task` e `daily_log`.
+
+## Como funciona
+
+O middleware `wrapToolWithCreatedBy` (`packages/team/src/multi-user/created-by-middleware.ts`) resolve a identidade nesta ordem:
+
+1. **Trusted-proxy actor** — um chamador que apresenta um `X-Lox-Proxy-Secret` válido (comparado em tempo constante com `LOX_TRUSTED_PROXY_SECRET`) pode encaminhar um header `X-Lox-Actor` com o nome do remetente autenticado. Serve para integrações de backend (ex.: um chat bot) que alcançam o MCP pela rede privada **sem** serem um peer WireGuard registrado.
+2. **WireGuard peer** — senão, o IP de origem do chamador (`req.socket.remoteAddress`) é resolvido para um peer registrado via `PeerResolver`.
+3. **Stripped** — senão, qualquer `_created_by` do cliente é removido (chamador desconhecido).
+
+```
+trusted actor  →  WireGuard peer  →  stripped
+```
+
+## Por que essa decisão
+
+O modelo original (#187) derivava a identidade **apenas** do IP WireGuard. Isso quebrava para writes que chegam por um proxy backend, que conecta pela VPC e não é um peer — a resolução falhava e `created_by` ficava `null` (#191). O trusted-proxy adiciona um canal confiável para carregar a identidade real do usuário, escopado a um único chamador autenticado por segredo compartilhado.
+
+O actor (`clientIpStorage`/`actorStorage`, ambos `AsyncLocalStorage` por requisição em `packages/core/src/mcp/index.ts`) é capturado no handler HTTP: o `X-Lox-Proxy-Secret` é comparado com `timingSafeEqual`; só em match o `X-Lox-Actor` é honrado.
+
+> [!NOTE]
+> O segredo é toda a fronteira de confiança. Um segredo ausente/vazio/errado/duplicado faz o header do actor ser ignorado por completo — peers normais não conseguem forjar `created_by`. Com `LOX_TRUSTED_PROXY_SECRET` não configurado, o caminho inteiro é no-op (permite subir o MCP antes do backend enviar headers, sem janela de brecha).
+
+> [!WARNING]
+> Uma vez que o segredo confere, o backend é totalmente confiado: não há allowlist ligando o `X-Lox-Actor` a um peer/usuário registrado (remetentes de chat não são peers WireGuard). Um backend comprometido poderia atribuir writes a um nome arbitrário. Cada atribuição via trusted-proxy é registrada em log de auditoria (sem logar o segredo). Nome do actor tem limite de 200 chars.
+
+## Relações
+
+- implementado em: [[Lox - MCP Server]]
+- parte de: [[Lox - Seguranca Zero Trust]]
+- contido em: [[Lox]]
+
+## References
+
+- `packages/team/src/multi-user/created-by-middleware.ts` (ordem de resolução)
+- `packages/core/src/mcp/trusted-proxy.ts` (`resolveTrustedActor`, comparação em tempo constante)
+- `packages/core/src/mcp/index.ts` (`actorStorage`, captura do header, log de auditoria)
+- `packages/core/.env.example` (`LOX_TRUSTED_PROXY_SECRET` e trust boundary)
+- [[Lox - MCP Server]]

--- a/docs/zettelkasten/mcp-server.md
+++ b/docs/zettelkasten/mcp-server.md
@@ -7,9 +7,18 @@ source: claude-skill
 
 # MCP Server do Lox
 
-O MCP Server e a interface entre Claude Code e o vault. Implementado com `@modelcontextprotocol/sdk`, usa transporte stdio over SSH -- o Claude Code invoca o servidor sob demanda via conexão SSH pela [[Lox - WireGuard VPN]].
+O MCP Server e a interface entre os clientes (Claude Code, integrações de backend) e o vault. Implementado com `@modelcontextprotocol/sdk`, suporta **dois transportes** selecionados por `MCP_TRANSPORT`: `stdio` (modo pessoal) e `http` (modo team).
 
-## 6 Tools disponíveis
+## Transportes
+
+- **`stdio` (default, modo pessoal)** — o Claude Code inicia o servidor sob demanda como processo filho e fala via stdin/stdout. Single-user, sem daemon.
+- **`http` (modo team)** — daemon de longa duração (`lox-mcp.service`) que faz bind em `MCP_HOST` (default `127.0.0.1`; em multi-user aponta para a interface da [[Lox - WireGuard VPN]]), porta `MCP_PORT` (default `3100`). Usa `StreamableHTTPServerTransport` com sessão (`sessionIdGenerator` gera um session ID por cliente — modo stateless quebra o health check do Claude Code). O IP de origem do chamador vem de `req.socket.remoteAddress` para atribuição de identidade.
+
+## Tools
+
+Os handlers base vivem em `packages/core/src/mcp/tools.ts` (`createTools`). No modo team, o pacote `@lox-brain/team` adiciona os team tools e envolve os writes com o middleware de autoria.
+
+**Core (11):**
 
 | Tool | Descricao |
 |------|-----------|
@@ -19,6 +28,22 @@ O MCP Server e a interface entre Claude Code e o vault. Implementado com `@model
 | `search_semantic` | Busca por similaridade vetorial (cosine distance) |
 | `search_text` | Busca textual case-insensitive (ILIKE) com filtro por tags |
 | `list_recent` | Lista notas mais recentes por `updated_at` |
+| `add_task` | Cria uma task (autoria via `created_by`) |
+| `list_tasks` | Lista tasks com filtros (status, `assigned_to`, etc.) |
+| `update_task` | Atualiza uma task (não sobrescreve o autor original) |
+| `complete_task` | Marca uma task como concluída |
+| `daily_log` | Anexa uma entrada ao daily log (autoria via `created_by`) |
+
+**Team (2), apenas no modo team** (`packages/team/src/mcp-extensions/team-tools.ts`):
+
+| Tool | Descricao |
+|------|-----------|
+| `list_team_activity` | Atividade recente agregada por autor |
+| `search_by_author` | Busca notas filtradas por autor |
+
+## Identidade e autoria (`created_by`)
+
+Writes autorados (`write_note`, `add_task`, `daily_log`) recebem `created_by` resolvido **server-side**, nunca a partir de args do cliente. A ordem de resolução (trusted-proxy actor → WireGuard peer → stripped) está detalhada em [[Lox - Atribuicao de Identidade created_by]].
 
 ## Segurança: safePath()
 
@@ -27,16 +52,6 @@ Toda operação de filesystem passa pela funcao `safePath()` que:
 - Verifica que o caminho resultante esta **dentro** do diretório do vault (prefix check com `path.sep`)
 - Rejeita null bytes (`\0`) no path
 - Impede path traversal (`../`)
-
-## Transporte stdio over SSH
-
-O MCP Server nao roda como daemon -- e iniciado sob demanda pelo Claude Code via SSH:
-
-```
-ssh lox-vm "bash -c 'set -a && source /etc/lox/secrets.env && set +a && node ~/lox-brain/packages/core/dist/mcp/index.js'"
-```
-
-Isso significa que após deploy de código na VM, o processo antigo precisa ser morto (`pkill -f "packages/core"`) e o Claude Code precisa reconectar.
 
 ## Respostas otimizadas
 
@@ -48,11 +63,14 @@ Todos retornam `PaginatedResult { results, total, limit, offset }`.
 
 - depende de: [[Lox - Banco pgvector]], [[Lox - Servico de Embedding]]
 - protegido por: [[Lox - Seguranca Zero Trust]]
+- atribui autoria via: [[Lox - Atribuicao de Identidade created_by]]
 - parte de: [[Lox - Arquitetura Geral]]
 - contido em: [[Lox]]
 
 ## References
 
-- `packages/core/src/mcp/index.ts` (entry point, Pool config, env validation)
-- `packages/core/src/mcp/tools.ts` (createTools, safePath, 6 handlers)
+- `packages/core/src/mcp/index.ts` (entry point, seleção de transporte, sessões HTTP, `clientIpStorage`/`actorStorage`)
+- `packages/core/src/mcp/tools.ts` (createTools, safePath, handlers core)
+- `packages/core/src/mcp/transports.ts` (TransportConfig, getTransportConfig)
+- `packages/team/src/mcp-extensions/team-tools.ts` (team tools)
 - `packages/shared/src/types.ts` (SearchOptions, PaginatedResult)


### PR DESCRIPTION
Doc-only. Brings the zettelkasten notes in line with the current codebase (follows #187/#191/#192).

- **`mcp-server.md`** was substantially stale — claimed "6 tools" and stdio-over-SSH only. Now documents both transports (stdio for personal mode, HTTP/`StreamableHTTPServerTransport` for team mode), the full current tool set (11 core + 2 team), `safePath()`, and a pointer to the identity model.
- **`identidade-created-by.md`** (new atomic note) — the server-side `created_by` attribution model: resolution order trusted-proxy actor (`X-Lox-Proxy-Secret`/`X-Lox-Actor` gated by `LOX_TRUSTED_PROXY_SECRET`) → WireGuard peer (source IP) → stripped. Covers the #187 → #191 evolution and the trust boundary.
- **`_MOC.md`** — fixed the stale MCP line, added the new note to the index and graph, bumped the note count (14 → 15).

No secrets, IPs, project IDs, or customer topology added. Language pt-BR per the vault convention; scoped to `docs/zettelkasten/` (not ingested into any Obsidian vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)