### PR TITLE
fix(search): rank recency by the note's own date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-08-08
+
+### Fixed
+- **`sort: 'recency'` ranked by when a note was last written to the index, not by the date the note is about.** `updated_at` records ingestion time. For the question the parameter exists to answer — "what was the last Weekly Meeting?" — those are different values, and only one is right. It looked correct because the watcher skips unchanged files, so a note written once keeps an `updated_at` near its creation date. Any bulk rewrite breaks that correlation across the whole vault at once, silently: `npm run index-vault` (a documented command), a backfill that recreates notes, a vault-wide retag. The Credifit vault was already in that state — all 813 rows stamped inside a 20-minute window by the calendar backfill, two seconds apart, so recency ordering there was *ingestion order*, returning the right answer only because the backfill happened to run chronologically. Reproduced against `pgvector/pgvector:pg16` with that exact shape: the query for "Weekly Meeting" returned **2026-06-01 first and 2026-08-03 third** — the oldest meeting on top, because it was ingested last. After the fix the same rows come back 2026-08-03, 2026-07-06, 2026-06-01, with the scrambled `updated_at` no longer able to influence the answer.
+
+  Recency now orders by the date the note declares in its own filename (`YYYY-MM-DD Title.md`, the convention the vault already follows), falling back to `updated_at` only for notes that declare none — "newest by the date the note claims, or by when it last changed if it claims none". Deliberately **not** a `note_date` column: that needs a migration, a backfill over 6672 rows and frontmatter parsing, and the filename convention is what is actually in use. The recency path already sorts a bounded candidate pool, so an unindexed expression costs nothing measurable there.
+
+  The extracted date is compared **as text, never cast to `date`**. Issue #200 proposed `to_date(substring(file_path from '(\d{4}-\d{2}-\d{2})'), 'YYYY-MM-DD')`; against the seeded table that raises `date/time field value out of range: "2026-13-45"` and fails the entire search — one junk filename anywhere in the vault would take recency search down completely. Tightening the regex is necessary but not sufficient: `2026-02-30 x.md` matches any plausible-date pattern and still throws, because it is well-formed and merely nonexistent. Zero-padded `YYYY-MM-DD` sorts identically as text and as a date, so the cast bought nothing it could not lose; `COLLATE "C"` keeps that true under a collation that would otherwise reweight the hyphens. The pattern admits only a real month (`01`–`12`) and day (`01`–`31`) so that `9999-99-99 junk.md` cannot outrank every real note, and is anchored with `[^/]*$` to the last path segment so a dated folder is not mistaken for the note's own date. Verified on Postgres 16: `2026-13-45`, `9999-99-99`, `2026-00-00`, `2026-8-3`, `20260803` and `Journal/2026-12-31/note.md` all fall through to `updated_at`; `2026-01-01 Planning/2026-08-03 Weekly.md` resolves to the note's date, not the folder's.
+
+  The `'similarity'` path (the default) is byte-identical — same SQL, same parameters — and a test enforces that. The `sort` description in `search_semantic`'s `inputSchema`, which the model reads to decide when to use it, now says which date it ranks by.
+
 ## [0.18.1] — 2026-08-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -67,6 +67,40 @@ function candidatePoolSize(limit: number, offset: number): number {
   return Math.max((limit + offset) * 10, 100);
 }
 
