### PR TITLE
Fix watcher failing to index notes without created_by frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.1] — 2026-08-15
+
+### Fixed
+- **The watcher could not index any note whose frontmatter omits `created_by:` — and reported those notes as indexed.** `upsertNote` passed an explicit `NULL` for `created_by` into a `TEXT NOT NULL DEFAULT ''` column. An explicit `NULL` does not fall back to a column default, so Postgres rejected the row with `null value in column "created_by" of relation "vault_embeddings" violates not-null constraint`. `created_by` is optional on `NoteMetadata`/`NoteRow` and `parseNote` only populates it when the field is present in frontmatter, which for a personal vault is essentially never — so the failure covered nearly every note, not an edge case. The value sent is now `''`, matching the column default. `area`/`source_type` are genuinely nullable columns and still send `null`.
+
+  The bug survived because a unit test asserted it: `should pass null created_by when not provided` expected `params` to contain `null`, so the mocked suite stayed green while every real insert failed. That test now asserts `''`, and by parameter position — `area`/`source_type` legitimately sit as `null` in the same list, so a `toContain(null)`-style check cannot tell the two apart.
+
+- **A failed index was logged as a successful one.** `VaultWatcher.handleFileChange` caught its own errors and returned normally, so the caller in `watcher/index.ts` logged `Indexed: <path>` immediately after — for a note that was never written. On a live vault this hid the not-null violation above for weeks: the log showed a clean run while the database received nothing. `handleFileChange` now propagates; `processFile` already try/catches per file, so one bad note still cannot take the watcher down, and its error message reads `Failed to index <path>` rather than the previous `Error indexed <path>`, which scanned as a status line.
+
+- **`created_by` could never be filled in after a row was first stored.** The `ON CONFLICT` clause read `COALESCE(vault_embeddings.created_by, EXCLUDED.created_by)`, intending "an existing attribution wins". Because the column is `NOT NULL`, the stored value is never `NULL`, so the `COALESCE` always selected it and the incoming value was unreachable — a note indexed as unattributed stayed unattributed even after gaining a `created_by:` field. Now `COALESCE(NULLIF(vault_embeddings.created_by, ''), EXCLUDED.created_by)`, treating `''` as the unset marker it already is.
+
+  Closes [#203](https://github.com/isorensen/lox-brain/issues/203).
+
 ## [0.19.0] — 2026-08-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -4342,7 +4342,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -5050,7 +5050,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/core/src/lib/db-client.ts
+++ b/packages/core/src/lib/db-client.ts
@@ -247,7 +247,12 @@ export class DbClient {
         tags = EXCLUDED.tags,
         embedding = EXCLUDED.embedding,
         file_hash = EXCLUDED.file_hash,
-        created_by = COALESCE(vault_embeddings.created_by, EXCLUDED.created_by),
+        -- An existing attribution wins over the incoming one, but the column is
+        -- NOT NULL DEFAULT '' — the stored value is never NULL, so a plain
+        -- COALESCE on it would pin every row to whatever it got first and a
+        -- note that later gains a created_by frontmatter field could never be
+        -- attributed. '' is the "unattributed" marker, so treat it as unset.
+        created_by = COALESCE(NULLIF(vault_embeddings.created_by, ''), EXCLUDED.created_by),
         area = COALESCE(EXCLUDED.area, vault_embeddings.area),
         source_type = COALESCE(EXCLUDED.source_type, vault_embeddings.source_type),
         updated_at = NOW()
@@ -262,7 +267,11 @@ export class DbClient {
       JSON.stringify(note.embedding),
       note.file_hash,
       note.chunk_index,
-      note.created_by ?? null,
+      // created_by is NOT NULL DEFAULT ''. An explicit NULL does not fall back
+      // to the column default, so it has to be the empty string here — sending
+      // null rejected every note without `created_by:` frontmatter, which is
+      // most of them (#203). area/source_type below are genuinely nullable.
+      note.created_by ?? '',
       note.area ?? null,
       note.source_type ?? null,
     ]);

--- a/packages/core/src/watcher/index.ts
+++ b/packages/core/src/watcher/index.ts
@@ -25,7 +25,9 @@ async function processFile(filePath: string, label: string): Promise<void> {
     await vaultWatcher.handleFileChange(filePath, content);
     console.log(`${label}: ${filePath}`);
   } catch (err) {
-    console.error(`Error ${label.toLowerCase()} ${filePath}:`, err);
+    // Reached for real now that handleFileChange propagates (#203); the old
+    // "Error indexed <path>" wording read as a status, not a failure.
+    console.error(`Failed to index ${filePath}:`, err);
   }
 }
 

