### PR TITLE
Fix deploy.sh aborting when config.json has no install_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.2] — 2026-08-15
+
+### Fixed
+- **`infra/deploy.sh` aborted on any host whose `~/.lox/config.json` exists but carries no `install_dir`.** The script resolved the install directory with `jq -r '.install_dir'`, which prints the literal string `null` for a missing key, so the deploy died on `cd null` under `set -e`. The `$HOME/lox-brain` fallback was unreachable because it only covered a config file that is *absent*, not one that is incomplete. The `node` branch had the same defect, printing `undefined`. Resolution now uses `// empty` (and `?? ''`), and the default is applied after resolution so it covers a missing key as well as a missing file. Hit in practice on the Credifit VM, whose config holds only a `calendar_ingest` key.
+
+### Documentation
+- **Corrected the runtime commands in `CLAUDE.md`.** `mcp`, `mcp:prod`, `watcher` and `index-vault` are defined in the core workspace, not at the root, so every documented form failed with `Missing script`; they now carry `--workspace=packages/core`. `npm run dev` was listed but no such script exists in any workspace, and has been dropped. Added the environment `index-vault` needs (`VAULT_PATH`, `PG_PASSWORD`, `OPENAI_API_KEY`), which systemd supplies to the services but a manual shell does not.
+
+### Chore
+- `package-lock.json` now carries the same version as the `package.json` files. It had drifted (lock `0.18.1` against package `0.19.0`, then lock `0.19.0` against package `0.19.1`); `npm ci` tolerates the mismatch, so it never surfaced in CI.
+
 ## [0.19.1] — 2026-08-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,18 @@ npm install
 npm run build --workspaces               # tsc (all packages)
 npm run test --workspace=packages/core   # vitest (core package)
 npm run test:coverage                    # vitest --coverage (target: 80%+)
-npm run dev                              # tsx watch for development
-npm run mcp                              # start MCP server (dev, tsx)
-npm run mcp:prod                         # start MCP server (prod, node dist)
-npm run watcher                          # start vault watcher (dev)
-npm run index-vault                      # one-time vault indexing
+# The runtime entrypoints live in the core workspace, not the root — running
+# these without --workspace fails with `Missing script`.
+npm run mcp --workspace=packages/core          # start MCP server (dev, tsx)
+npm run mcp:prod --workspace=packages/core     # start MCP server (prod, node dist)
+npm run watcher --workspace=packages/core      # start vault watcher (dev)
+npm run index-vault --workspace=packages/core  # one-time vault indexing
 ```
+
+`index-vault` reads `VAULT_PATH`, `PG_PASSWORD` and `OPENAI_API_KEY` from the
+environment. systemd supplies them to the services from an `EnvironmentFile`,
+but a manual shell does not — on a VM, load them first with
+`set -a; . /etc/lox/secrets.env; set +a`.
 
 ## Configuration
 

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -3,13 +3,17 @@ set -euo pipefail
 
 # Resolve install directory from Lox config or fallback to default
 LOX_CONFIG="$HOME/.lox/config.json"
+PROJECT_DIR=""
 if [ -f "$LOX_CONFIG" ] && command -v jq &> /dev/null; then
-  PROJECT_DIR=$(jq -r '.install_dir' "$LOX_CONFIG")
+  PROJECT_DIR=$(jq -r '.install_dir // empty' "$LOX_CONFIG")
 elif [ -f "$LOX_CONFIG" ]; then
-  PROJECT_DIR=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$LOX_CONFIG','utf8')).install_dir)")
-else
-  PROJECT_DIR="$HOME/lox-brain"
+  PROJECT_DIR=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$LOX_CONFIG','utf8')).install_dir ?? '')")
 fi
+# A config file that exists but carries no install_dir used to yield the literal
+# string "null" (jq) or "undefined" (node), and the deploy died on `cd null`
+# instead of falling back. The default belongs here, after resolution, so it
+# covers a missing key as well as a missing file.
+PROJECT_DIR="${PROJECT_DIR:-$HOME/lox-brain}"
 
 cd "$PROJECT_DIR"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lox-brain",
-  "version": "0.19.0",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lox-brain",
-      "version": "0.19.0",
+      "version": "0.19.2",
       "license": "MIT",
       "workspaces": [
         "packages/shared",
@@ -4342,7 +4342,7 @@
     },
     "packages/core": {
       "name": "@lox-brain/core",
-      "version": "0.19.0",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
@@ -4625,7 +4625,7 @@
     },
     "packages/installer": {
       "name": "lox",
-      "version": "0.19.0",
+      "version": "0.19.2",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
         "@lox-brain/shared": "*",
@@ -5050,7 +5050,7 @@
     },
     "packages/shared": {
       "name": "@lox-brain/shared",
-      "version": "0.19.0",
+      "version": "0.19.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox-brain",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "description": "Lox \u2014 Where knowledge lives. Personal AI-powered Second Brain with semantic search, MCP Server, and Obsidian integration.",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/core",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lox",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "description": "Lox installer \u2014 set up your personal AI-powered Second Brain",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lox-brain/shared",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Follow-ups found while deploying v0.19.1 to the personal and Credifit VMs.

## `infra/deploy.sh` aborted on the Credifit VM

The script resolved the install directory with:

```bash
PROJECT_DIR=$(jq -r '.install_dir' "$LOX_CONFIG")
```

`jq -r` prints the literal string `null` for a missing key, so `PROJECT_DIR` became `"null"` and the deploy died on `cd null` under `set -e`. The `$HOME/lox-brain` fallback never ran, because it sat in an `else` branch that only covers a config file that is **absent** — not one that exists but is incomplete. The `node` branch had the same defect, printing `undefined`.

Hit in practice: the Credifit VM's `~/.lox/config.json` holds only a `calendar_ingest` key, so its documented deploy path was broken.

Fixed by resolving with `// empty` (and `?? ''`) and applying the default **after** resolution, where it covers a missing key as well as a missing file.

Verified across both branches and all three config states:

| config | jq branch | node branch |
|---|---|---|
| has `install_dir` | `/opt/custom` | `/opt/custom` |
| exists, no `install_dir` | falls back | falls back |
| absent | falls back | falls back |

## The runtime commands in `CLAUDE.md` did not work

`mcp`, `mcp:prod`, `watcher` and `index-vault` are defined in `packages/core`, not at the root, so every documented form failed with `Missing script` — found when the documented `npm run index-vault` errored on the Credifit VM. They now carry `--workspace=packages/core`. `npm run dev` was listed but exists in no workspace at all, and is dropped.

Also documented the environment `index-vault` requires (`VAULT_PATH`, `PG_PASSWORD`, `OPENAI_API_KEY`) — systemd supplies these to the services from an `EnvironmentFile`, but a manual shell does not, which is the second way that command fails.

## Lockfile version drift

`package-lock.json` had drifted from the `package.json` files for two releases (lock `0.18.1` vs package `0.19.0`, then lock `0.19.0` vs package `0.19.1`). `npm ci` only validates the dependency tree, so it never surfaced. Realigned at `0.19.2`.

## Verification

`npm ci`, build, type check and the full suite run clean across all four workspaces. The one failure, `net-probe.test.ts`, is pre-existing and environment-dependent — it fails identically on `main` and passes in CI.

No behaviour change to any shipped code path: this touches a deploy script, docs, and version metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)