### PR TITLE
feat(search): add recency sort to search_semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-08-07
+
+### Added
+- **`search_semantic` accepts `sort: 'recency'` — "which of the relevant notes is the latest?" is now answerable.** Ranking was purely cosine distance, with no notion of date at all. Against a vault holding dozens of near-identical meeting notes, the similarity scores are effectively a tie, so *which* of them survives the `LIMIT` is arbitrary — and no client could ask for the most recent one. That already cost a production bug in the chat client; fixing it in the tool rather than in each caller keeps the next consumer out of the same trap. `'recency'` runs in two stages: an inner query picks a candidate pool by similarity, the outer one reorders that pool by `updated_at DESC` (ties broken by similarity) and applies `limit`/`offset`. It is deliberately **not** `ORDER BY updated_at DESC` over the table, which would return the newest notes regardless of the query. The pool is `max((limit + offset) * 10, 100)` rows — an order of magnitude of headroom so the newest relevant note survives the cut, floored so that the default limit of 5 reranks 100 candidates rather than 50. Deriving the pool from the requested window instead of fixing it is what keeps deep pages reachable.
+
+  `total` keeps the same meaning in both modes — the number of rows matching the metadata filters, never the pool size. `COUNT(*) OVER()` sits inside the pool CTE, and Postgres evaluates window functions before that query level's `LIMIT`, so the pool cap does not silently truncate the count and break pagination. The one caveat inherent to any oversample-then-rerank scheme: a deeper page widens the pool, so pages are not strict continuations of each other. The `sort` value is validated against the two literals before any SQL is built (it never reaches the query text; the pool size is a bound parameter). Omitting `sort` is fully backward compatible — the emitted SQL and parameters are byte-identical to the previous behavior, which is asserted by a test.
+
 ## [0.16.0] — 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bash scripts/install.sh
 | `write_note` | Create or update a note in the vault |
 | `read_note` | Read the full content of a note by path |
 | `delete_note` | Delete a note from the vault and index |
