### PR TITLE
fix(search): resize every ivfflat index, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.1] — 2026-08-07
+
+### Fixed
+- **v0.18.0's index resize repaired the wrong index on hosts that have two, so production recall never moved — still ~1%.** `vault_embeddings` can carry *two* ivfflat indexes over the same column: `infra/postgres/schema.sql` creates `idx_vault_embeddings_embedding` and the installer's VM setup created `idx_embedding_cosine`, both `IF NOT EXISTS`, both `WITH (lists = 100)`. `IF NOT EXISTS` matches on name, not definition, so a host that ran both ended up with two copies — every write maintaining both, the planner using one. `reindexEmbeddings()` selected the index with `LIMIT 1`, resized whichever the catalog happened to return, and derived `probes` from *that* index's `lists`. On the deployed VM it fixed `idx_embedding_cosine` while the planner kept using `idx_vault_embeddings_embedding` at `lists = 100`, and set `probes = ceil(sqrt(1)) = 1` from the wrong geometry. The boot log said `lists 100 -> 1 (index rebuilt), probes 1` and read as success.
+
+  `reindexEmbeddings()` now processes **every** ivfflat index on the table (`ORDER BY indexname`, no `LIMIT`), resizing each against the same row count, and derives `probes` from the **widest** resulting `lists` rather than from any single index. The max matters in a reachable case: `probes` is one setting shared by whichever index the planner picks, and two indexes can legitimately end a pass at different sizes — at 60k rows the target is 60, so an index already at 100 stays put (inside the 2× hysteresis band) while one at 1 is rebuilt to 60. `ceil(sqrt(100)) = 10` serves both; `ceil(sqrt(60)) = 8` would under-probe the wider one, and under-probing is the silent failure this whole path exists to prevent. Over-probing only costs latency — pgvector caps probes at `lists`.
+
+  The boot log now names each index — `ivfflat: 5000 rows, 2 index(es) [idx_embedding_cosine lists 5; idx_vault_embeddings_embedding lists 100 -> 5 (rebuilt)], probes 3` — and warns explicitly when more than one exists, since the duplicate is itself a defect worth seeing. Logging one line in the singular is what let a half-applied fix look complete.
+
+  The installer now creates the three indexes under the same names as `schema.sql` (`idx_vault_embeddings_embedding`, `idx_vault_embeddings_tags`, `idx_vault_embeddings_updated_at`; previously `idx_embedding_cosine`, `idx_tags`, `idx_updated_at`) with `lists = 1`, so a fresh install cannot produce the duplicate through either path. `schema.sql`'s names win because every sibling index there already follows that convention and because it is the name in use on deployed hosts — converging on it avoids inventing a third state. The GIN and btree indexes had the identical name split and the identical duplication, just without a recall symptom; they are unified in the same pass. De-duplicating **existing** deployments (dropping the extra index) is deliberately not automated here.
+
+  Verified against `pgvector/pgvector:pg16` with the deployed shape reproduced — 5000 rows, two ivfflat indexes. Half-fixed state as input (one index at `lists=5`, one at `100`, the exact v0.18.0 outcome): the planner chose the oversized one and `EXPLAIN ANALYZE` showed the scan stopping at **812 of 5000 rows**. After this fix both indexes sit at `lists=5`, `probes=3` is inherited by a brand-new pool, and the same scan reaches the full **2000** rows requested.
+
 ## [0.18.0] — 2026-08-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -4342,7 +4342,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -5050,7 +5050,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -7,13 +7,20 @@ import {
   needsResize, parseLists, probesFor, quoteIdent, rewriteLists, setProbesSql, targetLists,
 } from './ivfflat.js';
 