+/**
+ * Extracts the date a note declares in its own filename (`YYYY-MM-DD Title.md`).
+ *
+ * `[^/]*$` confines the match to the last path segment, so a dated folder above
+ * the note is not mistaken for the note's date, and a note inside one still
+ * sorts by its own.
+ *
+ * The month and day alternations are not decoration. Whatever this yields is
+ * used as a sort key without a cast, and the wider `\d{2}-\d{2}` would let
+ * `9999-99-99 junk.md` outrank every real note in the vault.
+ */
+export const NOTE_DATE_PATTERN = '(\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01]))[^/]*$';
+
+/**
+ * The sort key behind `sort: 'recency'`: the date the note declares, or the
+ * time it last changed if it declares none.
+ *
+ * `updated_at` alone answers a different question — when the row was last
+ * written to the *index*, which any bulk reindex (`npm run index-vault`, a
+ * calendar backfill) resets across the whole vault at once, silently turning
+ * "newest note" into "last row ingested". See issue #200.
+ *
+ * Compared as text and never cast: `to_date` raises 22008 on an impossible
+ * date, so one `2026-02-30 x.md` in the vault would take down every recency
+ * search — and no regex can rule that case out, because it is well-formed and
+ * merely nonexistent. Zero-padded `YYYY-MM-DD` orders identically as text and
+ * as a date, so the cast buys nothing; `COLLATE "C"` keeps that true under a
+ * collation that would otherwise reweight the hyphens.
+ */
+const NOTE_DATE_SQL = `COALESCE(
+        substring(file_path from '${NOTE_DATE_PATTERN}'),
+        to_char(updated_at, 'YYYY-MM-DD')
+      ) COLLATE "C"`;
+
 export class DbClient {
   private readonly pool: Pool;
 
@@ -349,8 +383,10 @@ export class DbClient {
    * `sort: 'recency'` answers "which of the relevant notes is the latest?" —
    * a question pure cosine ranking cannot answer at all. It runs in two
    * stages: an inner query picks a candidate pool by similarity, the outer
-   * one reorders that pool by `updated_at`. It is deliberately NOT a plain
-   * `ORDER BY updated_at DESC` over the table, which would ignore the query.
+   * one reorders that pool by `NOTE_DATE_SQL` — the date the note declares in
+   * its filename, falling back to `updated_at` for notes that declare none. It
+   * is deliberately NOT a plain `ORDER BY` over the table, which would ignore
+   * the query.
    *
    * `total` is not the pool size: `COUNT(*) OVER()` sits inside the CTE, and
    * Postgres evaluates window functions before that query level's `LIMIT`, so
@@ -404,7 +440,7 @@ export class DbClient {
       LIMIT $${poolIdx}
       )
       SELECT * FROM candidates
-      ORDER BY updated_at DESC, similarity DESC
+      ORDER BY ${NOTE_DATE_SQL} DESC, updated_at DESC, similarity DESC
       LIMIT $${limitIdx}
       OFFSET $${offsetIdx}
     `

--- a/packages/core/src/mcp/tools.ts
+++ b/packages/core/src/mcp/tools.ts
@@ -147,7 +147,7 @@ export function createTools(
             type: 'string',
             enum: ['similarity', 'recency'],
             description:
-              "How to order results (default: 'similarity'). Use 'recency' whenever the question is about the latest of something — \"the last 1:1\", \"our most recent decision on X\", \"what did we discuss yesterday\" — otherwise the newest note is easily outranked by an older, slightly more similar one. It ranks the semantically relevant notes by date, not the whole vault: the query still decides which notes are candidates. Keep 'similarity' for topical questions where date does not matter.",
+              "How to order results (default: 'similarity'). Use 'recency' whenever the question is about the latest of something — \"the last 1:1\", \"our most recent decision on X\", \"what did we discuss yesterday\" — otherwise the newest note is easily outranked by an older, slightly more similar one. It ranks the semantically relevant notes by date, not the whole vault: the query still decides which notes are candidates. The date it ranks by is the one in the note's filename (`YYYY-MM-DD Title.md`) — the date the note is about, not when it was indexed; notes without a dated filename fall back to when they last changed. Keep 'similarity' for topical questions where date does not matter.",
           },
         },
         required: ['query'],

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { DbClient } from '../../src/lib/db-client.js';
+import { DbClient, NOTE_DATE_PATTERN } from '../../src/lib/db-client.js';
 import type { NoteRow } from '@lox-brain/shared';
 
 describe('DbClient', () => {
@@ -355,7 +355,7 @@ describe('DbClient', () => {
       expect(defaultSql).not.toContain('candidates');
     });
 
-    it('should rerank a similarity-selected candidate pool by updated_at when sort=recency', async () => {
+    it('should rerank a similarity-selected candidate pool by note date when sort=recency', async () => {
       mockPool.query.mockResolvedValue({ rows: [] });
 
       await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
@@ -364,9 +364,59 @@ describe('DbClient', () => {
       // Inner stage: still selects candidates by cosine distance.
       expect(sql).toContain('WITH candidates AS');
       expect(sql).toContain('ORDER BY embedding <=> $1::vector');
-      // Outer stage: reorders that pool by recency.
+      // Outer stage: reorders that pool by the date the note declares,
+      // falling back to index time only for notes that declare none.
       expect(sql).toContain('FROM candidates');
-      expect(sql).toMatch(/ORDER BY updated_at DESC, similarity DESC/);
+      expect(sql).toMatch(/ORDER BY COALESCE\(/);
+      expect(sql).toContain('substring(file_path from');
+      expect(sql).toContain("to_char(updated_at, 'YYYY-MM-DD')");
+      expect(sql).toMatch(/DESC, updated_at DESC, similarity DESC/);
+    });
+
+    it('should never cast the extracted filename date to a date type', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
+
+      // `to_date` raises 22008 on an impossible date, and a single
+      // `2026-02-30 x.md` in the vault would take down every recency search.
+      const [sql] = mockPool.query.mock.calls[0];
+      expect(sql).not.toContain('to_date');
+      expect(sql).not.toMatch(/::\s*date/);
+    });
+
+    it('should compare note dates under the C collation', async () => {
+      mockPool.query.mockResolvedValue({ rows: [] });
+
+      await client.searchSemantic([0.1], { limit: 5, offset: 0, sort: 'recency' });
+
+      // Text ordering only equals date ordering if the database collation does
+      // not reweight the digits and hyphens.
+      const [sql] = mockPool.query.mock.calls[0];
+      expect(sql).toContain('COLLATE "C"');
+    });
+
+    it('should only admit a plausible calendar date from the last path segment', () => {
+      // Postgres ARE and JS agree on every construct this pattern uses
+      // (`\d`, `(?:a|b)`, character classes, `$`), so JS can stand in here for
+      // the engine that actually runs it.
+      const pattern = new RegExp(NOTE_DATE_PATTERN);
+      const dateOf = (filePath: string) => filePath.match(pattern)?.[1];
+
+      expect(dateOf('Meetings/2026-08-03 Weekly Meeting.md')).toBe('2026-08-03');
+      expect(dateOf('Meetings/Weekly Meeting 2026-08-03.md')).toBe('2026-08-03');
+      // A dated folder is not the note's own date.
+      expect(dateOf('Journal/2026-08-03/notes.md')).toBeUndefined();
+      // The note's own date wins over a dated folder above it.
+      expect(dateOf('2026-01-01 Planning/2026-08-03 Weekly.md')).toBe('2026-08-03');
+      // Impossible months and days never reach the sort key.
+      expect(dateOf('Meetings/2026-13-45 x.md')).toBeUndefined();
+      expect(dateOf('Meetings/9999-99-99 x.md')).toBeUndefined();
+      expect(dateOf('Meetings/2026-00-00 x.md')).toBeUndefined();
+      // Unpadded and unseparated forms are not the vault convention.
+      expect(dateOf('Meetings/2026-8-3 x.md')).toBeUndefined();
+      expect(dateOf('Meetings/20260803 x.md')).toBeUndefined();
+      expect(dateOf('Meetings/no date here.md')).toBeUndefined();
     });
 
     it('should size the candidate pool from limit+offset with a floor of 100', async () => {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -31,8 +31,9 @@ export interface SearchOptions {
   area?: string;
   source_type?: string;
   // Semantic search only. 'similarity' (default) ranks purely by cosine
-  // distance; 'recency' reranks a similarity-selected candidate pool by
-  // updated_at. See DbClient.searchSemantic.
+  // distance; 'recency' reranks a similarity-selected candidate pool by the
+  // date the note declares in its filename, falling back to updated_at.
+  // See DbClient.searchSemantic.
   sort?: SearchSort;
 }
 


### PR DESCRIPTION
Closes #200.

## Problem

`sort: 'recency'` ordered by `updated_at` — when the row was last written to the **index**, not the date the note is about.

It looked correct because `VaultWatcher` skips files whose hash is unchanged, so a note written once keeps an `updated_at` near its creation. Any bulk rewrite breaks that across the whole vault at once, silently: `npm run index-vault` (documented in CLAUDE.md), a backfill that recreates notes, a vault-wide retag.

The Credifit vault was **already in that state** — all 813 rows stamped inside a 20-minute window by the calendar backfill, two seconds apart:

```
2026-08-03 Weekly Meeting.md   updated_at 2026-08-07T18:59:47Z
2026-07-06 Weekly Meeting.md   updated_at 2026-08-07T18:59:45Z
2026-06-01 Weekly Meeting.md   updated_at 2026-08-07T18:59:43Z
```

Recency there was **ingestion order**, returning the right answer only because the backfill happened to run chronologically. Same shape as #199 and the ivfflat bug: correct output from a mechanism nobody wrote down.

## Fix

Order by the date the note declares in its own filename (`YYYY-MM-DD Title.md`, the convention the vault already follows), falling back to `updated_at` for notes that declare none — *"newest by the date the note claims, or by when it last changed if it claims none"*.

No `note_date` column: that needs a migration, a backfill over 6672 rows and frontmatter parsing, and the filename convention is what is actually in use. The recency path already sorts a bounded candidate pool, so an unindexed expression costs nothing measurable.

## The cast that isn't there

The issue proposed `to_date(substring(file_path from '(\d{4}-\d{2}-\d{2})'), 'YYYY-MM-DD')`. Verified against Postgres 16, that is a trap:

```sql
SELECT to_date('2026-02-30','YYYY-MM-DD');
ERROR:  date/time field value out of range: "2026-02-30"
```

One junk filename anywhere in the vault takes **every** recency search down. Tightening the regex is necessary but not sufficient — `2026-02-30` matches any plausible-date pattern and still throws, because it is well-formed and merely nonexistent.

So the extracted date is compared **as text**. Zero-padded `YYYY-MM-DD` sorts identically as text and as a date, so the cast bought nothing it could lose. `COLLATE "C"` keeps that true under a collation that would reweight the hyphens. The pattern admits only a real month (`01`–`12`) and day (`01`–`31`) so `9999-99-99 junk.md` cannot outrank every real note, and `[^/]*$` anchors it to the last path segment so a dated folder is not mistaken for the note's own date.

## Verification against real Postgres

Pattern behaviour (`pgvector/pgvector:pg16`):

```
7 - Meeting Notes/2026-08-03 Weekly Meeting.md  -> 2026-08-03
7 - Meeting Notes/9999-99-99 junk.md            -> (falls back)
7 - Meeting Notes/2026-13-45 junk.md            -> (falls back)
2025-01-01 Pasta Datada/nota sem data.md        -> (falls back, folder ignored)
2025-01-01 Pasta Datada/2026-08-03 nota.md      -> 2026-08-03 (note wins over folder)
notas/relatorio 2026-02-30 impossivel.md        -> 2026-02-30 (matched, and does not throw)
```

End-to-end with the Credifit shape reproduced — `updated_at` scrambled within one window, dates only in filenames, including the impossible one:

```
sort=recency returns:
  Weekly sem data.md              updated_at 18:59:30   <- undated, falls back to today
  2026-08-03 Weekly Meeting.md    updated_at 18:59:40
  2026-07-06 Weekly Meeting.md    updated_at 18:59:47
  2026-06-01 Weekly Meeting.md    updated_at 18:59:45
  2026-02-30 Weekly Meeting.md    updated_at 18:59:41
  2026-01-19 Weekly Meeting.md    updated_at 18:59:52
```

Dated notes come back in date order while `updated_at` runs 40, 47, 45, 41, 52 — the scrambled ingestion order no longer influences the answer.

**Known behaviour worth stating:** an undated note falls back to `updated_at`, so after a bulk reindex undated notes carry today's date and float above dated ones. That is the honest answer — there is no better signal for a note that declares no date — but it means recency mixes two kinds of date. Dated notes still order correctly among themselves, which is the use case.

## Gates

- 362 tests passed (359 before)
- Type check per package: `shared` OK, `core` OK
- Coverage 91.91% lines / 89.73% branch
- The `similarity` path is untouched and still asserted byte-identical
- 0.18.1 → 0.19.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)