--- a/packages/core/src/watcher/vault-watcher.ts
+++ b/packages/core/src/watcher/vault-watcher.ts
@@ -29,43 +29,45 @@ export class VaultWatcher {
 
     if (existingHash === newHash) return;
 
-    try {
-      const metadata = this.embeddingService.parseNote(content);
-      const chunks = this.embeddingService.chunkText(metadata.content);
+    // Failures propagate to the caller, which owns the logging. This used to
+    // catch and log them, then return normally — so watcher/index.ts logged
+    // "Indexed: <path>" for notes that were never written, and a not-null
+    // violation hid behind that false success for weeks (#203). processFile
+    // try/catches per file, so propagating cannot take the watcher down over
+    // one bad note.
+    const metadata = this.embeddingService.parseNote(content);
+    const chunks = this.embeddingService.chunkText(metadata.content);
 
-      // Phase 1: Generate all embeddings (may fail — no DB writes yet)
-      const chunkData: Array<{ content: string; embedding: number[] }> = [];
-      for (const chunkContent of chunks) {
-        const embeddingText = [metadata.title, chunkContent]
-          .filter(Boolean)
-          .join('\n');
-        const embedding = await this.embeddingService.generateEmbedding(embeddingText);
-        chunkData.push({ content: chunkContent, embedding });
-      }
-
-      // Phase 2: All embeddings succeeded — now upsert all chunks.
-      // area / source_type come from the note's own frontmatter (vault is the
-      // source of truth), so no per-vault folder taxonomy is baked into code.
-      for (let i = 0; i < chunkData.length; i++) {
-        await this.dbClient.upsertNote({
-          id: randomUUID(),
-          file_path: relative,
-          title: metadata.title,
-          content: chunkData[i].content,
-          tags: metadata.tags,
-          embedding: chunkData[i].embedding,
-          file_hash: newHash,
-          chunk_index: i,
-          created_by: metadata.created_by,
-          area: metadata.area,
-          source_type: metadata.source_type,
-        });
-      }
-
-      await this.dbClient.deleteChunksAbove(relative, chunkData.length - 1);
-    } catch (err) {
-      console.error(`[VaultWatcher] Failed to index ${relative}:`, err);
+    // Phase 1: Generate all embeddings (may fail — no DB writes yet)
+    const chunkData: Array<{ content: string; embedding: number[] }> = [];
+    for (const chunkContent of chunks) {
+      const embeddingText = [metadata.title, chunkContent]
+        .filter(Boolean)
+        .join('\n');
+      const embedding = await this.embeddingService.generateEmbedding(embeddingText);
+      chunkData.push({ content: chunkContent, embedding });
     }
+
+    // Phase 2: All embeddings succeeded — now upsert all chunks.
+    // area / source_type come from the note's own frontmatter (vault is the
+    // source of truth), so no per-vault folder taxonomy is baked into code.
+    for (let i = 0; i < chunkData.length; i++) {
+      await this.dbClient.upsertNote({
+        id: randomUUID(),
+        file_path: relative,
+        title: metadata.title,
+        content: chunkData[i].content,
+        tags: metadata.tags,
+        embedding: chunkData[i].embedding,
+        file_hash: newHash,
+        chunk_index: i,
+        created_by: metadata.created_by,
+        area: metadata.area,
+        source_type: metadata.source_type,
+      });
+    }
+
+    await this.dbClient.deleteChunksAbove(relative, chunkData.length - 1);
   }
 
   async handleFileDelete(filePath: string): Promise<void> {

--- a/packages/core/tests/lib/db-client.test.ts
+++ b/packages/core/tests/lib/db-client.test.ts
@@ -143,11 +143,18 @@ describe('DbClient', () => {
       const [sql, params] = mockPool.query.mock.calls[0];
       expect(sql).toContain('created_by');
       expect(params).toContain('eduardo');
-      // On conflict, created_by should NOT be overwritten (preserve original over incoming)
-      expect(sql).toContain('COALESCE(vault_embeddings.created_by, EXCLUDED.created_by)');
+      // On conflict an existing attribution wins, but '' means "unattributed",
+      // not "attributed to nobody" — the column is NOT NULL DEFAULT '', so a
+      // plain COALESCE on the stored value can never fill it in later (#203).
+      expect(sql).toContain(
+        "COALESCE(NULLIF(vault_embeddings.created_by, ''), EXCLUDED.created_by)",
+      );
     });
 
-    it('should pass null created_by when not provided', async () => {
+    // Regression (#203): created_by is NOT NULL DEFAULT ''. An explicit NULL does
+    // not fall back to the column default, so sending null rejected every note
+    // whose frontmatter carries no created_by — which is most of them.
+    it('should pass empty string created_by when not provided', async () => {
       mockPool.query.mockResolvedValue({ rowCount: 1 });
 
       const note: NoteRow = {
@@ -165,7 +172,11 @@ describe('DbClient', () => {
 
       const [sql, params] = mockPool.query.mock.calls[0];
       expect(sql).toContain('created_by');
-      expect(params).toContain(null);
+      // created_by is $9 — assert by position: area/source_type are genuinely
+      // nullable columns and legitimately stay null in this same param list.
+      expect(params[8]).toBe('');
+      expect(params[9]).toBeNull();
+      expect(params[10]).toBeNull();
     });
 
     it('should propagate pool.query rejection', async () => {

--- a/packages/core/tests/watcher/vault-watcher.test.ts
+++ b/packages/core/tests/watcher/vault-watcher.test.ts
@@ -138,18 +138,34 @@ describe('VaultWatcher', () => {
       expect(mockDb.upsertNote.mock.calls[0][0].file_hash).toBe('new-hash');
     });
 
-    it('should handle errors gracefully without crashing', async () => {
+    // Regression (#203): this used to swallow the error and resolve, so the
+    // caller in watcher/index.ts logged "Indexed: <path>" for a note that was
+    // never written. Failures must reach the caller, which owns the logging
+    // and already try/catches per file — so one bad note still can't kill the
+    // watcher.
+    it('should propagate indexing errors to the caller', async () => {
       mockEmbedding.generateEmbedding.mockRejectedValue(
         new Error('OpenAI API rate limit exceeded'),
       );
 
-      // Should not throw — error is handled internally
       await expect(
         watcher.handleFileChange(filePath, content),
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow('OpenAI API rate limit exceeded');
 
       // upsertNote should NOT have been called since embedding failed
       expect(mockDb.upsertNote).not.toHaveBeenCalled();
+    });
+
+    // Regression (#203): a DB rejection must surface too — this is the exact
+    // path the not-null violation took.
+    it('should propagate upsert failures to the caller', async () => {
+      mockDb.upsertNote.mockRejectedValue(
+        new Error('null value in column "created_by" violates not-null constraint'),
+      );
+
+      await expect(
+        watcher.handleFileChange(filePath, content),
+      ).rejects.toThrow('not-null constraint');
     });
 
     it('should generate embedding per chunk and upsert each with chunk_index', async () => {
@@ -192,7 +208,9 @@ describe('VaultWatcher', () => {
         .mockResolvedValueOnce(new Array(1536).fill(0.1))
         .mockRejectedValueOnce(new Error('OpenAI API rate limit exceeded'));
 
-      await watcher.handleFileChange(`${VAULT_PATH}/notes/failing.md`, 'raw content');
+      await expect(
+        watcher.handleFileChange(`${VAULT_PATH}/notes/failing.md`, 'raw content'),
+      ).rejects.toThrow('OpenAI API rate limit exceeded');
 
       // No upserts should have happened since embedding failed on chunk 1
       expect(mockDb.upsertNote).not.toHaveBeenCalled();

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Closes #203.

## The bug

`DbClient.upsertNote` passed an explicit `NULL` for `created_by` into a `TEXT NOT NULL DEFAULT ''` column. An explicit `NULL` does not fall back to a column default, so Postgres rejected the row:

```
null value in column "created_by" of relation "vault_embeddings" violates not-null constraint
```

`created_by` is optional on `NoteMetadata`/`NoteRow` and `parseNote` only populates it when the frontmatter carries the field. For a personal vault that is essentially never — so this covered nearly every note, not an edge case.

## Why it went unnoticed

Two things hid it.

**The watcher reported the failure as a success.** `handleFileChange` caught its own errors and returned normally, so `processFile` logged `Indexed: <path>` immediately after — for a note that was never written. The log showed a clean run while the database received nothing.

**A unit test asserted the bug.** `should pass null created_by when not provided` expected `params` to contain `null`, so the mocked suite stayed green while every real insert failed.

## Changes

- `upsertNote` sends `''`, matching the column default. `area`/`source_type` are genuinely nullable and still send `null`.
- `handleFileChange` propagates instead of swallowing. `processFile` already try/catches per file, so one bad note still cannot take the watcher down; its message now reads `Failed to index <path>` rather than `Error indexed <path>`, which scanned as a status line. The now-redundant `try/catch` wrapper was removed rather than left as a bare rethrow.
- **Adjacent fix:** the `ON CONFLICT` clause read `COALESCE(vault_embeddings.created_by, EXCLUDED.created_by)`, intending "an existing attribution wins". Because the column is `NOT NULL` the stored value is never `NULL`, so it always won and a row stored as unattributed could never gain an author. Now `COALESCE(NULLIF(vault_embeddings.created_by, ''), EXCLUDED.created_by)`, treating `''` as the unset marker it already is.
- The regression test asserts `''` **by parameter position** — `area`/`source_type` legitimately sit as `null` in the same list, so a `toContain(null)`-style check cannot tell the two apart.

## Verification

Given this repo's history of mocked tests passing while real execution fails, the SQL was exercised against **PostgreSQL 16** inside `BEGIN`/`ROLLBACK`:

| Case | Result |
|---|---|
| Old behaviour — explicit `NULL` | `not_null_violation` (bug reproduced) |
| New — `''` | inserts |
| Re-index carrying an author over `''` | fills in (`'' → lara`) |
| Re-index unattributed over an author | preserves (`lara` stays) |

Confirmed 0 rows persisted after rollback.

Full suite: **936 passing**, 1 skipped, across all four workspaces. Type check clean. Core coverage 91.89%.

## Notes for the reviewer

- Opened from a fork — I do not have push access to this repo.
- Out of scope: #199 (ivfflat resize only at MCP boot), which is adjacent but independent.