+/** What happened to one ivfflat index. */
+export interface IvfflatIndexState {
+  name: string;
+  listsBefore: number;
+  listsAfter: number;
+  resized: boolean;
+}
+
 /** Outcome of {@link DbClient.reindexEmbeddings}, for the boot log. */
 export interface IvfflatState {
   rows: number;
-  listsBefore: number;
-  listsAfter: number;
+  /** Every ivfflat index on the table. More than one means duplicates exist. */
+  indexes: IvfflatIndexState[];
   probes: number;
-  resized: boolean;
   /** False when the role does not own the database; probes stays at pgvector's default. */
   probesApplied: boolean;
 }
@@ -233,13 +240,21 @@ export class DbClient {
   }
 
   /**
-   * Rebuild the ivfflat index, resizing it to the current row count first.
+   * Rebuild the table's ivfflat indexes, resizing each to the current row count.
    *
-   * A plain `REINDEX` rebuilds the index with whatever `lists` it already has,
-   * so an index sized for the wrong volume stays wrong forever — see
-   * `lib/ivfflat.ts` for why that silently caps recall. Returns what it did so
-   * the caller can log it (the absence of that log is what kept the
-   * mis-sizing invisible), or `null` when the table has no ivfflat index.
+   * A plain `REINDEX` rebuilds an index with whatever `lists` it already has,
+   * so one sized for the wrong volume stays wrong forever — see
+   * `lib/ivfflat.ts` for why that silently caps recall.
+   *
+   * Handles *every* ivfflat index on the table, not the first one found. Two
+   * creation paths named the same index differently (`schema.sql` and the
+   * installer), so a host that ran both carries two indexes over the same
+   * column; picking one arbitrarily resized whichever the planner was not
+   * using and derived `probes` from it, which is how v0.18.0 reported success
+   * while production recall stayed at ~1%.
+   *
+   * Returns what it did so the caller can log it, or `null` when the table has
+   * no ivfflat index.
    */
   async reindexEmbeddings(): Promise<IvfflatState | null> {
     const result = await this.pool.query(`
@@ -248,44 +263,59 @@ export class DbClient {
       FROM pg_indexes
       WHERE tablename = 'vault_embeddings'
         AND indexdef LIKE '%ivfflat%'
-      LIMIT 1
+      ORDER BY indexname
     `);
     if (result.rows.length === 0) return null;
 
-    const { indexname, indexdef, database } = result.rows[0];
     const rows = Number(result.rows[0].row_count);
-    const listsBefore = parseLists(indexdef);
+    const database = result.rows[0].database;
     const target = targetLists(rows);
-    const quoted = quoteIdent(indexname);
 
-    const resized = needsResize(listsBefore, target);
-    if (resized) {
-      // DROP + CREATE (not CONCURRENTLY) holds an ACCESS EXCLUSIVE lock on the
-      // table for the duration. That is imperceptible at vault scale and this
-      // runs at boot, before the server accepts requests — but on a table large
-      // enough for the rebuild to take minutes, writes would block for that long.
-      // The transaction is what keeps a failed CREATE from leaving the table with
-      // no index at all: the caller only logs a warning, so that loss would be
-      // permanent and silent.
-      const client = await this.pool.connect();
-      try {
-        await client.query('BEGIN');
-        await client.query(`DROP INDEX ${quoted}`);
-        await client.query(rewriteLists(indexdef, target));
-        await client.query('COMMIT');
-      } catch (err) {
-        await client.query('ROLLBACK').catch(() => { /* connection already broken */ });
-        throw err;
-      } finally {
-        client.release();
+    const indexes: IvfflatIndexState[] = [];
+    for (const { indexname, indexdef } of result.rows) {
+      const listsBefore = parseLists(indexdef);
+      const resized = needsResize(listsBefore, target);
+      if (resized) {
+        await this.rebuildIndex(indexname, indexdef, target);
+      } else {
+        await this.pool.query(`REINDEX INDEX ${quoteIdent(indexname)}`);
       }
-    } else {
-      await this.pool.query(`REINDEX INDEX ${quoted}`);
+      indexes.push({ name: indexname, listsBefore, listsAfter: resized ? target : listsBefore, resized });
     }
 
-    const listsAfter = resized ? target : listsBefore;
-    const probes = probesFor(listsAfter);
-    return { rows, listsBefore, listsAfter, probes, resized, probesApplied: await this.setProbes(database, probes) };
+    // `probes` is one setting shared by whichever index the planner picks, so
+    // it is derived from the widest one rather than from any single index.
+    // Over-probing costs latency and pgvector caps it at `lists`; under-probing
+    // silently drops rows, which is the failure this whole path exists to fix.
+    // After a successful pass every index sits at `target` and the max is that
+    // — the spread only matters when one of them could not be resized.
+    const probes = probesFor(Math.max(...indexes.map((i) => i.listsAfter)));
+    return { rows, indexes, probes, probesApplied: await this.setProbes(database, probes) };
+  }
+
+  /**
+   * DROP + CREATE (not CONCURRENTLY) holds an ACCESS EXCLUSIVE lock on the
+   * table for the duration. That is imperceptible at vault scale and this runs
+   * at boot, before the server accepts requests — but on a table large enough
+   * for the rebuild to take minutes, writes would block for that long.
+   *
+   * The transaction is what keeps a failed CREATE from leaving the table with
+   * no index at all: the caller only logs a warning, so that loss would be
+   * permanent and silent.
+   */
+  private async rebuildIndex(name: string, indexdef: string, lists: number): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(`DROP INDEX ${quoteIdent(name)}`);
+      await client.query(rewriteLists(indexdef, lists));
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => { /* connection already broken */ });
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   /**

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -186,15 +186,30 @@ async function main(): Promise<void> {
     if (state === null) {
       console.error('ivfflat: no embedding index on vault_embeddings, nothing to reindex');
     } else {
-      const lists = state.resized
-        ? `lists ${state.listsBefore} -> ${state.listsAfter} (index rebuilt)`
-        : `lists ${state.listsAfter}`;
-      console.error(`ivfflat: ${state.rows} rows, ${lists}, probes ${state.probes}`);
+      // Every index is named individually. v0.18.0 logged one line in the
+      // singular, which read as success while it had resized an index the
+      // planner was not using.
+      const summary = state.indexes
+        .map((i) => (i.resized
+          ? `${i.name} lists ${i.listsBefore} -> ${i.listsAfter} (rebuilt)`
+          : `${i.name} lists ${i.listsAfter}`))
+        .join('; ');
+      console.error(
+        `ivfflat: ${state.rows} rows, ${state.indexes.length} index(es) [${summary}], probes ${state.probes}`,
+      );
+      if (state.indexes.length > 1) {
+        console.error(
+          `Warning: vault_embeddings carries ${state.indexes.length} ivfflat indexes ` +
+            `(${state.indexes.map((i) => i.name).join(', ')}). They are duplicates of each other: ` +
+            `every write maintains all of them and the planner uses only one. This happens on hosts ` +
+            `that ran both infra/postgres/schema.sql and the installer, which used different names ` +
+            `for the same index before v0.18.1. Dropping the extras is safe but not automatic.`,
+        );
+      }
       if (!state.probesApplied) {
         console.error(
           `Warning: could not set ivfflat.probes (requires ownership of the database). ` +
-            `Semantic search runs at pgvector's default of 1 probe, which reads one of ` +
-            `${state.listsAfter} index clusters. Run as the database owner: ` +
+            `Semantic search runs at pgvector's default of 1 probe. Run as the database owner: ` +
             `ALTER DATABASE <db> SET ivfflat.probes = ${state.probes};`,
         );
       }

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -671,14 +671,15 @@ describe('DbClient', () => {
   });
 
   describe('reindexEmbeddings', () => {
-    const indexRow = (lists: number | null, rowCount: number) => ({
-      indexname: 'idx_embedding',
+    const named = (name: string, lists: number | null, rowCount: number) => ({
+      indexname: name,
       database: 'lox_brain',
       indexdef: lists === null
-        ? 'CREATE INDEX idx_embedding ON public.vault_embeddings USING ivfflat (embedding vector_cosine_ops)'
-        : `CREATE INDEX idx_embedding ON public.vault_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists='${lists}')`,
+        ? `CREATE INDEX ${name} ON public.vault_embeddings USING ivfflat (embedding vector_cosine_ops)`
+        : `CREATE INDEX ${name} ON public.vault_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists='${lists}')`,
       row_count: String(rowCount),
     });
+    const indexRow = (lists: number | null, rowCount: number) => named('idx_embedding', lists, rowCount);
 
     /** Statements issued on the pool after the catalog lookup. */
     const poolStatements = () => mockPool.query.mock.calls.slice(1).map((c: any[]) => c[0]);
@@ -698,7 +699,10 @@ describe('DbClient', () => {
       ]);
       expect(mockClient.query).not.toHaveBeenCalled();
       expect(state).toEqual({
-        rows: 812, listsBefore: 1, listsAfter: 1, probes: 1, resized: false, probesApplied: true,
+        rows: 812,
+        indexes: [{ name: 'idx_embedding', listsBefore: 1, listsAfter: 1, resized: false }],
+        probes: 1,
+        probesApplied: true,
       });
     });
 