-| `search_semantic` | Semantic search using embeddings (cosine similarity) |
+| `search_semantic` | Semantic search using embeddings (cosine similarity); `sort: 'recency'` reranks the relevant notes by date |
 | `search_text` | Full-text search using PostgreSQL tsvector |
 | `list_recent` | List recently modified notes |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -4342,7 +4342,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -5050,7 +5050,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -31,6 +31,21 @@ const RECENT_DEFAULTS: SearchOptions = {
 // can run.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * How many similarity-ranked rows to rerank by recency.
+ *
+ * Ten times the requested window so the newest relevant note survives the
+ * cut even when many near-identical notes crowd the top of the ranking —
+ * the failure mode this exists for (47 meeting notes, all a near-tie on
+ * cosine distance). The floor keeps small windows from reranking a pool too
+ * thin to contain that note: the default limit of 5 would otherwise look at
+ * 50 candidates. Deriving it from the window, rather than fixing it, is what
+ * keeps deep pages reachable.
+ */
+function candidatePoolSize(limit: number, offset: number): number {
+  return Math.max((limit + offset) * 10, 100);
+}
+
 export class DbClient {
   private readonly pool: Pool;
 
@@ -216,12 +231,35 @@ export class DbClient {
     }
   }
 
+  /**
+   * Semantic search over the vault.
+   *
+   * `sort: 'recency'` answers "which of the relevant notes is the latest?" —
+   * a question pure cosine ranking cannot answer at all. It runs in two
+   * stages: an inner query picks a candidate pool by similarity, the outer
+   * one reorders that pool by `updated_at`. It is deliberately NOT a plain
+   * `ORDER BY updated_at DESC` over the table, which would ignore the query.
+   *
+   * `total` keeps the same meaning in both modes — the number of rows
+   * matching the metadata filters, not the pool size. `COUNT(*) OVER()` sits
+   * inside the CTE, and Postgres evaluates window functions before that
+   * query level's `LIMIT`, so the pool cap does not truncate the count.
+   * Pagination stays reachable because the pool is derived from
+   * `limit + offset`, never a fixed constant. The one caveat of any
+   * oversample-then-rerank scheme: a deeper page widens the pool, so pages
+   * are not strict continuations of each other.
+   */
   async searchSemantic(
     embedding: number[],
     limitOrOptions: number | Partial<SearchOptions> = {},
   ): Promise<PaginatedResult<SearchResult>> {
     const opts = this.buildSearchOptions(limitOrOptions, SEMANTIC_DEFAULTS);
     if (opts.limit <= 0) throw new RangeError('limit must be a positive integer');
+
+    const sort = opts.sort ?? 'similarity';
+    if (sort !== 'similarity' && sort !== 'recency') {
+      throw new RangeError(`sort must be 'similarity' or 'recency', got: ${String(sort)}`);
+    }
 
     // $1 = embedding (vector), then dynamic params follow
     let paramIdx = 2;
@@ -231,19 +269,32 @@ export class DbClient {
     const filters = this.buildMetadataFilters(opts, paramIdx);
     paramIdx = filters.nextParamIndex;
 
+    const poolIdx = sort === 'recency' ? paramIdx++ : 0;
     const limitIdx = paramIdx++;
     const offsetIdx = paramIdx++;
 
     const whereClause = filters.clauses.length > 0 ? `WHERE ${filters.clauses.join(' AND ')}` : '';
 
-    const sql = `
+    const projection = `
       SELECT id, file_path, title, ${contentCol.sql}, tags,
              1 - (embedding <=> $1::vector) AS similarity,
              updated_at, created_by, area, source_type,
              COUNT(*) OVER() AS total_count
       FROM vault_embeddings
       ${whereClause}
-      ORDER BY embedding <=> $1::vector
+      ORDER BY embedding <=> $1::vector`;
+
+    const sql = sort === 'recency'
+      ? `
+      WITH candidates AS (${projection}
+      LIMIT $${poolIdx}
+      )
+      SELECT * FROM candidates
+      ORDER BY updated_at DESC, similarity DESC
+      LIMIT $${limitIdx}
+      OFFSET $${offsetIdx}
+    `
+      : `${projection}
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
     `;
@@ -252,6 +303,7 @@ export class DbClient {
       JSON.stringify(embedding),
       ...contentCol.params,
       ...filters.params,
+      ...(sort === 'recency' ? [candidatePoolSize(opts.limit, opts.offset)] : []),
       opts.limit,
       opts.offset,
     ];

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -143,6 +143,12 @@ export function createTools(
           content_preview_length: { type: 'number', description: 'Truncate content to N chars, 0 for full (default: 300)' },
           area: { type: 'string', description: "Filter by the note's `area` frontmatter field" },
           source_type: { type: 'string', description: "Filter by the note's `source_type` frontmatter field" },
+          sort: {
+            type: 'string',
+            enum: ['similarity', 'recency'],
+            description:
+              "How to order results (default: 'similarity'). Use 'recency' whenever the question is about the latest of something — \"the last 1:1\", \"our most recent decision on X\", \"what did we discuss yesterday\" — otherwise the newest note is easily outranked by an older, slightly more similar one. It ranks the semantically relevant notes by date, not the whole vault: the query still decides which notes are candidates. Keep 'similarity' for topical questions where date does not matter.",
+          },
         },
         required: ['query'],
       },
@@ -159,6 +165,7 @@ export function createTools(
           contentPreviewLength: (args.content_preview_length as number | undefined) ?? 300,
           area: args.area as string | undefined,
           source_type: args.source_type as string | undefined,
+          sort: args.sort as SearchOptions['sort'],
         };
 
         const embedding = await embeddingService.generateEmbedding(query);

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -338,6 +338,102 @@ describe('DbClient', () => {
     });
   });
 
+  describe('searchSemantic with sort', () => {
+    it('should produce the exact same SQL for sort omitted and sort=similarity', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0 });
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'similarity' });
+
+      const [defaultSql, defaultParams] = mockPool.query.mock.calls[0];
+      const [explicitSql, explicitParams] = mockPool.query.mock.calls[1];
+      expect(explicitSql).toBe(defaultSql);
+      expect(explicitParams).toEqual(defaultParams);
+      expect(defaultSql).not.toContain('candidates');
+    });
+
+    it('should rerank a similarity-selected candidate pool by updated_at when sort=recency', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
+
+      const [sql] = mockPool.query.mock.calls[0];
+      // Inner stage: still selects candidates by cosine distance.
+      expect(sql).toContain('WITH candidates AS');
+      expect(sql).toContain('ORDER BY embedding <=> $1::vector');
+      // Outer stage: reorders that pool by recency.
+      expect(sql).toContain('FROM candidates');
+      expect(sql).toMatch(/ORDER BY updated_at DESC, similarity DESC/);
+    });
+
+    it('should size the candidate pool from limit+offset with a floor of 100', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
+      const [, smallParams] = mockPool.query.mock.calls[0];
+      expect(smallParams).toContain(100);
+
+      await client.searchSemantic([0.1], { limit: 50, offset: 200, sort: 'recency' });
+      const [, largeParams] = mockPool.query.mock.calls[1];
+      expect(largeParams).toContain(2500);
+    });
+
+    it('should pass the candidate pool size as a bound parameter, never inlined', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
+
+      const [sql] = mockPool.query.mock.calls[0];
+      expect(sql).not.toContain('LIMIT 100');
+      expect(sql).toMatch(/LIMIT \$\d+/);
+    });
+
+    it('should count all filter-matched rows inside the pool CTE, not the pool itself', async () => {
+      mockPool.query.mockResolvedValue({
+        rows: [{
+          id: 'id1', file_path: 'a.md', title: 'A', content: null, tags: [],
+          similarity: 0.9, updated_at: new Date(), total_count: '4711',
+        }],
+      });
+
+      const result = await client.searchSemantic([0.1], { limit: 5, sort: 'recency' });
+
+      // COUNT(*) OVER() must sit in the CTE, where window functions are
+      // evaluated before its LIMIT, so it reports the real match count.
+      const [sql] = mockPool.query.mock.calls[0];
+      const cteBody = sql.slice(sql.indexOf('WITH candidates AS'), sql.indexOf('FROM candidates'));
+      expect(cteBody).toContain('COUNT(*) OVER() AS total_count');
+      expect(result.total).toBe(4711);
+    });
+
+    it('should keep metadata filters inside the candidate pool', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, sort: 'recency', area: 'work', source_type: 'meeting' });
+
+      const [sql, params] = mockPool.query.mock.calls[0];
+      const cteBody = sql.slice(0, sql.indexOf('FROM candidates'));
+      expect(cteBody).toContain('WHERE area = $2 AND source_type = $3');
+      expect(params).toEqual([JSON.stringify([0.1]), 'work', 'meeting', 100, 5, 0]);
+    });
+
+    it('should honour includeContent in recency mode', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, sort: 'recency', includeContent: true, contentPreviewLength: 200 });
+
+      const [sql] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('LEFT(content, $2) AS content');
+    });
+
+    it('should reject a sort value outside the two literals without querying', async () => {
+      await expect(
+        client.searchSemantic([0.1], { limit: 5, sort: 'updated_at DESC --' as never }),
+      ).rejects.toThrow(/sort must be 'similarity' or 'recency'/);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getFileHash', () => {
     it('should return hash string for known file', async () => {
       mockPool.query.mockResolvedValue({

--- a/packages/core/tests/mcp/mcp-tools.test.ts
+++ b/packages/core/tests/mcp/mcp-tools.test.ts
@@ -193,6 +193,39 @@ describe('createTools', () => {
     });
   });
 
+  describe('search_semantic sort param', () => {
+    it('should forward sort to dbClient when provided', async () => {
+      const tools = createTools(dbClient, embeddingService, tempVaultPath);
+      const tool = tools.find((t) => t.name === 'search_semantic')!;
+
+      await tool.handler({ query: 'last retro', sort: 'recency' });
+
+      expect(dbClient.searchSemantic).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ sort: 'recency' }),
+      );
+    });
+
+    it('should not force a sort when omitted', async () => {
+      const tools = createTools(dbClient, embeddingService, tempVaultPath);
+      const tool = tools.find((t) => t.name === 'search_semantic')!;
+
+      await tool.handler({ query: 'test' });
+
+      const [, options] = vi.mocked(dbClient.searchSemantic).mock.calls[0];
+      expect((options as Record<string, unknown>).sort).toBeUndefined();
+    });
+
+    it('should expose sort as an enum in inputSchema with recency guidance', () => {
+      const tools = createTools(dbClient, embeddingService, tempVaultPath);
+      const tool = tools.find((t) => t.name === 'search_semantic')!;
+      const sortProp = (tool.inputSchema as any).properties.sort;
+
+      expect(sortProp.enum).toEqual(['similarity', 'recency']);
+      expect(sortProp.description).toMatch(/recen|latest|last/i);
+    });
+  });
+
   describe('search_text handler', () => {
     it('should call dbClient.searchText with query and options', async () => {
       const mockPaginated = {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,6 +21,8 @@ export interface NoteRow {
   source_type?: string | null;
 }
 
+export type SearchSort = 'similarity' | 'recency';
+
 export interface SearchOptions {
   limit: number;
   offset: number;
@@ -28,6 +30,10 @@ export interface SearchOptions {
   contentPreviewLength: number; // 0 = full content, >0 = truncate at N chars
   area?: string;
   source_type?: string;
+  // Semantic search only. 'similarity' (default) ranks purely by cosine
+  // distance; 'recency' reranks a similarity-selected candidate pool by
+  // updated_at. See DbClient.searchSemantic.
+  sort?: SearchSort;
 }
 
 export interface PaginatedResult<T> {


### PR DESCRIPTION
## Problem

`search_semantic` ranked purely by cosine distance, with no notion of date. Against a vault holding dozens of near-identical meeting notes the similarity scores are effectively a tie, so *which* of them survives the `LIMIT` is arbitrary — and no client could ask for the most recent one.

This already cost a production bug: the Credifit chat client reported the latest Weekly Meeting as 2026-04-27 when 47 notes existed and the newest was 2026-08-03. Fixing it in the tool rather than in each caller keeps the next consumer out of the same trap.

## Change

`search_semantic` accepts `sort: 'similarity' | 'recency'`. Default and omitted behave exactly as before.

`'recency'` runs in two stages — an inner query picks a candidate pool by similarity, the outer one reorders that pool by `updated_at DESC` (ties broken by similarity) and applies `limit`/`offset`:

```sql
WITH candidates AS (
  SELECT ..., 1 - (embedding <=> $1::vector) AS similarity,
         COUNT(*) OVER() AS total_count
  FROM vault_embeddings
  WHERE <filters>
  ORDER BY embedding <=> $1::vector
  LIMIT $pool
)
SELECT * FROM candidates
ORDER BY updated_at DESC, similarity DESC
LIMIT $limit OFFSET $offset
```

It is deliberately **not** `ORDER BY updated_at DESC` over the table, which would return the newest notes regardless of the query. The pool is `max((limit + offset) * 10, 100)`, derived from the requested window rather than fixed, so deep pages stay reachable.

## Notes for review

- **`total` is unchanged in meaning** — rows matching the metadata filters, never the pool size. `COUNT(*) OVER()` sits inside the CTE, and Postgres evaluates window functions before that query level's `LIMIT`, so the pool cap cannot truncate the count. Verified against a real `postgres:16` instance during review, not just by reading the docs.
- **Backward compatible**: omitting `sort` emits byte-identical SQL and parameters, asserted by a test.
- **Validation**: `sort` is compared against the two literals and throws `RangeError` before any SQL is built; it never reaches the query text, and the pool size is a bound parameter.
- **Known caveat**: a deeper page widens the pool, so pages are not strict continuations of each other — inherent to any oversample-then-rerank scheme, documented in the JSDoc and CHANGELOG.

## Follow-ups (not blocking, from review)

- No upper clamp on pool size; `limit` itself has no clamp either (pre-existing, this multiplies it 10x). Low severity given VPN-only access.
- The `COUNT(*) OVER()` + `LIMIT` guarantee has no integration test — the repo has no integration-test tooling today.

## Verification

- `npm run test --workspace=packages/core` — 337 passed (326 before, 11 new)
- Coverage: `db-client.ts` 83.6% branch / `tools.ts` 91.3% branch, above the 80% gate
- Type check per package (with `packages/shared` built first): `shared` OK, `core` OK. `team`/`installer` failures are pre-existing (`jsonwebtoken` absent from `node_modules`).
- Version 0.16.0 → 0.17.0 (minor, feature) in root + core + shared + installer; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)