@@ -717,8 +721,67 @@ describe('DbClient', () => {
       ]);
       expect(mockClient.release).toHaveBeenCalled();
       expect(state).toEqual({
-        rows: 812, listsBefore: 100, listsAfter: 1, probes: 1, resized: true, probesApplied: true,
+        rows: 812,
+        indexes: [{ name: 'idx_embedding', listsBefore: 100, listsAfter: 1, resized: true }],
+        probes: 1,
+        probesApplied: true,
       });
+    });
+
+    it('should resize EVERY ivfflat index, not just the first one found', async () => {
+      // Exactly the deployed VM: schema.sql and the installer each created an
+      // ivfflat index over `embedding` under a different name. v0.18.0 took
+      // `LIMIT 1`, resized whichever came back, and left the one the planner
+      // actually used at lists=100 — reporting success the whole time.
+      mockPool.query
+        .mockResolvedValueOnce({
+          rows: [named('idx_embedding_cosine', 1, 812), named('idx_vault_embeddings_embedding', 100, 812)],
+        })
+        .mockResolvedValue({ rowCount: 0 });
+      mockClient.query.mockResolvedValue({ rowCount: 0 });
+
+      const state = await client.reindexEmbeddings();
+
+      // A mock returns both rows no matter what the SQL says, so the catalog
+      // query is asserted directly: `LIMIT 1` is the defect itself, and the
+      // ordering is what makes the reported list deterministic.
+      const catalogSql = mockPool.query.mock.calls[0][0];
+      expect(catalogSql).not.toMatch(/LIMIT\s+1/i);
+      expect(catalogSql).toMatch(/ORDER BY\s+indexname/i);
+
+      expect(state!.indexes).toEqual([
+        { name: 'idx_embedding_cosine', listsBefore: 1, listsAfter: 1, resized: false },
+        { name: 'idx_vault_embeddings_embedding', listsBefore: 100, listsAfter: 1, resized: true },
+      ]);
+      // The already-correct one is reindexed in place; the oversized one rebuilt.
+      expect(poolStatements()).toEqual([
+        'REINDEX INDEX "idx_embedding_cosine"',
+        'ALTER DATABASE "lox_brain" SET ivfflat.probes = 1',
+        'SET ivfflat.probes = 1',
+      ]);
+      expect(mockClient.query.mock.calls.map((c: any[]) => c[0])).toEqual([
+        'BEGIN',
+        'DROP INDEX "idx_vault_embeddings_embedding"',
+        'CREATE INDEX idx_vault_embeddings_embedding ON public.vault_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 1)',
+        'COMMIT',
+      ]);
+    });
+
+    it('should derive probes from the widest index when they end up disagreeing', async () => {
+      // 60k rows -> target 60. An index at 100 is inside the hysteresis band
+      // (100/60 < 2) so it keeps lists=100, while one at 1 is rebuilt to 60.
+      // probes must serve whichever the planner picks: ceil(sqrt(100)) = 10,
+      // not ceil(sqrt(60)) = 8. Under-probing is the silent failure.
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [named('a_wide', 100, 60_000), named('b_narrow', 1, 60_000)] })
+        .mockResolvedValue({ rowCount: 0 });
+      mockClient.query.mockResolvedValue({ rowCount: 0 });
+
+      const state = await client.reindexEmbeddings();
+
+      expect(state!.indexes.map((i) => i.listsAfter)).toEqual([100, 60]);
+      expect(state!.probes).toBe(10);
+      expect(poolStatements()).toContain('ALTER DATABASE "lox_brain" SET ivfflat.probes = 10');
     });
 
     it('should grow lists and probes together as the vault grows', async () => {
@@ -732,7 +795,7 @@ describe('DbClient', () => {
         'ALTER DATABASE "lox_brain" SET ivfflat.probes = 7',
         'SET ivfflat.probes = 7',
       ]);
-      expect(state).toMatchObject({ listsAfter: 40, probes: 7, resized: true });
+      expect(state).toMatchObject({ probes: 7, indexes: [{ listsAfter: 40, resized: true }] });
     });
 
     it('should assume pgvector\'s default lists when the index carries no reloption', async () => {
@@ -742,7 +805,7 @@ describe('DbClient', () => {
       const state = await client.reindexEmbeddings();
 
       expect(mockClient.query.mock.calls[2][0]).toMatch(/WITH \(lists = 1\)$/);
-      expect(state).toMatchObject({ listsBefore: 100, resized: true });
+      expect(state).toMatchObject({ indexes: [{ listsBefore: 100, resized: true }] });
     });
 
     it('should roll back and rethrow when the rebuild fails', async () => {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/installer/src/steps/step-vm-setup.ts
+++ b/packages/installer/src/steps/step-vm-setup.ts
@@ -316,7 +316,13 @@ function buildDbSetupScript(dbPassword: string): string {
     // Enable pgvector extension (already idempotent)
     `sudo -u postgres psql -d ${DB_NAME} -c "CREATE EXTENSION IF NOT EXISTS vector;"`,
 
-    // Apply schema (already idempotent — all IF NOT EXISTS)
+    // Apply schema (already idempotent — all IF NOT EXISTS).
+    // Index names MUST match infra/postgres/schema.sql exactly. `IF NOT EXISTS`
+    // matches on name, not on definition, so a host that runs both this step and
+    // schema.sql gets one index per name — two copies of the same index over the
+    // same column. That is what happened to the ivfflat index before v0.18.1:
+    // every write maintained both, the planner used one, and the boot-time
+    // resizer fixed the other.
     `sudo -u postgres psql -d ${DB_NAME} -c "
       CREATE TABLE IF NOT EXISTS vault_embeddings (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -332,9 +338,9 @@ function buildDbSetupScript(dbPassword: string): string {
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         UNIQUE (file_path, chunk_index)
       );
-      CREATE INDEX IF NOT EXISTS idx_embedding_cosine ON vault_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
-      CREATE INDEX IF NOT EXISTS idx_tags ON vault_embeddings USING gin (tags);
-      CREATE INDEX IF NOT EXISTS idx_updated_at ON vault_embeddings (updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_embedding ON vault_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 1);
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_tags ON vault_embeddings USING gin (tags);
+      CREATE INDEX IF NOT EXISTS idx_vault_embeddings_updated_at ON vault_embeddings (updated_at DESC);
     "`,
   ].join(' && ');
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.18.0 shipped, deployed, and did nothing

Recall in production is still ~1%. The fix repaired an index the planner does not use.

`vault_embeddings` carries **two** ivfflat indexes over the same column:

| Creator | Name | |
|---|---|---|
| `infra/postgres/schema.sql` | `idx_vault_embeddings_embedding` | `WITH (lists = 100)` |
| `packages/installer` VM setup | `idx_embedding_cosine` | `WITH (lists = 100)` |

Both `IF NOT EXISTS`, which matches on **name**, not definition — so a host that ran both kept two copies of the same index. Every write maintains both; the planner uses one.

`reindexEmbeddings()` selected with `LIMIT 1`, resized whichever the catalog returned, and derived `probes` from *that* index's `lists`. On the deployed VM:

```
index = idx_vault_embeddings_embedding ... WITH (lists='100')   <- planner uses this
      | idx_embedding_cosine           ... WITH (lists='1')     <- v0.18.0 resized this
probes = 1                                                       <- ceil(sqrt(1)), wrong geometry

EXPLAIN: Index Scan using idx_vault_embeddings_embedding ... rows=11
```

Boot logged `ivfflat: 812 rows, lists 100 -> 1 (index rebuilt), probes 1` and read as success. Which index gets picked is catalog scan order, so the same release can appear to work on one host and not another — reproduced both outcomes locally.

## Fix

- `reindexEmbeddings()` processes **every** ivfflat index on the table (`ORDER BY indexname`, no `LIMIT`), resizing each against the same row count.
- `probes` derives from the **widest** resulting `lists`, not from any single index. This matters in a reachable case: at 60k rows the target is 60, so an index already at 100 stays put inside the 2× hysteresis band while one at 1 is rebuilt to 60. `ceil(sqrt(100)) = 10` serves both; `ceil(sqrt(60)) = 8` would under-probe the wider one. Over-probing only costs latency — pgvector caps probes at `lists`.
- Boot log names each index and warns when more than one exists: `ivfflat: 5000 rows, 2 index(es) [idx_embedding_cosine lists 5; idx_vault_embeddings_embedding lists 100 -> 5 (rebuilt)], probes 3`. Logging in the singular is what let a half-applied fix look complete.
- The installer creates all three indexes under `schema.sql`'s names (`idx_vault_embeddings_embedding`, `idx_vault_embeddings_tags`, `idx_vault_embeddings_updated_at`) with `lists = 1`, so a fresh install cannot duplicate through either path. `schema.sql`'s names win because they are the ones on deployed hosts — converging avoids inventing a third state.

De-duplicating **existing** deployments is deliberately not automated; the boot warning surfaces it and dropping the extra is an operator decision.

## Verification

Independently reproduced by the reviewer against `pgvector/pgvector:pg16`, 812 rows, two ivfflat indexes at `lists=100` — the deployed shape.

Baseline, running the **v0.18.0** build against that fixture:

```
indexes before: idx_embedding_cosine=100  idx_vault_embeddings_embedding=100
reindexEmbeddings(): {listsBefore:100, listsAfter:1, resized:true, probesApplied:true}
indexes after : idx_embedding_cosine=100  idx_vault_embeddings_embedding=1   <- one left behind
```

Same fixture, this branch:

```
indexes before: idx_embedding_cosine=100  idx_vault_embeddings_embedding=100
reindexEmbeddings(): {rows:812, indexes:[
  {name:"idx_embedding_cosine", listsBefore:100, listsAfter:1, resized:true},
  {name:"idx_vault_embeddings_embedding", listsBefore:100, listsAfter:1, resized:true}],
  probes:1, probesApplied:true}
indexes after : idx_embedding_cosine=1  idx_vault_embeddings_embedding=1
  limit=5  -> total=812 returned=5
  limit=20 -> total=812 returned=20
```

## Gates

- 359 tests passed (357 before), including one that builds two differently-named ivfflat indexes and asserts both end correct — a single-index test passes with the bug present, which is exactly what happened
- Type check per package: `shared` OK, `core` OK
- Coverage 91.89% lines / 89.73% branch
- 0.18.0 → 0.18.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)